### PR TITLE
Hide gift value, link and comment when not set

### DIFF
--- a/resources/views/people/gifts/index.blade.php
+++ b/resources/views/people/gifts/index.blade.php
@@ -32,11 +32,11 @@
             {{ \App\Helpers\DateHelper::getShortDate($gift->getCreatedAt()) }}
           </div>
           <div class="table-cell">
-            @if (! is_null($gift->getValue()))
+            @if (! empty($gift->getValue()))
               <span class="value">{{ Auth::user()->currency->symbol }} {{ $gift->getValue() }}</span>
             @endif
             {{ $gift->getName() }}
-            @if (! is_null($gift->getUrl()))
+            @if (! empty($gift->getUrl()))
               <span class="gift-list-item-url">
                 <a href="{{ $gift->getUrl() }}">{{ trans('people.gifts_link') }}</a>
               </span>
@@ -49,7 +49,7 @@
             @endif
           </div>
           <div class="table-cell comment">
-            @if (! is_null($gift->getComment()))
+            @if (! empty($gift->getComment()))
               {{ $gift->getComment() }}
             @endif
           </div>
@@ -73,11 +73,11 @@
             {{ \App\Helpers\DateHelper::getShortDate($gift->getCreatedAt()) }}
           </div>
           <div class="table-cell">
-            @if (! is_null($gift->getValue()))
+            @if (! empty($gift->getValue()))
               <span class="value">{{ Auth::user()->currency->symbol }} {{ $gift->getValue() }}</span>
             @endif
             {{ $gift->getName() }}
-            @if (! is_null($gift->getUrl()))
+            @if (! empty($gift->getUrl()))
               <span class="gift-list-item-url">
                 <a href="{{ $gift->getUrl() }}">{{ trans('people.gifts_link') }}</a>
               </span>
@@ -90,7 +90,7 @@
             @endif
           </div>
           <div class="table-cell comment">
-            @if (! is_null($gift->getComment()))
+            @if (! empty($gift->getComment()))
               {{ $gift->getComment() }}
             @endif
           </div>


### PR DESCRIPTION
This commit updates the gift UI to hide the `value`, `link` and
`comment` blocks when the values are not set. The usage of `is_null`
does not work because when the values are empty strings when not set.