### PR TITLE
Shorten 'purpose' section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,8 +17,7 @@ Monica allows people to keep track of everything that's important about their
 friends and family. Like the activities done with them.
 When you last called someone. What you talked about. It will help you remember
 the name and the age of the kids. It can also remind you to call someone you
-haven't talked to in a while. It's like an assistant (some call it spouse) you
-dream you had.
+haven't talked to in a while.
 
 ### What Monica isn't
 


### PR DESCRIPTION
"It's like an assistant (some call it spouse) you dream you had." might rub some people the wrong way, and the purpose is clearer and more to-the-point without it anyway.

(feel free to simply close this if you disagree, just my 2 cents ;) )