### PR TITLE
Dashboard: Use singular 'day' when a reminder is scheduled for 1 day

### DIFF
--- a/resources/lang/en/dashboard.php
+++ b/resources/lang/en/dashboard.php
@@ -25,7 +25,7 @@ return [
     'tab_lastest_actions' => 'Latest actions',
     'tasks_title' => 'Tasks',
     'tasks_blank' => 'No tasks are planned.',
-    'reminders_in_days' => 'in :number days',
+    'reminders_in_days' => '{1} in 1 day|in :number days',
     'statistics_title' => 'Statistics about your account',
     'statistics_contacts' => 'Contacts',
     'statistics_kids' => 'Kids',

--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -98,7 +98,8 @@
                     @foreach ($upcomingReminders as $reminder)
                       <li>
                         <span class="reminder-in-days">
-                          {{ trans('dashboard.reminders_in_days', ['number' => $reminder->next_expected_date->diffInDays(Carbon\Carbon::now())]) }}
+                          <?php $reminder_day_diff = $reminder->next_expected_date->diffInDays(Carbon\Carbon::now()) + 1 ?>
+                          {{ trans_choice('dashboard.reminders_in_days', $reminder_day_diff, ['number' => $reminder_day_diff]) }}
                           ({{ \App\Helpers\DateHelper::getShortDate($reminder->getNextExpectedDate()) }})
                         </span>
                         <a href="/people/{{ $reminder->contact_id }}">{{ App\Contact::find($reminder->contact_id)->getCompleteName() }}</a>:


### PR DESCRIPTION
![screen shot 2017-06-19 at 2 18 47 pm](https://user-images.githubusercontent.com/4861023/27301830-467e4748-54fa-11e7-8c7e-45d405038f86.png)

Note: The initial commit only updates the `en` translation source.
I do not know other languages well enough to update them properly.