### PR TITLE
Remove encryption in the journal table

### DIFF
--- a/app/Entry.php
+++ b/app/Entry.php
@@ -14,7 +14,7 @@ class Entry extends Model
             return null;
         }
 
-        return decrypt($this->post);
+        return $this->post;
     }
 
     public function getTitle()
@@ -23,6 +23,6 @@ class Entry extends Model
             return null;
         }
 
-        return decrypt($this->title);
+        return $this->title;
     }
 }

--- a/database/migrations/2017_06_11_025227_remove_encryption_journal.php
+++ b/database/migrations/2017_06_11_025227_remove_encryption_journal.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Entry;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class RemoveEncryptionJournal extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $entries = Entry::all();
+        foreach ($entries as $entry) {
+            echo $entry->id.' ';
+            if (!is_null ($entry->title)) {
+                $entry->title = decrypt($entry->title);
+            }
+
+            if (!is_null ($entry->post)) {
+                $entry->post = decrypt($entry->post);
+            }
+
+            $entry->save();
+        }
+    }
+}

--- a/tests/Unit/EntryTest.php
+++ b/tests/Unit/EntryTest.php
@@ -22,7 +22,7 @@ class EntryTest extends TestCase
     public function testGetPostReturnsPost()
     {
         $entry = new Entry;
-        $entry->post = encrypt('This is a test');
+        $entry->post = 'This is a test';
 
         $this->assertEquals(
             'This is a test',
@@ -40,7 +40,7 @@ class EntryTest extends TestCase
     public function testGetTitleReturnsTitle()
     {
         $entry = new Entry;
-        $entry->title = encrypt('This is a test');
+        $entry->title = 'This is a test';
 
         $this->assertEquals(
             'This is a test',


### PR DESCRIPTION
I used to encrypt this but the decryption randomly generates problems sometimes. I wonder why. Is it because of special characters that are included and get corrupted while encrypted? I don't know, but I've found that removing the encryption (which is not necessary anyway), solves the problem - until we find a better solution.