### PR TITLE
Temporarily fix Bootstrap tabs (#26)

### DIFF
--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -1,5 +1,16 @@
 @extends('layouts.skeleton')
 
+{{-- Temp Fix for Bootstrap Tabs: Issue #26 --}}
+@push('scripts')
+  <script type="text/javascript">
+      $( ".nav-item" ).click(function() {
+          $(this).children().addClass('active');
+          $(this).siblings().children().removeClass('active');
+      });
+  </script>
+@endpush
+
+
 @section('content')
   <div class="dashboard">
 

--- a/resources/views/layouts/skeleton.blade.php
+++ b/resources/views/layouts/skeleton.blade.php
@@ -54,5 +54,8 @@
       <script>(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/j25qx4na';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()
       </script>
     @endif
+
+    @stack('scripts')
+
   </body>
 </html>


### PR DESCRIPTION
Provides a temporary fix for #26. The problem has been fixed in the [Bootstrap v4-dev branch](https://github.com/twbs/bootstrap/pull/21807) but has not yet been released - hopefully won't be too long. 

Summary:

- Added a 'scripts' [stack](https://laravel.com/docs/5.4/blade#stacks) to the layout file, so that the javascript fix doesn't have to be present on all pages
- Added a temporary javascript fix to manually add/remove the "active" class from the tabs when clicked