### PR TITLE
Fix migrations for Postgres

### DIFF
--- a/database/migrations/2017_05_04_193252_alter_activity_nullable.php
+++ b/database/migrations/2017_05_04_193252_alter_activity_nullable.php
@@ -13,6 +13,8 @@ class AlterActivityNullable extends Migration
      */
     public function up()
     {
-        DB::statement('ALTER TABLE `activities` MODIFY `activity_type_id` INTEGER UNSIGNED NULL;');
+        Schema::table('activities', function(Blueprint $table) {
+            $table->integer('activity_type_id')->unsigned()->nullable()->change();
+        });
     }
 }


### PR DESCRIPTION
Postgres doesn't work with backticks; makes sense to use actual Laravel migration syntax for changing columns where possible to allow SQL grammar to take care of the rest.