### PR TITLE
Fix debt description on the dashboard not fetching the localized 'debts_for' resource

### DIFF
--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -157,7 +157,7 @@
                         ${{ $debt->amount }}
 
                         @if (! is_null($debt->reason))
-                        <span class="debt-description">{{ trans('dashboard.for') }}</span>
+                        <span class="debt-description">{{ trans('dashboard.debts_for') }}</span>
                         {{ $debt->reason }}
                         @endif
                       </li>


### PR DESCRIPTION
Closes #210 