### PR TITLE
Change the email text to be a mailto link

### DIFF
--- a/resources/views/people/dashboard/people-information/index.blade.php
+++ b/resources/views/people/dashboard/people-information/index.blade.php
@@ -33,7 +33,9 @@
         @if (is_null($contact->getEmail()))
         {{ trans('people.information_no_email_defined') }}
         @else
-        {{ $contact->getEmail() }}
+        <a href="mailto:{{ $contact->getEmail() }}">
+          {{ $contact->getEmail() }}
+        </a>
         @endif
       </li>
 


### PR DESCRIPTION
I do not know php so there may be a way to only call `getEmail` once (so we don't have to fetch it over and over again). If so please let me know and I'll do that.

If there is a better way to implement this I am certainly all for that too.

If merged this will close #208.