### PR TITLE
Fix/improve Heroku Deploy button and instructions

### DIFF
--- a/docs/installation/heroku.md
+++ b/docs/installation/heroku.md
@@ -2,12 +2,17 @@
 
 Monica can be deployed on Heroku using the button below:
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/monicahq/monica/tree/master)
 
 Please ensure to enter a custom `APP_KEY` when asked. Your Monica instance will
-utilise a [ClearDB Ignite plan](https://elements.heroku.com/addons/cleardb) by
-default. Additional environment variables, such as details of the mail server,
+utilise a [ClearDB Ignite plan](https://elements.heroku.com/addons/cleardb) (free)
+by default. Additional environment variables, such as details of the mail server,
 can be added after setup through the Heroku interface.
+
+Email configuration isn't required to use Monica on Heroku, but it's
+recommended. Mailgun has a
+[free email add-on on Heroku](https://elements.heroku.com/addons/mailgun) that is
+easy to set up.
 
 Monica doesn't require a lot of power - it means it will run on the free plan
 provided by Heroku.


### PR DESCRIPTION
Hi there.  Thanks for creating Monica and adding a Heroku Deploy button.  I'm hoping to highlight this Deploy Button in Heroku's monthly newsletter for June.

Here are a few changes to the Heroku deploy instructions that I think will make it easier for others to deploy to Heroku and use.

- Fix deploy button URL (without specifying the `template=` query string variable, it looks at the referring URL which doesn't work since this button no longer lives in the root README file)
- Specify that email configuration isn't required (this confused me for a few minutes.  I didn't realize I could register the first user without having email properly setup.)
- Suggest free Mailgun add-on to setup email (Easy way to get email working for free.)

