### PR TITLE
Add birthday automatically when defining a birthdate

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+2017-06-16
+----------
+
+Improvements:
+* Add automatic reminders when setting a birthdate When adding a birthdate (contact, kid, significant other). When updating or deleting the person, the reminder will be changed accordingly.
+
 2017-06-15
 ----------
 

--- a/app/Contact.php
+++ b/app/Contact.php
@@ -19,6 +19,13 @@ class Contact extends Model
     ];
 
     /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array
+     */
+    protected $guarded = ['id'];
+
+    /**
      * Eager load account with every contact.
      */
     protected $with = [

--- a/app/Http/Controllers/People/KidsController.php
+++ b/app/Http/Controllers/People/KidsController.php
@@ -70,7 +70,8 @@ class KidsController extends Controller
                     'people.kids_add_birthday_reminder',
                     ['name' => $request->get('first_name'), 'contact_firstname' => $contact->first_name]
                 ),
-                $request->get('birthdate')
+                $request->get('birthdate'),
+                $kid
             );
 
             $kid->update([
@@ -155,7 +156,8 @@ class KidsController extends Controller
                     'people.kids_add_birthday_reminder',
                     ['name' => $request->get('first_name'), 'contact_firstname' => $contact->first_name]
                 ),
-                $request->get('birthdate')
+                $request->get('birthdate'),
+                $kid
             );
 
             $kid->update([

--- a/app/Http/Controllers/People/SignificantOthersController.php
+++ b/app/Http/Controllers/People/SignificantOthersController.php
@@ -69,7 +69,9 @@ class SignificantOthersController extends Controller
                     'people.significant_other_add_birthday_reminder',
                     ['name' => $request->get('first_name'), 'contact_firstname' => $contact->first_name]
                 ),
-                $request->get('birthdate')
+                $request->get('birthdate'),
+                null,
+                $significantOther
             );
 
             $significantOther->update([
@@ -154,7 +156,9 @@ class SignificantOthersController extends Controller
                     'people.significant_other_add_birthday_reminder',
                     ['name' => $request->get('first_name'), 'contact_firstname' => $contact->first_name]
                 ),
-                $request->get('birthdate')
+                $request->get('birthdate'),
+                null,
+                $significantOther
             );
 
             $significantOther->update([

--- a/app/Reminder.php
+++ b/app/Reminder.php
@@ -83,9 +83,10 @@ class Reminder extends Model
      * @param string $title
      * @param Carbon|string $date
      * @param Kid $kid
+     * @param SignificantOther $kid
      * @return static
      */
-    public static function addBirthdayReminder($contact, $title, $date, $kid = null)
+    public static function addBirthdayReminder($contact, $title, $date, $kid = null, $significantOther = null)
     {
         $date = Carbon::parse($date);
 
@@ -96,7 +97,9 @@ class Reminder extends Model
                 'frequency_number' => 1,
                 'next_expected_date' => $date,
                 'account_id' => $contact->account_id,
-                'kid_id' => $kid ? $kid->id : null
+                'is_birthday' => 'true',
+                'about_object' => $kid ? 'kid' : ($significantOther ? 'significantother' : 'contact'),
+                'about_object_id' => $kid ? $kid->id : ($significantOther ? $significantOther->id : $contact->id)
             ]);
 
         $reminder->calculateNextExpectedDate($date, 'year', 1)

--- a/database/migrations/2017_06_16_215256_add_about_who_to_reminders.php
+++ b/database/migrations/2017_06_16_215256_add_about_who_to_reminders.php
@@ -1,0 +1,93 @@
+<?php
+
+use App\Contact;
+use App\Reminder;
+use App\SignificantOther;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddAboutWhoToReminders extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('reminders', function (Blueprint $table) {
+            $table->string('is_birthday')->after('contact_id')->default('false');
+            $table->string('about_object')->after('is_birthday')->nullable();
+            $table->string('about_object_id')->after('about_object')->nullable();
+        });
+
+        // Migrate all kids birthdays to the new system to track birthdays reminders
+        foreach (Reminder::all() as $reminder) {
+            if ($reminder->kid_id) {
+                $reminder->is_birthday = 'true';
+                $reminder->about_object = 'kid';
+                $reminder->about_object_id = $reminder->kid_id;
+                $reminder->save();
+            }
+        }
+
+        // Get rid of the kid_id field
+        Schema::table('reminders', function (Blueprint $table) {
+            $table->dropColumn(
+                ['kid_id']
+            );
+        });
+
+        // Fix mistakes in the significant others table
+        foreach (SignificantOther::all() as $significantOther) {
+            if ($significantOther->is_birthdate_approximate == 'exact' and is_null($significantOther->birthdate)) {
+                $significantOther->is_birthdate_approximate = 'unknown';
+                $significantOther->save();
+            }
+
+            if ($significantOther->is_birthdate_approximate == 'exact' and is_null($significantOther->birthday_reminder_id)) {
+                $significantOther->is_birthdate_approximate = 'approximate';
+                $significantOther->save();
+            }
+
+            if (! is_null($significantOther->birthday_reminder_id)) {
+                $reminder = $significantOther->reminder;
+                if (is_null($reminder)) {
+                    $significantOther->birthday_reminder_id = null;
+                    $significantOther->save();
+                } else {
+                    $reminder->is_birthday = 'true';
+                    $reminder->about_object = 'significantother';
+                    $reminder->about_object_id = $significantOther->id;
+                    $reminder->save();
+                }
+            }
+        }
+
+        foreach (Contact::all() as $contact) {
+            // Fix mistakes that are in the database. An old bug introduced exact dates
+            // without birthdates, which is not possible.
+            if ($contact->is_birthdate_approximate == 'exact' and is_null($contact->birthdate)) {
+                $contact->is_birthdate_approximate = 'unknown';
+                $contact->save();
+            }
+
+            // Make sure that contacts with birthday_reminder_id set haven't deleted
+            // the reminders yet. If they did delete it, we need to make sure that
+            // birthday_reminder_id is set to null.
+            if (! is_null($contact->birthday_reminder_id)) {
+                $reminder = $contact->reminders->find($contact->birthday_reminder_id);
+                if (is_null($reminder)) {
+                    $contact->birthday_reminder_id = null;
+                    $contact->save();
+                } else {
+                    $reminder->is_birthday = 'true';
+                    $reminder->about_object = 'contact';
+                    $reminder->about_object_id = $reminder->contact_id;
+                    $reminder->save();
+                }
+            }
+        }
+    }
+}

--- a/resources/lang/en/people.php
+++ b/resources/lang/en/people.php
@@ -120,7 +120,7 @@ return [
     'reminders_delete_cta' => 'Delete',
     'reminders_next_expected_date' => 'on',
     'reminders_cta' => 'Add a reminder',
-    'reminders_description' => 'We will send an email for each one of the reminders below. Reminders are sent every morning the day events will happen',
+    'reminders_description' => 'We will send an email for each one of the reminders below. Reminders are sent every morning the day events will happen. Reminders automatically added for birthdates can not be deleted. If you want to change those dates, edit the birthdate of the contacts.',
     'reminders_frequency' => 'every',
     'reminders_date' => 'Date',
     'reminders_content' => 'Content',

--- a/resources/views/people/reminders/form.blade.php
+++ b/resources/views/people/reminders/form.blade.php
@@ -52,7 +52,7 @@
                     <input type="number" class="form-control frequency-type" name="frequency_number"
                            value="1"
                            min="1"
-                           max="99"
+                           max="115"
                            :disabled="reminders_frequency == 'once'">
 
                     <select name="frequency_type" :disabled="reminders_frequency == 'once'">

--- a/resources/views/people/reminders/index.blade.php
+++ b/resources/views/people/reminders/index.blade.php
@@ -53,11 +53,14 @@
 
             <td class="actions">
 
+              {{-- Only display this if the reminder can be deleted - ie if it's not a reminder added automatically for birthdates --}}
+              @if ($reminder->is_birthday == 'false')
               <div class="reminder-actions">
                 <ul class="horizontal">
                   <li><a href="/people/{{ $contact->id }}/reminders/{{ $reminder->id }}/delete" onclick="return confirm('{{ trans('people.reminders_delete_confirmation') }}')">{{ trans('people.reminders_delete_cta') }}</a></li>
                 </ul>
               </div>
+              @endif
 
             </td>
 


### PR DESCRIPTION
* When adding an exact birthdate for a contact, a significant other or a kid, a reminder is now automatically created.
* When editing this date, the reminder will be automatically updated.
* When deleting the object, the associated reminder will be deleted.
* Fix birthdate data in production.
* Add a new way of tracking birthdays in the reminders table.

This will also fix #325