### PR TITLE
Add import:vcard command

### DIFF
--- a/app/Console/Commands/ImportVCards.php
+++ b/app/Console/Commands/ImportVCards.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Contact;
+use App\Country;
+use App\User;
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Sabre\VObject\Component\VCard;
+use Sabre\VObject\Property\ICalendar\DateTime;
+use Sabre\VObject\Reader;
+
+class ImportVCards extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'import:vcard {user} {path}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Imports contacts from vCard files for a specific user';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @param Filesystem $filesystem
+     * @return mixed
+     */
+    public function handle(Filesystem $filesystem)
+    {
+        $path = './' . $this->argument('path');
+
+        $user = User::where('email', $this->argument('user'))->first();
+
+        if (!$user) {
+            $this->error('You need to provide a valid user email!');
+            return;
+        }
+
+        if (!$filesystem->exists($path) || $filesystem->extension($path) !== 'vcf') {
+            $this->error('The provided vcard file was not found or is not valid!');
+
+            return;
+        }
+
+        $matchCount = preg_match_all('/(BEGIN:VCARD.*?END:VCARD)/s', $filesystem->get($path), $matches);
+
+        $this->info("We found {$matchCount} contacts in {$path}.");
+
+        if ($this->confirm('Would you like to import them?', true)) {
+
+            $this->info("Importing contacts from {$path}");
+
+            $this->output->progressStart($matchCount);
+
+            $skippedContacts = 0;
+
+            collect($matches[0])->map(function ($vcard) {
+                return Reader::read($vcard);
+            })->each(function (VCard $vcard) use ($user, $skippedContacts) {
+
+                if ($this->contactExists($vcard, $user)) {
+                    $this->output->progressAdvance();
+                    $skippedContacts++;
+
+                    return;
+                }
+
+                // Skip contact if there isn't a first name or a nickname
+                if (! $this->contactHasName($vcard)) {
+                    $this->output->progressAdvance();
+                    $skippedContacts++;
+
+                    return;
+                }
+
+                $contact = new Contact();
+                $contact->account_id = $user->account_id;
+
+                if($vcard->N && ! empty($vcard->N->getParts()[1])) {
+                    $contact->first_name = $this->formatValue($vcard->N->getParts()[1]);
+                    $contact->middle_name = $this->formatValue($vcard->N->getParts()[2]);
+                    $contact->last_name = $this->formatValue($vcard->N->getParts()[0]);
+                } else {
+                    $contact->first_name = $this->formatValue($vcard->NICKNAME);
+                }
+
+                $contact->gender = 'none';
+                $contact->is_birthdate_approximate = 'unknown';
+
+                if ($vcard->BDAY && !empty((string) $vcard->BDAY)) {
+                    $contact->birthdate = new \DateTime((string) $vcard->BDAY);
+                }
+
+                $contact->email = $this->formatValue($vcard->EMAIL);
+                $contact->phone_number = $this->formatValue($vcard->TEL);
+
+                if($vcard->ADR) {
+                    $contact->street = $this->formatValue($vcard->ADR->getParts()[2]);
+                    $contact->city = $this->formatValue($vcard->ADR->getParts()[3]);
+                    $contact->province = $this->formatValue($vcard->ADR->getParts()[4]);
+                    $contact->postal_code = $this->formatValue($vcard->ADR->getParts()[5]);
+
+                    $country = Country::where('country', $vcard->ADR->getParts()[6])
+                        ->orWhere('iso', strtolower($vcard->ADR->getParts()[6]))
+                        ->first();
+
+                    if ($country) {
+                        $contact->country_id = $country->id;
+                    }
+                }
+
+                $contact->job = $this->formatValue($vcard->ORG);
+
+                $contact->setAvatarColor();
+
+                $contact->save();
+
+                $contact->logEvent('contact', $contact->id, 'create');
+
+                $this->output->progressAdvance();
+            });
+
+            $this->output->progressFinish();
+
+            $this->info("Successfully imported {$matchCount} contacts and skipped {$skippedContacts}.");
+        }
+
+    }
+
+    /**
+     * Formats and returns a string for the contact
+     *
+     * @param null|string $value
+     * @return null|string
+     */
+    private function formatValue($value)
+    {
+        return !empty((string) $value) ? (string) $value : null;
+    }
+
+    /**
+     * Checks whether a contact already exists for a given account
+     *
+     * @param VCard $vcard
+     * @param User $user
+     * @return bool
+     */
+    private function contactExists(VCard $vcard, User $user)
+    {
+        $email = (string) $vcard->EMAIL;
+
+        $contact = Contact::where([
+            ['account_id', $user->account_id],
+            ['email', $email]
+        ])->first();
+
+        return $email && $contact;
+    }
+
+    /**
+     * Checks whether a contact has a first name or a nickname.
+     * Nickname is used as a fallback if no first name is provided.
+     *
+     * @param VCard $vcard
+     * @return bool
+     */
+    function contactHasName(VCard $vcard): bool
+    {
+        return ! empty($vcard->N->getParts()[1]) || ! empty((string) $vcard->NICKNAME);
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -20,7 +20,8 @@ class Kernel extends ConsoleKernel
         //'App\Console\Commands\EncryptAllTheThings'
         //'App\Console\Commands\MigrateActivities'
         //'App\Console\Commands\MigratePeopleInformation',
-        //'App\Console\Commands\RemoveEncryption'
+        //'App\Console\Commands\RemoveEncryption',
+        'App\Console\Commands\ImportVCards'
     ];
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "fzaninotto/faker": "^1.6",
         "doctrine/dbal": "^2.5",
         "laravel/socialite": "^3.0",
-        "intervention/image": "^2.3"
+        "intervention/image": "^2.3",
+        "sabre/vobject": "^4.1"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "c78380634054b1d0b48dc51b2135afbf",
+    "content-hash": "8c8d34b420f5b831208e7512df29b8f7",
     "packages": [
         {
             "name": "barryvdh/laravel-debugbar",
@@ -1809,6 +1809,217 @@
                 "uuid"
             ],
             "time": "2017-03-26T20:37:53+00:00"
+        },
+        {
+            "name": "sabre/uri",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fruux/sabre-uri.git",
+                "reference": "a42126042c7dcb53e2978dadb6d22574d1359b4c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fruux/sabre-uri/zipball/a42126042c7dcb53e2978dadb6d22574d1359b4c",
+                "reference": "a42126042c7dcb53e2978dadb6d22574d1359b4c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0",
+                "sabre/cs": "~1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/functions.php"
+                ],
+                "psr-4": {
+                    "Sabre\\Uri\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Functions for making sense out of URIs.",
+            "homepage": "http://sabre.io/uri/",
+            "keywords": [
+                "rfc3986",
+                "uri",
+                "url"
+            ],
+            "time": "2017-02-20T20:02:35+00:00"
+        },
+        {
+            "name": "sabre/vobject",
+            "version": "4.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fruux/sabre-vobject.git",
+                "reference": "d0fde2fafa2a3dad1f559c2d1c2591d4fd75ae3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fruux/sabre-vobject/zipball/d0fde2fafa2a3dad1f559c2d1c2591d4fd75ae3c",
+                "reference": "d0fde2fafa2a3dad1f559c2d1c2591d4fd75ae3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=5.5",
+                "sabre/xml": ">=1.5 <3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*",
+                "sabre/cs": "^1.0.0"
+            },
+            "suggest": {
+                "hoa/bench": "If you would like to run the benchmark scripts"
+            },
+            "bin": [
+                "bin/vobject",
+                "bin/generate_vcards"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Sabre\\VObject\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Dominik Tobschall",
+                    "email": "dominik@fruux.com",
+                    "homepage": "http://tobschall.de/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Ivan Enderlin",
+                    "email": "ivan.enderlin@hoa-project.net",
+                    "homepage": "http://mnt.io/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "The VObject library for PHP allows you to easily parse and manipulate iCalendar and vCard objects",
+            "homepage": "http://sabre.io/vobject/",
+            "keywords": [
+                "availability",
+                "freebusy",
+                "iCalendar",
+                "ical",
+                "ics",
+                "jCal",
+                "jCard",
+                "recurrence",
+                "rfc2425",
+                "rfc2426",
+                "rfc2739",
+                "rfc4770",
+                "rfc5545",
+                "rfc5546",
+                "rfc6321",
+                "rfc6350",
+                "rfc6351",
+                "rfc6474",
+                "rfc6638",
+                "rfc6715",
+                "rfc6868",
+                "vCalendar",
+                "vCard",
+                "vcf",
+                "xCal",
+                "xCard"
+            ],
+            "time": "2016-12-06T04:14:09+00:00"
+        },
+        {
+            "name": "sabre/xml",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fruux/sabre-xml.git",
+                "reference": "054292959a1f2b64c10c9c7a03a816ba1872b8a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fruux/sabre-xml/zipball/054292959a1f2b64c10c9c7a03a816ba1872b8a3",
+                "reference": "054292959a1f2b64c10c9c7a03a816ba1872b8a3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xmlreader": "*",
+                "ext-xmlwriter": "*",
+                "lib-libxml": ">=2.6.20",
+                "php": ">=7.0",
+                "sabre/uri": ">=1.0,<3.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*",
+                "sabre/cs": "~1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Sabre\\Xml\\": "lib/"
+                },
+                "files": [
+                    "lib/Deserializer/functions.php",
+                    "lib/Serializer/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Markus Staab",
+                    "email": "markus.staab@redaxo.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "sabre/xml is an XML library that you may not hate.",
+            "homepage": "https://sabre.io/xml/",
+            "keywords": [
+                "XMLReader",
+                "XMLWriter",
+                "dom",
+                "xml"
+            ],
+            "time": "2016-11-16T00:41:01+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",

--- a/tests/Unit/ImportVCardsTest.php
+++ b/tests/Unit/ImportVCardsTest.php
@@ -2,8 +2,10 @@
 
 namespace Tests\Unit;
 
+use App\Account;
 use App\Contact;
 use App\Country;
+use App\Helpers\RandomHelper;
 use App\User;
 use Mockery as m;
 use Tests\TestCase;
@@ -33,7 +35,7 @@ class ImportVCardsTest extends TestCase
 
     public function testItValidatesFile()
     {
-        $user = User::find(1);
+        $user = $this->getUser();
 
         $command = m::mock('\App\Console\Commands\ImportVCards[error]', [new \Illuminate\Filesystem\Filesystem()]);
 
@@ -48,7 +50,7 @@ class ImportVCardsTest extends TestCase
 
     public function testItImportsContacts()
     {
-        $user = User::find(1);
+        $user = $this->getUser();
         $path = 'tests/stubs/vcard_stub.vcf';
 
         $totalContacts = Contact::where('account_id', $user->account_id)->count();
@@ -86,6 +88,23 @@ class ImportVCardsTest extends TestCase
         );
 
         $this->assertEquals(0, $exitCode);
+    }
+
+    private function getUser() {
+        $user = new User();
+        $user->first_name = 'John';
+        $user->last_name = 'Doe';
+        $user->email = 'johndoe@example.com';
+        $user->password = bcrypt('secret');
+
+        $account = new Account();
+        $account->api_key = RandomHelper::generateString(30);
+        $account->save();
+
+        $user->account_id = $account->id;
+        $user->save();
+
+        return $user;
     }
 
 }

--- a/tests/Unit/ImportVCardsTest.php
+++ b/tests/Unit/ImportVCardsTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Contact;
+use App\Country;
+use App\User;
+use Mockery as m;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class ImportVCardsTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function testItValidatesUser()
+    {
+        $path = 'tests/stubs/vcard_stub.vcf';
+
+        $command = m::mock('\App\Console\Commands\ImportVCards[error]', [new \Illuminate\Filesystem\Filesystem()]);
+
+        $command->shouldReceive('error')->once()->with('You need to provide a valid user email!');
+
+        $this->app['Illuminate\Contracts\Console\Kernel']->registerCommand($command);
+
+        $exitCode = $this->artisan('import:vcard', ['user' => 'notfound@example.com', 'path' => $path, '--no-interaction' => true]);
+
+        $this->assertEquals(0, $exitCode);
+    }
+
+
+    public function testItValidatesFile()
+    {
+        $user = User::find(1);
+
+        $command = m::mock('\App\Console\Commands\ImportVCards[error]', [new \Illuminate\Filesystem\Filesystem()]);
+
+        $command->shouldReceive('error')->once()->with('The provided vcard file was not found or is not valid!');
+
+        $this->app['Illuminate\Contracts\Console\Kernel']->registerCommand($command);
+
+        $exitCode = $this->artisan('import:vcard', ['user' => $user->email, 'path' => 'not_found', '--no-interaction' => true]);
+
+        $this->assertEquals(0, $exitCode);
+    }
+
+    public function testItImportsContacts()
+    {
+        $user = User::find(1);
+        $path = 'tests/stubs/vcard_stub.vcf';
+
+        $totalContacts = Contact::where('account_id', $user->account_id)->count();
+
+        $exitCode = $this->artisan('import:vcard', ['user' => $user->email, 'path' => $path, '--no-interaction' => true]);
+
+        $this->assertDatabaseHas('contacts', [
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'email' => 'john.doe@example.com',
+        ]);
+
+        // Allows checking if birthday was correctly set
+        $this->assertDatabaseHas('contacts', [
+            'first_name' => 'Bono',
+            'birthdate' => '1960-05-10 00:00:00',
+            'email' => 'bono@example.com',
+            'phone_number' => '+1 202-555-0191',
+            'job' => 'U2',
+        ]);
+
+        // Allows checking nickname fallback
+        $this->assertDatabaseHas('contacts', [
+            'first_name' => 'Johnny',
+            'street' => '17 Shakespeare Ave.',
+            'postal_code' => 'SO17 2HB',
+            'city' => 'Southampton',
+            'country_id' => Country::where('country', 'United Kingdom')->first()->id,
+        ]);
+
+        // Asserts that only 3 new contacts were created
+        $this->assertEquals(
+            $totalContacts + 3,
+            Contact::where('account_id', $user->account_id)->count()
+        );
+
+        $this->assertEquals(0, $exitCode);
+    }
+
+}

--- a/tests/stubs/vcard_stub.vcf
+++ b/tests/stubs/vcard_stub.vcf
@@ -1,0 +1,23 @@
+BEGIN:VCARD
+VERSION:3.0
+FN:Bono
+N:;Bono;;;
+EMAIL;TYPE=INTERNET:bono@example.com
+TEL:+1 202-555-0191
+ORG:U2
+BDAY:1960-05-10
+NOTE:Lorem ipsum dolor sit amet
+END:VCARD
+BEGIN:VCARD
+VERSION:3.0
+FN:John Doe
+N:Doe;John;;;
+EMAIL;TYPE=INTERNET:john.doe@example.com
+END:VCARD
+BEGIN:VCARD
+VERSION:3.0
+FN:
+N:;;;;
+NICKNAME:Johnny
+ADR:;;17 Shakespeare Ave.;Southampton;;SO17 2HB;United Kingdom
+END:VCARD


### PR DESCRIPTION
This pull request adds a command to import vcards (similar to #60 ).

Usage: `php artisan import:vcard {user: User's email address} {path: Path to a .vcf file}`

The command checks whether an email already exists, so duplicates shouldn't be an issue. However, I think the unique constraint is too eager. If another user wants to add the same person (whether through import or otherwise), they will not be added. I think this is a bug and the constraint should be `['account_id', 'email']`. I can handle it in another pull request.
