### PR TITLE
Fix debts display

### DIFF
--- a/app/Contact.php
+++ b/app/Contact.php
@@ -57,7 +57,7 @@ class Contact extends Model
     /**
      * Get the debt records associated with the contact.
      */
-    public function debt()
+    public function debts()
     {
         return $this->hasMany('App\Debt');
     }

--- a/app/Contact.php
+++ b/app/Contact.php
@@ -1064,11 +1064,11 @@ class Contact extends Model
 
     /**
      * Check if the contact has debt (by the contact or the user for this contact)
-     * @return int amount
+     * @return boolean
      */
     public function hasDebt()
     {
-        return $this->debts !== null;
+        return $this->debts()->count() !== 0;
     }
 
     /**

--- a/app/Task.php
+++ b/app/Task.php
@@ -19,6 +19,11 @@ class Task extends Model
         return $this->belongsTo('App\Account');
     }
 
+    public function contact()
+    {
+        return $this->belongsTo('App\Contact');
+    }
+
     public function scopeCompleted(Builder $query)
     {
         return $query->where('status', 'completed');

--- a/resources/views/people/debt/index.blade.php
+++ b/resources/views/people/debt/index.blade.php
@@ -9,7 +9,7 @@
   </h3>
 </div>
 
-@if ($contact->hasDebt() == 0)
+@if (!$contact->hasDebt())
 
   <div class="col-xs-12">
     <div class="section-blank">


### PR DESCRIPTION
Debts are not displayed anymore. This is because of two things:
* First, the model association was wrongly named (a `s` was missing)
* Second, the `hasDebt` method were always right due to the nature of the relationship.