### PR TITLE
fix content table seeder

### DIFF
--- a/database/seeds/FakeContentTableSeeder.php
+++ b/database/seeds/FakeContentTableSeeder.php
@@ -153,12 +153,10 @@ class FakeContentTableSeeder extends Seeder
             // // notes
             if (rand(1, 2) == 1) {
                 for ($j = 0; $j < rand(1, 13); $j++) {
-                    $note = $contact->notes->create([
+                    $note = $contact->notes()->create([
                         'body' => $faker->realText(rand(40, 500)),
                         'account_id' => $contact->account_id
                     ]);
-
-                    $this->logEvent('note', $note->id, 'create');
                 }
             }
         }


### PR DESCRIPTION
Fixes error when trying to seed fake notes, also removed logEvent as method doesn't exist on this class. 