### PR TITLE
Add ability to define name order

### DIFF
--- a/app/Contact.php
+++ b/app/Contact.php
@@ -186,26 +186,6 @@ class Contact extends Model
     }
 
     /**
-     * Get contact's full name
-     *
-     * @return string
-     */
-    public function getNameAttribute()
-    {
-        $completeName = $this->first_name;
-
-        if (!is_null($this->middle_name)) {
-            $completeName = $completeName . ' ' . $this->middle_name;
-        }
-
-        if (!is_null($this->last_name)) {
-            $completeName = $completeName . ' ' . $this->last_name;
-        }
-
-        return $completeName;
-    }
-
-    /**
      * Get user's initials
      *
      * @return string
@@ -222,9 +202,33 @@ class Contact extends Model
      *
      * @return string
      */
-    public function getCompleteName()
+    public function getCompleteName($nameOrder = 'firstname_first')
     {
-        return $this->name;
+        $completeName = '';
+
+        if ($nameOrder == 'firstname_first') {
+            $completeName = $this->first_name;
+
+            if (!is_null($this->middle_name)) {
+                $completeName = $completeName . ' ' . $this->middle_name;
+            }
+
+            if (!is_null($this->last_name)) {
+                $completeName = $completeName . ' ' . $this->last_name;
+            }
+        } else {
+            if (!is_null($this->last_name)) {
+                $completeName = $this->last_name;
+            }
+
+            if (!is_null($this->middle_name)) {
+                $completeName = $completeName . ' ' . $this->middle_name;
+            }
+
+            $completeName = $completeName . ' ' . $this->first_name;
+        }
+
+        return $completeName;
     }
 
     /**

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -41,6 +41,7 @@ class SettingsController extends Controller
                 'timezone',
                 'locale',
                 'currency_id',
+                'name_order'
             ]) + [
                 'fluid_container' => $request->get('layout')
             ]

--- a/app/Mail/UserReminded.php
+++ b/app/Mail/UserReminded.php
@@ -40,7 +40,7 @@ class UserReminded extends Mailable
         \App::setLocale($this->user->locale);
 
         return $this->text('emails.reminder.reminder')
-                    ->subject(trans('mail.subject_line', ['contact' => $contact->getCompleteName()]))
+                    ->subject(trans('mail.subject_line', ['contact' => $contact->getCompleteName($this->user()->name_order)]))
                     ->with([
                         'contact' => $contact,
                         'reminder' => $this->reminder,

--- a/app/User.php
+++ b/app/User.php
@@ -16,7 +16,7 @@ class User extends Authenticatable
      * @var array
      */
     protected $fillable = [
-        'name', 'email', 'password', 'timezone', 'locale', 'currency_id', 'fluid_layout'
+        'name', 'email', 'password', 'timezone', 'locale', 'currency_id', 'fluid_container', 'name_order'
     ];
 
     /**
@@ -80,16 +80,27 @@ class User extends Authenticatable
     }
 
     /**
-     * Get users's full name
+     * Get users's full name. The name is formatted according to the user's
+     * preference, either "Firstname Lastname", or "Lastname Firstname".
      *
      * @return string
      */
     public function getNameAttribute()
     {
-        $completeName = $this->first_name;
+        $completeName = '';
 
-        if (!is_null($this->last_name)) {
-            $completeName = $completeName . ' ' . $this->last_name;
+        if ($this->name_order == 'firstname_first') {
+            $completeName = $this->first_name;
+
+            if (!is_null($this->last_name)) {
+                $completeName = $completeName . ' ' . $this->last_name;
+            }
+        } else {
+            if (!is_null($this->last_name)) {
+                $completeName = $this->last_name;
+            }
+
+            $completeName = $completeName . ' ' . $this->first_name;
         }
 
         return $completeName;

--- a/composer.lock
+++ b/composer.lock
@@ -692,16 +692,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.2.3",
+            "version": "6.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "8d6c6cc55186db87b7dc5009827429ba4e9dc006"
+                "reference": "f4db5a78a5ea468d4831de7f0bf9d9415e348699"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/8d6c6cc55186db87b7dc5009827429ba4e9dc006",
-                "reference": "8d6c6cc55186db87b7dc5009827429ba4e9dc006",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/f4db5a78a5ea468d4831de7f0bf9d9415e348699",
+                "reference": "f4db5a78a5ea468d4831de7f0bf9d9415e348699",
                 "shasum": ""
             },
             "require": {
@@ -711,8 +711,11 @@
             },
             "require-dev": {
                 "ext-curl": "*",
-                "phpunit/phpunit": "^4.0",
+                "phpunit/phpunit": "^4.0 || ^5.0",
                 "psr/log": "^1.0"
+            },
+            "suggest": {
+                "psr/log": "Required for using the Log middleware"
             },
             "type": "library",
             "extra": {
@@ -750,7 +753,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2017-02-28T22:50:30+00:00"
+            "time": "2017-06-22T18:50:49+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -2260,16 +2263,16 @@
         },
         {
             "name": "stripe/stripe-php",
-            "version": "v4.12.0",
+            "version": "v4.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stripe/stripe-php.git",
-                "reference": "a4d64ebe8fff63e9c490674cd3bf6d773e3db1df"
+                "reference": "834681b9cdfa68d88a27e36ec9e356b598a5f0e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/a4d64ebe8fff63e9c490674cd3bf6d773e3db1df",
-                "reference": "a4d64ebe8fff63e9c490674cd3bf6d773e3db1df",
+                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/834681b9cdfa68d88a27e36ec9e356b598a5f0e6",
+                "reference": "834681b9cdfa68d88a27e36ec9e356b598a5f0e6",
                 "shasum": ""
             },
             "require": {
@@ -2311,7 +2314,7 @@
                 "payment processing",
                 "stripe"
             ],
-            "time": "2017-06-06T00:06:25+00:00"
+            "time": "2017-06-20T01:39:06+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",

--- a/database/migrations/2017_06_22_210813_add_name_order_to_users.php
+++ b/database/migrations/2017_06_22_210813_add_name_order_to_users.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddNameOrderToUsers extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('name_order')->default('firstname_first')->after('contacts_sort_order');
+        });
+    }
+}

--- a/database/seeds/FakeContentTableSeeder.php
+++ b/database/seeds/FakeContentTableSeeder.php
@@ -153,12 +153,12 @@ class FakeContentTableSeeder extends Seeder
             // // notes
             if (rand(1, 2) == 1) {
                 for ($j = 0; $j < rand(1, 13); $j++) {
-                    $note = $contact->notes->create([
+                    $note = $contact->notes()->create([
                         'body' => $faker->realText(rand(40, 500)),
                         'account_id' => $contact->account_id
                     ]);
 
-                    $this->logEvent('note', $note->id, 'create');
+                    $contact->logEvent('note', $note->id, 'create');
                 }
             }
         }

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -13,8 +13,11 @@ return [
     'export_sql_cta' => 'Export to SQL',
     'export_sql_link_instructions' => 'Note: <a href=":url">read the instructions</a> to learn more about importing this file to your instance.',
 
+    'name_order' => 'Name order',
+    'name_order_firstname_first' => 'First name first (John Doe)',
+    'name_order_lastname_first' => 'Last name first (Doe John)',
     'currency' => 'Currency',
-    'name' => 'Your name: :firstname :lastname',
+    'name' => 'Your name: :name',
     'email' => 'Email address',
     'email_placeholder' => 'Enter email',
     'email_help' => 'This is the email used to login, and this is where you\'ll receive your reminders.',

--- a/resources/lang/fr/settings.php
+++ b/resources/lang/fr/settings.php
@@ -13,8 +13,11 @@ return [
     'export_sql_cta' => 'Exporter en SQL',
     'export_sql_link_instructions' => 'Note : <a href=":url">lisez les instructions</a> afin d\'apprendre comment importer ce fichier dans votre instance.',
 
+    'name_order' => 'Ordre des noms',
+    'name_order_firstname_first' => 'Prénom d\'abord (John Doe)',
+    'name_order_lastname_first' => 'Nom de famille d\'abord (Doe John)',
     'currency' => 'Devise',
-    'name' => 'Votre nom : :firstname :lastname',
+    'name' => 'Votre nom : :name',
     'email' => 'Adresse courriel',
     'email_placeholder' => 'Entrez le courriel',
     'email_help' => 'Ce courriel est utilisé pour vous connecter à ce compte, et c\'est l\'adresse que nous utiliserons pour vous envoyer les rappels par courriel.',

--- a/resources/lang/pt-br/settings.php
+++ b/resources/lang/pt-br/settings.php
@@ -13,8 +13,11 @@ return [
     'export_sql_cta' => 'Export to SQL',
     'export_sql_link_instructions' => 'Note: <a href=":url">read the instructions</a> to learn more about importing this file to your instance.',
 
+    'name_order' => 'Name order',
+    'name_order_firstname_first' => 'First name first (John Doe)',
+    'name_order_lastname_first' => 'Last name first (Doe John)',
     'currency' => 'Moneda',
-    'name' => 'Seu nome: :firstname :lastname',
+    'name' => 'Seu nome: :name',
     'email' => 'Endereço de email',
     'email_placeholder' => 'Digite o email',
     'email_help' => 'Este é o e-mail usado para logar, e é aqui que você receberá seus lembretes.',

--- a/resources/lang/ru/settings.php
+++ b/resources/lang/ru/settings.php
@@ -13,8 +13,11 @@ return [
     'export_sql_cta' => 'Export to SQL',
     'export_sql_link_instructions' => 'Note: <a href=":url">read the instructions</a> to learn more about importing this file to your instance.',
 
+    'name_order' => 'Name order',
+    'name_order_firstname_first' => 'First name first (John Doe)',
+    'name_order_lastname_first' => 'Last name first (Doe John)',
     'currency' => 'Валюта',
-    'name' => 'Ваше имя: :firstname :lastname',
+    'name' => 'Ваше имя: :name',
     'email' => 'Email',
     'email_placeholder' => 'Введите email',
     'email_help' => 'Этот email используется в качетве логина и на него вы будете получать напоминания.',

--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -102,7 +102,7 @@
                           {{ trans_choice('dashboard.reminders_in_days', $reminder_day_diff, ['number' => $reminder_day_diff]) }}
                           ({{ \App\Helpers\DateHelper::getShortDate($reminder->getNextExpectedDate()) }})
                         </span>
-                        <a href="/people/{{ $reminder->contact_id }}">{{ App\Contact::find($reminder->contact_id)->getCompleteName() }}</a>:
+                        <a href="/people/{{ $reminder->contact_id }}">{{ App\Contact::find($reminder->contact_id)->getCompleteName(auth()->user()->name_order) }}</a>:
                         {{ $reminder->getTitle() }}
                       </li>
                     @endforeach
@@ -124,7 +124,7 @@
                   <ul>
                     @foreach ($tasks as $task)
                       <li>
-                        <a href="/people/{{ $task->contact_id }}">{{ App\Contact::find($task->contact_id)->getCompleteName() }}</a>:
+                        <a href="/people/{{ $task->contact_id }}">{{ App\Contact::find($task->contact_id)->getCompleteName(auth()->user()->name_order) }}</a>:
                         {{ $task->getTitle() }}
                         {{ $task->getDescription() }}
                       </li>
@@ -147,7 +147,7 @@
                   <ul>
                     @foreach ($debts as $debt)
                       <li>
-                        <a href="/people/{{ $debt->contact_id }}">{{ App\Contact::find($debt->contact_id)->getCompleteName() }}</a>:
+                        <a href="/people/{{ $debt->contact_id }}">{{ App\Contact::find($debt->contact_id)->getCompleteName(auth()->user()->name_order) }}</a>:
 
                         @if ($debt->in_debt == 'yes')
                         <span class="debt-description">{{ trans('dashboard.debts_you_owe') }}</span>
@@ -272,7 +272,7 @@
               <h3>{{ trans('dashboard.tab_last_edited_contacts') }}</h3>
               <ul>
                 @foreach ($lastUpdatedContacts as $contact)
-                  <li><a href="/people/{{ $contact->id }}">{{ $contact->getCompleteName() }}</a></li>
+                  <li><a href="/people/{{ $contact->id }}">{{ $contact->getCompleteName(auth()->user()->name_order) }}</a></li>
                 @endforeach
               </ul>
             </div>

--- a/resources/views/emails/reminder/reminder.blade.php
+++ b/resources/views/emails/reminder/reminder.blade.php
@@ -6,7 +6,7 @@
 
 {{ trans('mail.for') }}
 
-{{ $contact->getCompleteName() }}
+{{ $contact->getCompleteName($user()->name_order) }}
 
 {{-- COMMENTS --}}
 @if (! is_null($reminder->getDescription()))

--- a/resources/views/people/_header.blade.php
+++ b/resources/views/people/_header.blade.php
@@ -26,7 +26,7 @@
           @endif
 
           <h2>
-            {{ $contact->getCompleteName() }}
+            {{ $contact->getCompleteName(auth()->user()->name_order) }}
           </h2>
 
           <ul class="horizontal profile-detail-summary">

--- a/resources/views/people/activities/add.blade.php
+++ b/resources/views/people/activities/add.blade.php
@@ -16,7 +16,7 @@
                 <a href="/people">{{ trans('app.breadcrumb_list_contacts') }}</a>
               </li>
               <li>
-                {{ $contact->getCompleteName() }}
+                {{ $contact->getCompleteName(auth()->user()->name_order) }}
               </li>
             </ul>
           </div>

--- a/resources/views/people/activities/edit.blade.php
+++ b/resources/views/people/activities/edit.blade.php
@@ -16,7 +16,7 @@
                 <a href="/people">{{ trans('app.breadcrumb_list_contacts') }}</a>
               </li>
               <li>
-                {{ $contact->getCompleteName() }}
+                {{ $contact->getCompleteName(auth()->user()->name_order) }}
               </li>
             </ul>
           </div>

--- a/resources/views/people/dashboard/food-preferencies/edit.blade.php
+++ b/resources/views/people/dashboard/food-preferencies/edit.blade.php
@@ -16,7 +16,7 @@
                 <a href="/people">{{ trans('app.breadcrumb_list_contacts') }}</a>
               </li>
               <li>
-                {{ $contact->getCompleteName() }}
+                {{ $contact->getCompleteName(auth()->user()->name_order) }}
               </li>
             </ul>
           </div>

--- a/resources/views/people/dashboard/kids/add.blade.php
+++ b/resources/views/people/dashboard/kids/add.blade.php
@@ -16,7 +16,7 @@
                 <a href="/people">{{ trans('app.breadcrumb_list_contacts') }}</a>
               </li>
               <li>
-                {{ $contact->getCompleteName() }}
+                {{ $contact->getCompleteName(auth()->user()->name_order) }}
               </li>
             </ul>
           </div>

--- a/resources/views/people/dashboard/kids/edit.blade.php
+++ b/resources/views/people/dashboard/kids/edit.blade.php
@@ -16,7 +16,7 @@
                 <a href="/people">{{ trans('app.breadcrumb_list_contacts') }}</a>
               </li>
               <li>
-                {{ $contact->getCompleteName() }}
+                {{ $contact->getCompleteName(auth()->user()->name_order) }}
               </li>
             </ul>
           </div>

--- a/resources/views/people/dashboard/significantother/add.blade.php
+++ b/resources/views/people/dashboard/significantother/add.blade.php
@@ -16,7 +16,7 @@
                 <a href="/people">{{ trans('app.breadcrumb_list_contacts') }}</a>
               </li>
               <li>
-                {{ $contact->getCompleteName() }}
+                {{ $contact->getCompleteName(auth()->user()->name_order) }}
               </li>
             </ul>
           </div>

--- a/resources/views/people/dashboard/significantother/edit.blade.php
+++ b/resources/views/people/dashboard/significantother/edit.blade.php
@@ -16,7 +16,7 @@
                 <a href="/people">{{ trans('app.breadcrumb_list_contacts') }}</a>
               </li>
               <li>
-                {{ $contact->getCompleteName() }}
+                {{ $contact->getCompleteName(auth()->user()->name_order) }}
               </li>
             </ul>
           </div>

--- a/resources/views/people/dashboard/work/edit.blade.php
+++ b/resources/views/people/dashboard/work/edit.blade.php
@@ -16,7 +16,7 @@
                 <a href="/people">{{ trans('app.breadcrumb_list_contacts') }}</a>
               </li>
               <li>
-                {{ $contact->getCompleteName() }}
+                {{ $contact->getCompleteName(auth()->user()->name_order) }}
               </li>
             </ul>
           </div>

--- a/resources/views/people/debt/add.blade.php
+++ b/resources/views/people/debt/add.blade.php
@@ -16,7 +16,7 @@
                 <a href="/people">{{ trans('app.breadcrumb_list_contacts') }}</a>
               </li>
               <li>
-                {{ $contact->getCompleteName() }}
+                {{ $contact->getCompleteName(auth()->user()->name_order) }}
               </li>
             </ul>
           </div>

--- a/resources/views/people/debt/edit.blade.php
+++ b/resources/views/people/debt/edit.blade.php
@@ -16,7 +16,7 @@
                 <a href="/people">{{ trans('app.breadcrumb_list_contacts') }}</a>
               </li>
               <li>
-                {{ $contact->getCompleteName() }}
+                {{ $contact->getCompleteName(auth()->user()->name_order) }}
               </li>
             </ul>
           </div>

--- a/resources/views/people/edit.blade.php
+++ b/resources/views/people/edit.blade.php
@@ -16,7 +16,7 @@
                 <a href="/people">{{ trans('app.breadcrumb_list_contacts') }}</a>
               </li>
               <li>
-                <a href="/people/{{ $contact->id }}">{{ $contact->getCompleteName() }}</a>
+                <a href="/people/{{ $contact->id }}">{{ $contact->getCompleteName(auth()->user()->name_order) }}</a>
               </li>
               <li>
                 {{ trans('people.edit_contact_information') }}

--- a/resources/views/people/gifts/add.blade.php
+++ b/resources/views/people/gifts/add.blade.php
@@ -16,7 +16,7 @@
                 <a href="/people">{{ trans('app.breadcrumb_list_contacts') }}</a>
               </li>
               <li>
-                {{ $contact->getCompleteName() }}
+                {{ $contact->getCompleteName(auth()->user()->name_order) }}
               </li>
             </ul>
           </div>

--- a/resources/views/people/index.blade.php
+++ b/resources/views/people/index.blade.php
@@ -75,7 +75,7 @@
                       @endif
                     @endif
                     <span class="people-list-item-name">
-                      {{ $contact->getCompleteName() }}
+                      {{ $contact->getCompleteName(auth()->user()->name_order) }}
                     </span>
 
                     <span class="people-list-item-information">

--- a/resources/views/people/notes/add.blade.php
+++ b/resources/views/people/notes/add.blade.php
@@ -16,7 +16,7 @@
                 <a href="/people">{{ trans('app.breadcrumb_list_contacts') }}</a>
               </li>
               <li>
-                {{ $contact->getCompleteName() }}
+                {{ $contact->getCompleteName(auth()->user()->name_order) }}
               </li>
             </ul>
           </div>

--- a/resources/views/people/notes/edit.blade.php
+++ b/resources/views/people/notes/edit.blade.php
@@ -16,7 +16,7 @@
                 <a href="/people">{{ trans('app.breadcrumb_list_contacts') }}</a>
               </li>
               <li>
-                {{ $contact->getCompleteName() }}
+                {{ $contact->getCompleteName(auth()->user()->name_order) }}
               </li>
             </ul>
           </div>

--- a/resources/views/people/profile.blade.php
+++ b/resources/views/people/profile.blade.php
@@ -1,5 +1,7 @@
 @extends('layouts.skeleton')
-@section('title', $contact->getCompleteName() )
+
+@section('title', $contact->getCompleteName(auth()->user()->name_order) )
+
 @section('content')
   <div class="people-show">
     {{ csrf_field() }}
@@ -17,7 +19,7 @@
                 <a href="/people">{{ trans('app.breadcrumb_list_contacts') }}</a>
               </li>
               <li>
-                {{ $contact->getCompleteName() }}
+                {{ $contact->getCompleteName(auth()->user()->name_order) }}
               </li>
             </ul>
           </div>

--- a/resources/views/people/reminders/add.blade.php
+++ b/resources/views/people/reminders/add.blade.php
@@ -16,7 +16,7 @@
                 <a href="/people">{{ trans('app.breadcrumb_list_contacts') }}</a>
               </li>
               <li>
-                {{ $contact->getCompleteName() }}
+                {{ $contact->getCompleteName(auth()->user()->name_order) }}
               </li>
             </ul>
           </div>

--- a/resources/views/people/reminders/edit.blade.php
+++ b/resources/views/people/reminders/edit.blade.php
@@ -16,7 +16,7 @@
                 <a href="/people">{{ trans('app.breadcrumb_list_contacts') }}</a>
               </li>
               <li>
-                {{ $contact->getCompleteName() }}
+                {{ $contact->getCompleteName(auth()->user()->name_order) }}
               </li>
             </ul>
           </div>

--- a/resources/views/people/tasks/add.blade.php
+++ b/resources/views/people/tasks/add.blade.php
@@ -16,7 +16,7 @@
                 <a href="/people">{{ trans('app.breadcrumb_list_contacts') }}</a>
               </li>
               <li>
-                {{ $contact->getCompleteName() }}
+                {{ $contact->getCompleteName(auth()->user()->name_order) }}
               </li>
             </ul>
           </div>

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -6,7 +6,7 @@
 
   {{-- Breadcrumb --}}
   <div class="breadcrumb">
-    <div class="{{ Auth::user()->getFluidLayout() }}">
+    <div class="{{ auth()->user()->getFluidLayout() }}">
       <div class="row">
         <div class="col-xs-12">
           <ul class="horizontal">
@@ -22,7 +22,7 @@
     </div>
   </div>
 
-  <div class="{{ Auth::user()->getFluidLayout() }}">
+  <div class="{{ auth()->user()->getFluidLayout() }}">
     <div class="row">
 
       @include('settings._sidebar')
@@ -40,183 +40,200 @@
         <form action="/settings/save" method="POST">
           {{ csrf_field() }}
           <div class="form-group">
-            <p>{{ trans('settings.name', ['firstname' => Auth::user()->first_name, 'lastname' => Auth::user()->last_name]) }}</p>
+            <p>{{ trans('settings.name', ['name' => auth()->user()->name]) }}</p>
           </div>
+
+          {{-- email address --}}
+          <div class="form-group">
+            <label for="email">{{ trans('settings.email') }}</label>
+            <input type="email" class="form-control" name="email" id="email" placeholder="{{ trans('settings.email_placeholder') }}" required value="{{ auth()->user()->email }}">
+            <small id="emailHelp" class="form-text text-muted">{{ trans('settings.email_help') }}</small>
+          </div>
+
+          {{-- Locale --}}
           <div class="form-group">
             <label for="locale">{{ trans('settings.locale') }}</label>
             <select class="form-control" name="locale" id="locale">
               @foreach(config('monica.langs') as $lang)
-                <option value="{{ $lang }}" {{ (Auth::user()->locale == $lang)?'selected':'' }}>{{ trans('settings.locale_'.$lang) }}</option>
+                <option value="{{ $lang }}" {{ (auth()->user()->locale == $lang)?'selected':'' }}>{{ trans('settings.locale_'.$lang) }}</option>
               @endforeach
             </select>
           </div>
+
+          {{-- currency for user --}}
           <div class="form-group">
-            <label for="email">{{ trans('settings.email') }}</label>
-            <input type="email" class="form-control" name="email" id="email" placeholder="{{ trans('settings.email_placeholder') }}" required value="{{ Auth::user()->email }}">
-            <small id="emailHelp" class="form-text text-muted">{{ trans('settings.email_help') }}</small>
+            <label for="layout">{{ trans('settings.currency') }}</label>
+            @include('partials.components.currency-select', ['selectionID' => auth()->user()->currency_id ])
           </div>
+
+          {{-- Way of displaying names --}}
+          <div class="form-group">
+            <label for="name_order">{{ trans('settings.name_order') }}</label>
+            <select name="name_order" class="form-control">
+              <option value="firstname_first" {{ (auth()->user()->name_order == 'firstname_first')?'selected':'' }}>{{ trans('settings.name_order_firstname_first') }}</option>
+              <option value="lastname_first" {{ (auth()->user()->name_order == 'lastname_first')?'selected':'' }}>{{ trans('settings.name_order_lastname_first') }}</option>
+            </select>
+          </div>
+
+          {{-- Timezone --}}
           <div class="form-group">
             <label for="timezone">{{ trans('settings.timezone') }}</label>
             <select class="form-control" name="timezone" id="timezone">
-              <option value='US/Eastern' {{ (Auth::user()->timezone == 'US/Eastern')?'selected':'' }}>(UTC-05:00) Montreal/New-York</option>
-              <option value='US/Central' {{ (Auth::user()->timezone == 'US/Central')?'selected':'' }}>(UTC-06:00) Central Time (US &amp; Canada)</option>
-              <option value='America/Los_Angeles' {{ (Auth::user()->timezone == 'America/Los_Angeles')?'selected':'' }}>(UTC-08:00) Pacific Time (US &amp; Canada)</option>
-              <option value='Pacific/Midway' {{ (Auth::user()->timezone == 'Pacific/Midway')?'selected':'' }}>(UTC-11:00) Midway Island</option>
-              <option value='Pacific/Samoa' {{ (Auth::user()->timezone == 'Pacific/Samoa')?'selected':'' }}>(UTC-11:00) Samoa</option>
-              <option value='Pacific/Honolulu' {{ (Auth::user()->timezone == 'Pacific/Honolulu')?'selected':'' }}>(UTC-10:00) Hawaii</option>
-              <option value='US/Alaska' {{ (Auth::user()->timezone == 'US/Alaska')?'selected':'' }}>(UTC-09:00) Alaska</option>
-              <option value='America/Tijuana' {{ (Auth::user()->timezone == 'America/Tijuana')?'selected':'' }}>(UTC-08:00) Tijuana</option>
-              <option value='US/Arizona' {{ (Auth::user()->timezone == 'US/Arizona')?'selected':'' }}>(UTC-07:00) Arizona</option>
-              <option value='America/Chihuahua' {{ (Auth::user()->timezone == 'America/Chihuahua')?'selected':'' }}>(UTC-07:00) Chihuahua</option>
-              <option value='America/Chihuahua' {{ (Auth::user()->timezone == 'America/Chihuahua')?'selected':'' }}>(UTC-07:00) La Paz</option>
-              <option value='America/Mazatlan' {{ (Auth::user()->timezone == 'America/Mazatlan')?'selected':'' }}>(UTC-07:00) Mazatlan</option>
-              <option value='US/Mountain' {{ (Auth::user()->timezone == 'US/Mountain')?'selected':'' }}>(UTC-07:00) Mountain Time (US &amp; Canada)</option>
-              <option value='America/Managua' {{ (Auth::user()->timezone == 'America/Managua')?'selected':'' }}>(UTC-06:00) Central America</option>
-              <option value='US/Central' {{ (Auth::user()->timezone == 'US/Central')?'selected':'' }}>(UTC-06:00) Central Time (US &amp; Canada)</option>
-              <option value='America/Mexico_City' {{ (Auth::user()->timezone == 'America/Mexico_City')?'selected':'' }}>(UTC-06:00) Guadalajara</option>
-              <option value='America/Mexico_City' {{ (Auth::user()->timezone == 'America/Mexico_City')?'selected':'' }}>(UTC-06:00) Mexico City</option>
-              <option value='America/Monterrey' {{ (Auth::user()->timezone == 'America/Monterrey')?'selected':'' }}>(UTC-06:00) Monterrey</option>
-              <option value='Canada/Saskatchewan' {{ (Auth::user()->timezone == 'Canada/Saskatchewan')?'selected':'' }}>(UTC-06:00) Saskatchewan</option>
-              <option value='America/Bogota' {{ (Auth::user()->timezone == 'America/Bogota')?'selected':'' }}>(UTC-05:00) Bogota</option>
-              <option value='US/Eastern' {{ (Auth::user()->timezone == 'US/Eastern')?'selected':'' }}>(UTC-05:00) Eastern Time (US &amp; Canada)</option>
-              <option value='US/East- {{ (Auth::user()->timezone == 'US/East')?'selected':'' }}Indiana'>(UTC-05:00) Indiana (East)</option>
-              <option value='America/Lima' {{ (Auth::user()->timezone == 'America/Lima')?'selected':'' }}>(UTC-05:00) Lima</option>
-              <option value='America/Bogota' {{ (Auth::user()->timezone == 'America/Bogota')?'selected':'' }}>(UTC-05:00) Quito</option>
-              <option value='Canada/Atlantic' {{ (Auth::user()->timezone == 'Canada/Atlantic')?'selected':'' }}>(UTC-04:00) Atlantic Time (Canada)</option>
-              <option value='America/Caracas' {{ (Auth::user()->timezone == 'America/Caracas')?'selected':'' }}>(UTC-04:30) Caracas</option>
-              <option value='America/La_Paz' {{ (Auth::user()->timezone == 'America/La_Paz')?'selected':'' }}>(UTC-04:00) La Paz</option>
-              <option value='America/Santiago' {{ (Auth::user()->timezone == 'America/Santiago')?'selected':'' }}>(UTC-04:00) Santiago</option>
-              <option value='Canada/Newfoundland' {{ (Auth::user()->timezone == 'Canada/Newfoundland')?'selected':'' }}>(UTC-03:30) Newfoundland</option>
-              <option value='America/Sao_Paulo' {{ (Auth::user()->timezone == 'America/Sao_Paulo')?'selected':'' }}>(UTC-03:00) Brasilia</option>
-              <option value='America/Argentina/Buenos_Aires' {{ (Auth::user()->timezone == 'America/Argentina')?'selected':'' }}>(UTC-03:00) Buenos Aires</option>
-              <option value='America/Godthab' {{ (Auth::user()->timezone == 'America/Godthab')?'selected':'' }}>(UTC-03:00) Greenland</option>
-              <option value='America/Noronha' {{ (Auth::user()->timezone == 'America/Noronha')?'selected':'' }}>(UTC-02:00) Mid-Atlantic</option>
-              <option value='Atlantic/Azores' {{ (Auth::user()->timezone == 'Atlantic/Azores')?'selected':'' }}>(UTC-01:00) Azores</option>
-              <option value='Atlantic/Cape_Verde' {{ (Auth::user()->timezone == 'Atlantic/Cape_Verde')?'selected':'' }}>(UTC-01:00) Cape Verde Is.</option>
-              <option value='Africa/Casablanca' {{ (Auth::user()->timezone == 'Africa/Casablanca')?'selected':'' }}>(UTC+00:00) Casablanca</option>
-              <option value='Europe/London' {{ (Auth::user()->timezone == 'Europe/London')?'selected':'' }}>(UTC+00:00) Edinburgh</option>
-              <option value='Etc/Greenwich' {{ (Auth::user()->timezone == 'Etc/Greenwich')?'selected':'' }}>(UTC+00:00) Greenwich Mean Time : Dublin</option>
-              <option value='Europe/Lisbon' {{ (Auth::user()->timezone == 'Europe/Lisbon')?'selected':'' }}>(UTC+00:00) Lisbon</option>
-              <option value='Europe/London' {{ (Auth::user()->timezone == 'Europe/London')?'selected':'' }}>(UTC+00:00) London</option>
-              <option value='Africa/Monrovia' {{ (Auth::user()->timezone == 'Africa/Monrovia')?'selected':'' }}>(UTC+00:00) Monrovia</option>
-              <option value='UTC' {{ (Auth::user()->timezone == 'UTC')?'selected':'' }}>(UTC+00:00) UTC</option>
-              <option value='Europe/Amsterdam' {{ (Auth::user()->timezone == 'Europe/Amsterdam')?'selected':'' }}>(UTC+01:00) Amsterdam</option>
-              <option value='Europe/Belgrade' {{ (Auth::user()->timezone == 'Europe/Belgrade')?'selected':'' }}>(UTC+01:00) Belgrade</option>
-              <option value='Europe/Berlin' {{ (Auth::user()->timezone == 'Europe/Berlin')?'selected':'' }}>(UTC+01:00) Berlin</option>
-              <option value='Europe/Bratislava' {{ (Auth::user()->timezone == 'Europe/Bratislava')?'selected':'' }}>(UTC+01:00) Bratislava</option>
-              <option value='Europe/Brussels' {{ (Auth::user()->timezone == 'Europe/Brussels')?'selected':'' }}>(UTC+01:00) Brussels</option>
-              <option value='Europe/Budapest' {{ (Auth::user()->timezone == 'Europe/Budapest')?'selected':'' }}>(UTC+01:00) Budapest</option>
-              <option value='Europe/Copenhagen' {{ (Auth::user()->timezone == 'Europe/Copenhagen')?'selected':'' }}>(UTC+01:00) Copenhagen</option>
-              <option value='Europe/Ljubljana' {{ (Auth::user()->timezone == 'Europe/Ljubljana')?'selected':'' }}>(UTC+01:00) Ljubljana</option>
-              <option value='Europe/Madrid' {{ (Auth::user()->timezone == 'Europe/Madrid')?'selected':'' }}>(UTC+01:00) Madrid</option>
-              <option value='Europe/Paris' {{ (Auth::user()->timezone == 'Europe/Paris')?'selected':'' }}>(UTC+01:00) Paris</option>
-              <option value='Europe/Prague' {{ (Auth::user()->timezone == 'Europe/Prague')?'selected':'' }}>(UTC+01:00) Prague</option>
-              <option value='Europe/Rome' {{ (Auth::user()->timezone == 'Europe/Rome')?'selected':'' }}>(UTC+01:00) Rome</option>
-              <option value='Europe/Sarajevo' {{ (Auth::user()->timezone == 'Europe/Sarajevo')?'selected':'' }}>(UTC+01:00) Sarajevo</option>
-              <option value='Europe/Skopje' {{ (Auth::user()->timezone == 'Europe/Skopje')?'selected':'' }}>(UTC+01:00) Skopje</option>
-              <option value='Europe/Stockholm' {{ (Auth::user()->timezone == 'Europe/Stockholm')?'selected':'' }}>(UTC+01:00) Stockholm</option>
-              <option value='Europe/Vienna' {{ (Auth::user()->timezone == 'Europe/Vienna')?'selected':'' }}>(UTC+01:00) Vienna</option>
-              <option value='Europe/Warsaw' {{ (Auth::user()->timezone == 'Europe/Warsaw')?'selected':'' }}>(UTC+01:00) Warsaw</option>
-              <option value='Africa/Lagos' {{ (Auth::user()->timezone == 'Africa/Lagos')?'selected':'' }}>(UTC+01:00) West Central Africa</option>
-              <option value='Europe/Zagreb' {{ (Auth::user()->timezone == 'Europe/Zagreb')?'selected':'' }}>(UTC+01:00) Zagreb</option>
-              <option value='Europe/Zurich' {{ (Auth::user()->timezone == 'Europe/Zurich')?'selected':'' }}>(UTC+01:00) Zurich</option>
-              <option value='Europe/Athens' {{ (Auth::user()->timezone == 'Europe/Athens')?'selected':'' }}>(UTC+02:00) Athens</option>
-              <option value='Europe/Bucharest' {{ (Auth::user()->timezone == 'Europe/Bucharest')?'selected':'' }}>(UTC+02:00) Bucharest</option>
-              <option value='Africa/Cairo' {{ (Auth::user()->timezone == 'Africa/Cairo')?'selected':'' }}>(UTC+02:00) Cairo</option>
-              <option value='Africa/Harare' {{ (Auth::user()->timezone == 'Africa/Harare')?'selected':'' }}>(UTC+02:00) Harare</option>
-              <option value='Europe/Helsinki' {{ (Auth::user()->timezone == 'Europe/Helsinki')?'selected':'' }}>(UTC+02:00) Helsinki</option>
-              <option value='Europe/Istanbul' {{ (Auth::user()->timezone == 'Europe/Istanbul')?'selected':'' }}>(UTC+02:00) Istanbul</option>
-              <option value='Asia/Jerusalem' {{ (Auth::user()->timezone == 'Asia/Jerusalem')?'selected':'' }}>(UTC+02:00) Jerusalem</option>
-              <option value='Europe/Helsinki' {{ (Auth::user()->timezone == 'Europe/Helsinki')?'selected':'' }}>(UTC+02:00) Kyiv</option>
-              <option value='Africa/Johannesburg' {{ (Auth::user()->timezone == 'Africa/Johannesburg')?'selected':'' }}>(UTC+02:00) Pretoria</option>
-              <option value='Europe/Riga' {{ (Auth::user()->timezone == 'Europe/Riga')?'selected':'' }}>(UTC+02:00) Riga</option>
-              <option value='Europe/Sofia' {{ (Auth::user()->timezone == 'Europe/Sofia')?'selected':'' }}>(UTC+02:00) Sofia</option>
-              <option value='Europe/Tallinn' {{ (Auth::user()->timezone == 'Europe/Tallinn')?'selected':'' }}>(UTC+02:00) Tallinn</option>
-              <option value='Europe/Vilnius' {{ (Auth::user()->timezone == 'Europe/Vilnius')?'selected':'' }}>(UTC+02:00) Vilnius</option>
-              <option value='Asia/Baghdad' {{ (Auth::user()->timezone == 'Asia/Baghdad')?'selected':'' }}>(UTC+03:00) Baghdad</option>
-              <option value='Asia/Kuwait' {{ (Auth::user()->timezone == 'Asia/Kuwait')?'selected':'' }}>(UTC+03:00) Kuwait</option>
-              <option value='Europe/Minsk' {{ (Auth::user()->timezone == 'Europe/Minsk')?'selected':'' }}>(UTC+03:00) Minsk</option>
-              <option value='Africa/Nairobi' {{ (Auth::user()->timezone == 'Africa/Nairobi')?'selected':'' }}>(UTC+03:00) Nairobi</option>
-              <option value='Asia/Riyadh' {{ (Auth::user()->timezone == 'Asia/Riyadh')?'selected':'' }}>(UTC+03:00) Riyadh</option>
-              <option value='Europe/Volgograd' {{ (Auth::user()->timezone == 'Europe/Volgograd')?'selected':'' }}>(UTC+03:00) Volgograd</option>
-              <option value='Asia/Tehran' {{ (Auth::user()->timezone == 'Asia/Tehran')?'selected':'' }}>(UTC+03:30) Tehran</option>
-              <option value='Asia/Muscat' {{ (Auth::user()->timezone == 'Asia/Muscat')?'selected':'' }}>(UTC+04:00) Abu Dhabi</option>
-              <option value='Asia/Baku' {{ (Auth::user()->timezone == 'Asia/Baku')?'selected':'' }}>(UTC+04:00) Baku</option>
-              <option value='Europe/Moscow' {{ (Auth::user()->timezone == 'Europe/Moscow')?'selected':'' }}>(UTC+04:00) Moscow</option>
-              <option value='Asia/Muscat' {{ (Auth::user()->timezone == 'Asia/Muscat')?'selected':'' }}>(UTC+04:00) Muscat</option>
-              <option value='Europe/Moscow' {{ (Auth::user()->timezone == 'Europe/Moscow')?'selected':'' }}>(UTC+04:00) St. Petersburg</option>
-              <option value='Asia/Tbilisi' {{ (Auth::user()->timezone == 'Asia/Tbilisi')?'selected':'' }}>(UTC+04:00) Tbilisi</option>
-              <option value='Asia/Yerevan' {{ (Auth::user()->timezone == 'Asia/Yerevan')?'selected':'' }}>(UTC+04:00) Yerevan</option>
-              <option value='Asia/Kabul' {{ (Auth::user()->timezone == 'Asia/Kabul')?'selected':'' }}>(UTC+04:30) Kabul</option>
-              <option value='Asia/Karachi' {{ (Auth::user()->timezone == 'Asia/Karachi')?'selected':'' }}>(UTC+05:00) Islamabad</option>
-              <option value='Asia/Karachi' {{ (Auth::user()->timezone == 'Asia/Karachi')?'selected':'' }}>(UTC+05:00) Karachi</option>
-              <option value='Asia/Tashkent' {{ (Auth::user()->timezone == 'Asia/Tashkent')?'selected':'' }}>(UTC+05:00) Tashkent</option>
-              <option value='Asia/Calcutta' {{ (Auth::user()->timezone == 'Asia/Calcutta')?'selected':'' }}>(UTC+05:30) Chennai</option>
-              <option value='Asia/Kolkata' {{ (Auth::user()->timezone == 'Asia/Kolkata')?'selected':'' }}>(UTC+05:30) Kolkata</option>
-              <option value='Asia/Calcutta' {{ (Auth::user()->timezone == 'Asia/Calcutta')?'selected':'' }}>(UTC+05:30) Mumbai</option>
-              <option value='Asia/Calcutta' {{ (Auth::user()->timezone == 'Asia/Calcutta')?'selected':'' }}>(UTC+05:30) New Delhi</option>
-              <option value='Asia/Calcutta' {{ (Auth::user()->timezone == 'Asia/Calcutta')?'selected':'' }}>(UTC+05:30) Sri Jayawardenepura</option>
-              <option value='Asia/Katmandu' {{ (Auth::user()->timezone == 'Asia/Katmandu')?'selected':'' }}>(UTC+05:45) Kathmandu</option>
-              <option value='Asia/Almaty' {{ (Auth::user()->timezone == 'Asia/Almaty')?'selected':'' }}>(UTC+06:00) Almaty</option>
-              <option value='Asia/Dhaka' {{ (Auth::user()->timezone == 'Asia/Dhaka')?'selected':'' }}>(UTC+06:00) Astana</option>
-              <option value='Asia/Dhaka' {{ (Auth::user()->timezone == 'Asia/Dhaka')?'selected':'' }}>(UTC+06:00) Dhaka</option>
-              <option value='Asia/Yekaterinburg' {{ (Auth::user()->timezone == 'Asia/Yekaterinburg')?'selected':'' }}>(UTC+06:00) Ekaterinburg</option>
-              <option value='Asia/Rangoon' {{ (Auth::user()->timezone == 'Asia/Rangoon')?'selected':'' }}>(UTC+06:30) Rangoon</option>
-              <option value='Asia/Bangkok' {{ (Auth::user()->timezone == 'Asia/Bangkok')?'selected':'' }}>(UTC+07:00) Bangkok</option>
-              <option value='Asia/Bangkok' {{ (Auth::user()->timezone == 'Asia/Bangkok')?'selected':'' }}>(UTC+07:00) Hanoi</option>
-              <option value='Asia/Jakarta' {{ (Auth::user()->timezone == 'Asia/Jakarta')?'selected':'' }}>(UTC+07:00) Jakarta</option>
-              <option value='Asia/Novosibirsk' {{ (Auth::user()->timezone == 'Asia/Novosibirsk')?'selected':'' }}>(UTC+07:00) Novosibirsk</option>
-              <option value='Asia/Hong_Kong' {{ (Auth::user()->timezone == 'Asia/Hong_Kong')?'selected':'' }}>(UTC+08:00) Beijing</option>
-              <option value='Asia/Chongqing' {{ (Auth::user()->timezone == 'Asia/Chongqing')?'selected':'' }}>(UTC+08:00) Chongqing</option>
-              <option value='Asia/Hong_Kong' {{ (Auth::user()->timezone == 'Asia/Hong_Kong')?'selected':'' }}>(UTC+08:00) Hong Kong</option>
-              <option value='Asia/Krasnoyarsk' {{ (Auth::user()->timezone == 'Asia/Krasnoyarsk')?'selected':'' }}>(UTC+08:00) Krasnoyarsk</option>
-              <option value='Asia/Kuala_Lumpur' {{ (Auth::user()->timezone == 'Asia/Kuala_Lumpur')?'selected':'' }}>(UTC+08:00) Kuala Lumpur</option>
-              <option value='Australia/Perth' {{ (Auth::user()->timezone == 'Australia/Perth')?'selected':'' }}>(UTC+08:00) Perth</option>
-              <option value='Asia/Singapore' {{ (Auth::user()->timezone == 'Asia/Singapore')?'selected':'' }}>(UTC+08:00) Singapore</option>
-              <option value='Asia/Taipei' {{ (Auth::user()->timezone == 'Asia/Taipei')?'selected':'' }}>(UTC+08:00) Taipei</option>
-              <option value='Asia/Ulan_Bator' {{ (Auth::user()->timezone == 'Asia/Ulan_Bator')?'selected':'' }}>(UTC+08:00) Ulaan Bataar</option>
-              <option value='Asia/Urumqi' {{ (Auth::user()->timezone == 'Asia/Urumqi')?'selected':'' }}>(UTC+08:00) Urumqi</option>
-              <option value='Asia/Irkutsk' {{ (Auth::user()->timezone == 'Asia/Irkutsk')?'selected':'' }}>(UTC+09:00) Irkutsk</option>
-              <option value='Asia/Tokyo' {{ (Auth::user()->timezone == 'Asia/Tokyo')?'selected':'' }}>(UTC+09:00) Osaka</option>
-              <option value='Asia/Tokyo' {{ (Auth::user()->timezone == 'Asia/Tokyo')?'selected':'' }}>(UTC+09:00) Sapporo</option>
-              <option value='Asia/Seoul' {{ (Auth::user()->timezone == 'Asia/Seoul')?'selected':'' }}>(UTC+09:00) Seoul</option>
-              <option value='Asia/Tokyo' {{ (Auth::user()->timezone == 'Asia/Tokyo')?'selected':'' }}>(UTC+09:00) Tokyo</option>
-              <option value='Australia/Adelaide' {{ (Auth::user()->timezone == 'Australia/Adelaide')?'selected':'' }}>(UTC+09:30) Adelaide</option>
-              <option value='Australia/Darwin' {{ (Auth::user()->timezone == 'Australia/Darwin')?'selected':'' }}>(UTC+09:30) Darwin</option>
-              <option value='Australia/Brisbane' {{ (Auth::user()->timezone == 'Australia/Brisbane')?'selected':'' }}>(UTC+10:00) Brisbane</option>
-              <option value='Australia/Canberra' {{ (Auth::user()->timezone == 'Australia/Canberra')?'selected':'' }}>(UTC+10:00) Canberra</option>
-              <option value='Pacific/Guam' {{ (Auth::user()->timezone == 'Pacific/Guam')?'selected':'' }}>(UTC+10:00) Guam</option>
-              <option value='Australia/Hobart' {{ (Auth::user()->timezone == 'Australia/Hobart')?'selected':'' }}>(UTC+10:00) Hobart</option>
-              <option value='Australia/Melbourne' {{ (Auth::user()->timezone == 'Australia/Melbourne')?'selected':'' }}>(UTC+10:00) Melbourne</option>
-              <option value='Pacific/Port_Moresby' {{ (Auth::user()->timezone == 'Pacific/Port_Moresby')?'selected':'' }}>(UTC+10:00) Port Moresby</option>
-              <option value='Australia/Sydney' {{ (Auth::user()->timezone == 'Australia/Sydney')?'selected':'' }}>(UTC+10:00) Sydney</option>
-              <option value='Asia/Yakutsk' {{ (Auth::user()->timezone == 'Asia/Yakutsk')?'selected':'' }}>(UTC+10:00) Yakutsk</option>
-              <option value='Asia/Vladivostok' {{ (Auth::user()->timezone == 'Asia/Vladivostok')?'selected':'' }}>(UTC+11:00) Vladivostok</option>
-              <option value='Pacific/Auckland' {{ (Auth::user()->timezone == 'Pacific/Auckland')?'selected':'' }}>(UTC+12:00) Auckland</option>
-              <option value='Pacific/Fiji' {{ (Auth::user()->timezone == 'Pacific/Fiji')?'selected':'' }}>(UTC+12:00) Fiji</option>
-              <option value='Pacific/Kwajalein' {{ (Auth::user()->timezone == 'Pacific/Kwajalein')?'selected':'' }}>(UTC+12:00) International Date Line West</option>
-              <option value='Asia/Kamchatka' {{ (Auth::user()->timezone == 'Asia/Kamchatka')?'selected':'' }}>(UTC+12:00) Kamchatka</option>
-              <option value='Asia/Magadan' {{ (Auth::user()->timezone == 'Asia/Magadan')?'selected':'' }}>(UTC+12:00) Magadan</option>
-              <option value='Pacific/Fiji' {{ (Auth::user()->timezone == 'Pacific/Fiji')?'selected':'' }}>(UTC+12:00) Marshall Is.</option>
-              <option value='Asia/Magadan' {{ (Auth::user()->timezone == 'Asia/Magadan')?'selected':'' }}>(UTC+12:00) New Caledonia</option>
-              <option value='Asia/Magadan' {{ (Auth::user()->timezone == 'Asia/Magadan')?'selected':'' }}>(UTC+12:00) Solomon Is.</option>
-              <option value='Pacific/Auckland' {{ (Auth::user()->timezone == 'Pacific/Auckland')?'selected':'' }}>(UTC+12:00) Wellington</option>
-              <option value='Pacific/Tongatapu' {{ (Auth::user()->timezone == 'Pacific/Tongatapu')?'selected':'' }}>(UTC+13:00) Nuku'alofa</option>
+              <option value='US/Eastern' {{ (auth()->user()->timezone == 'US/Eastern')?'selected':'' }}>(UTC-05:00) Montreal/New-York</option>
+              <option value='US/Central' {{ (auth()->user()->timezone == 'US/Central')?'selected':'' }}>(UTC-06:00) Central Time (US &amp; Canada)</option>
+              <option value='America/Los_Angeles' {{ (auth()->user()->timezone == 'America/Los_Angeles')?'selected':'' }}>(UTC-08:00) Pacific Time (US &amp; Canada)</option>
+              <option value='Pacific/Midway' {{ (auth()->user()->timezone == 'Pacific/Midway')?'selected':'' }}>(UTC-11:00) Midway Island</option>
+              <option value='Pacific/Samoa' {{ (auth()->user()->timezone == 'Pacific/Samoa')?'selected':'' }}>(UTC-11:00) Samoa</option>
+              <option value='Pacific/Honolulu' {{ (auth()->user()->timezone == 'Pacific/Honolulu')?'selected':'' }}>(UTC-10:00) Hawaii</option>
+              <option value='US/Alaska' {{ (auth()->user()->timezone == 'US/Alaska')?'selected':'' }}>(UTC-09:00) Alaska</option>
+              <option value='America/Tijuana' {{ (auth()->user()->timezone == 'America/Tijuana')?'selected':'' }}>(UTC-08:00) Tijuana</option>
+              <option value='US/Arizona' {{ (auth()->user()->timezone == 'US/Arizona')?'selected':'' }}>(UTC-07:00) Arizona</option>
+              <option value='America/Chihuahua' {{ (auth()->user()->timezone == 'America/Chihuahua')?'selected':'' }}>(UTC-07:00) Chihuahua</option>
+              <option value='America/Chihuahua' {{ (auth()->user()->timezone == 'America/Chihuahua')?'selected':'' }}>(UTC-07:00) La Paz</option>
+              <option value='America/Mazatlan' {{ (auth()->user()->timezone == 'America/Mazatlan')?'selected':'' }}>(UTC-07:00) Mazatlan</option>
+              <option value='US/Mountain' {{ (auth()->user()->timezone == 'US/Mountain')?'selected':'' }}>(UTC-07:00) Mountain Time (US &amp; Canada)</option>
+              <option value='America/Managua' {{ (auth()->user()->timezone == 'America/Managua')?'selected':'' }}>(UTC-06:00) Central America</option>
+              <option value='US/Central' {{ (auth()->user()->timezone == 'US/Central')?'selected':'' }}>(UTC-06:00) Central Time (US &amp; Canada)</option>
+              <option value='America/Mexico_City' {{ (auth()->user()->timezone == 'America/Mexico_City')?'selected':'' }}>(UTC-06:00) Guadalajara</option>
+              <option value='America/Mexico_City' {{ (auth()->user()->timezone == 'America/Mexico_City')?'selected':'' }}>(UTC-06:00) Mexico City</option>
+              <option value='America/Monterrey' {{ (auth()->user()->timezone == 'America/Monterrey')?'selected':'' }}>(UTC-06:00) Monterrey</option>
+              <option value='Canada/Saskatchewan' {{ (auth()->user()->timezone == 'Canada/Saskatchewan')?'selected':'' }}>(UTC-06:00) Saskatchewan</option>
+              <option value='America/Bogota' {{ (auth()->user()->timezone == 'America/Bogota')?'selected':'' }}>(UTC-05:00) Bogota</option>
+              <option value='US/Eastern' {{ (auth()->user()->timezone == 'US/Eastern')?'selected':'' }}>(UTC-05:00) Eastern Time (US &amp; Canada)</option>
+              <option value='US/East- {{ (auth()->user()->timezone == 'US/East')?'selected':'' }}Indiana'>(UTC-05:00) Indiana (East)</option>
+              <option value='America/Lima' {{ (auth()->user()->timezone == 'America/Lima')?'selected':'' }}>(UTC-05:00) Lima</option>
+              <option value='America/Bogota' {{ (auth()->user()->timezone == 'America/Bogota')?'selected':'' }}>(UTC-05:00) Quito</option>
+              <option value='Canada/Atlantic' {{ (auth()->user()->timezone == 'Canada/Atlantic')?'selected':'' }}>(UTC-04:00) Atlantic Time (Canada)</option>
+              <option value='America/Caracas' {{ (auth()->user()->timezone == 'America/Caracas')?'selected':'' }}>(UTC-04:30) Caracas</option>
+              <option value='America/La_Paz' {{ (auth()->user()->timezone == 'America/La_Paz')?'selected':'' }}>(UTC-04:00) La Paz</option>
+              <option value='America/Santiago' {{ (auth()->user()->timezone == 'America/Santiago')?'selected':'' }}>(UTC-04:00) Santiago</option>
+              <option value='Canada/Newfoundland' {{ (auth()->user()->timezone == 'Canada/Newfoundland')?'selected':'' }}>(UTC-03:30) Newfoundland</option>
+              <option value='America/Sao_Paulo' {{ (auth()->user()->timezone == 'America/Sao_Paulo')?'selected':'' }}>(UTC-03:00) Brasilia</option>
+              <option value='America/Argentina/Buenos_Aires' {{ (auth()->user()->timezone == 'America/Argentina')?'selected':'' }}>(UTC-03:00) Buenos Aires</option>
+              <option value='America/Godthab' {{ (auth()->user()->timezone == 'America/Godthab')?'selected':'' }}>(UTC-03:00) Greenland</option>
+              <option value='America/Noronha' {{ (auth()->user()->timezone == 'America/Noronha')?'selected':'' }}>(UTC-02:00) Mid-Atlantic</option>
+              <option value='Atlantic/Azores' {{ (auth()->user()->timezone == 'Atlantic/Azores')?'selected':'' }}>(UTC-01:00) Azores</option>
+              <option value='Atlantic/Cape_Verde' {{ (auth()->user()->timezone == 'Atlantic/Cape_Verde')?'selected':'' }}>(UTC-01:00) Cape Verde Is.</option>
+              <option value='Africa/Casablanca' {{ (auth()->user()->timezone == 'Africa/Casablanca')?'selected':'' }}>(UTC+00:00) Casablanca</option>
+              <option value='Europe/London' {{ (auth()->user()->timezone == 'Europe/London')?'selected':'' }}>(UTC+00:00) Edinburgh</option>
+              <option value='Etc/Greenwich' {{ (auth()->user()->timezone == 'Etc/Greenwich')?'selected':'' }}>(UTC+00:00) Greenwich Mean Time : Dublin</option>
+              <option value='Europe/Lisbon' {{ (auth()->user()->timezone == 'Europe/Lisbon')?'selected':'' }}>(UTC+00:00) Lisbon</option>
+              <option value='Europe/London' {{ (auth()->user()->timezone == 'Europe/London')?'selected':'' }}>(UTC+00:00) London</option>
+              <option value='Africa/Monrovia' {{ (auth()->user()->timezone == 'Africa/Monrovia')?'selected':'' }}>(UTC+00:00) Monrovia</option>
+              <option value='UTC' {{ (auth()->user()->timezone == 'UTC')?'selected':'' }}>(UTC+00:00) UTC</option>
+              <option value='Europe/Amsterdam' {{ (auth()->user()->timezone == 'Europe/Amsterdam')?'selected':'' }}>(UTC+01:00) Amsterdam</option>
+              <option value='Europe/Belgrade' {{ (auth()->user()->timezone == 'Europe/Belgrade')?'selected':'' }}>(UTC+01:00) Belgrade</option>
+              <option value='Europe/Berlin' {{ (auth()->user()->timezone == 'Europe/Berlin')?'selected':'' }}>(UTC+01:00) Berlin</option>
+              <option value='Europe/Bratislava' {{ (auth()->user()->timezone == 'Europe/Bratislava')?'selected':'' }}>(UTC+01:00) Bratislava</option>
+              <option value='Europe/Brussels' {{ (auth()->user()->timezone == 'Europe/Brussels')?'selected':'' }}>(UTC+01:00) Brussels</option>
+              <option value='Europe/Budapest' {{ (auth()->user()->timezone == 'Europe/Budapest')?'selected':'' }}>(UTC+01:00) Budapest</option>
+              <option value='Europe/Copenhagen' {{ (auth()->user()->timezone == 'Europe/Copenhagen')?'selected':'' }}>(UTC+01:00) Copenhagen</option>
+              <option value='Europe/Ljubljana' {{ (auth()->user()->timezone == 'Europe/Ljubljana')?'selected':'' }}>(UTC+01:00) Ljubljana</option>
+              <option value='Europe/Madrid' {{ (auth()->user()->timezone == 'Europe/Madrid')?'selected':'' }}>(UTC+01:00) Madrid</option>
+              <option value='Europe/Paris' {{ (auth()->user()->timezone == 'Europe/Paris')?'selected':'' }}>(UTC+01:00) Paris</option>
+              <option value='Europe/Prague' {{ (auth()->user()->timezone == 'Europe/Prague')?'selected':'' }}>(UTC+01:00) Prague</option>
+              <option value='Europe/Rome' {{ (auth()->user()->timezone == 'Europe/Rome')?'selected':'' }}>(UTC+01:00) Rome</option>
+              <option value='Europe/Sarajevo' {{ (auth()->user()->timezone == 'Europe/Sarajevo')?'selected':'' }}>(UTC+01:00) Sarajevo</option>
+              <option value='Europe/Skopje' {{ (auth()->user()->timezone == 'Europe/Skopje')?'selected':'' }}>(UTC+01:00) Skopje</option>
+              <option value='Europe/Stockholm' {{ (auth()->user()->timezone == 'Europe/Stockholm')?'selected':'' }}>(UTC+01:00) Stockholm</option>
+              <option value='Europe/Vienna' {{ (auth()->user()->timezone == 'Europe/Vienna')?'selected':'' }}>(UTC+01:00) Vienna</option>
+              <option value='Europe/Warsaw' {{ (auth()->user()->timezone == 'Europe/Warsaw')?'selected':'' }}>(UTC+01:00) Warsaw</option>
+              <option value='Africa/Lagos' {{ (auth()->user()->timezone == 'Africa/Lagos')?'selected':'' }}>(UTC+01:00) West Central Africa</option>
+              <option value='Europe/Zagreb' {{ (auth()->user()->timezone == 'Europe/Zagreb')?'selected':'' }}>(UTC+01:00) Zagreb</option>
+              <option value='Europe/Zurich' {{ (auth()->user()->timezone == 'Europe/Zurich')?'selected':'' }}>(UTC+01:00) Zurich</option>
+              <option value='Europe/Athens' {{ (auth()->user()->timezone == 'Europe/Athens')?'selected':'' }}>(UTC+02:00) Athens</option>
+              <option value='Europe/Bucharest' {{ (auth()->user()->timezone == 'Europe/Bucharest')?'selected':'' }}>(UTC+02:00) Bucharest</option>
+              <option value='Africa/Cairo' {{ (auth()->user()->timezone == 'Africa/Cairo')?'selected':'' }}>(UTC+02:00) Cairo</option>
+              <option value='Africa/Harare' {{ (auth()->user()->timezone == 'Africa/Harare')?'selected':'' }}>(UTC+02:00) Harare</option>
+              <option value='Europe/Helsinki' {{ (auth()->user()->timezone == 'Europe/Helsinki')?'selected':'' }}>(UTC+02:00) Helsinki</option>
+              <option value='Europe/Istanbul' {{ (auth()->user()->timezone == 'Europe/Istanbul')?'selected':'' }}>(UTC+02:00) Istanbul</option>
+              <option value='Asia/Jerusalem' {{ (auth()->user()->timezone == 'Asia/Jerusalem')?'selected':'' }}>(UTC+02:00) Jerusalem</option>
+              <option value='Europe/Helsinki' {{ (auth()->user()->timezone == 'Europe/Helsinki')?'selected':'' }}>(UTC+02:00) Kyiv</option>
+              <option value='Africa/Johannesburg' {{ (auth()->user()->timezone == 'Africa/Johannesburg')?'selected':'' }}>(UTC+02:00) Pretoria</option>
+              <option value='Europe/Riga' {{ (auth()->user()->timezone == 'Europe/Riga')?'selected':'' }}>(UTC+02:00) Riga</option>
+              <option value='Europe/Sofia' {{ (auth()->user()->timezone == 'Europe/Sofia')?'selected':'' }}>(UTC+02:00) Sofia</option>
+              <option value='Europe/Tallinn' {{ (auth()->user()->timezone == 'Europe/Tallinn')?'selected':'' }}>(UTC+02:00) Tallinn</option>
+              <option value='Europe/Vilnius' {{ (auth()->user()->timezone == 'Europe/Vilnius')?'selected':'' }}>(UTC+02:00) Vilnius</option>
+              <option value='Asia/Baghdad' {{ (auth()->user()->timezone == 'Asia/Baghdad')?'selected':'' }}>(UTC+03:00) Baghdad</option>
+              <option value='Asia/Kuwait' {{ (auth()->user()->timezone == 'Asia/Kuwait')?'selected':'' }}>(UTC+03:00) Kuwait</option>
+              <option value='Europe/Minsk' {{ (auth()->user()->timezone == 'Europe/Minsk')?'selected':'' }}>(UTC+03:00) Minsk</option>
+              <option value='Africa/Nairobi' {{ (auth()->user()->timezone == 'Africa/Nairobi')?'selected':'' }}>(UTC+03:00) Nairobi</option>
+              <option value='Asia/Riyadh' {{ (auth()->user()->timezone == 'Asia/Riyadh')?'selected':'' }}>(UTC+03:00) Riyadh</option>
+              <option value='Europe/Volgograd' {{ (auth()->user()->timezone == 'Europe/Volgograd')?'selected':'' }}>(UTC+03:00) Volgograd</option>
+              <option value='Asia/Tehran' {{ (auth()->user()->timezone == 'Asia/Tehran')?'selected':'' }}>(UTC+03:30) Tehran</option>
+              <option value='Asia/Muscat' {{ (auth()->user()->timezone == 'Asia/Muscat')?'selected':'' }}>(UTC+04:00) Abu Dhabi</option>
+              <option value='Asia/Baku' {{ (auth()->user()->timezone == 'Asia/Baku')?'selected':'' }}>(UTC+04:00) Baku</option>
+              <option value='Europe/Moscow' {{ (auth()->user()->timezone == 'Europe/Moscow')?'selected':'' }}>(UTC+04:00) Moscow</option>
+              <option value='Asia/Muscat' {{ (auth()->user()->timezone == 'Asia/Muscat')?'selected':'' }}>(UTC+04:00) Muscat</option>
+              <option value='Europe/Moscow' {{ (auth()->user()->timezone == 'Europe/Moscow')?'selected':'' }}>(UTC+04:00) St. Petersburg</option>
+              <option value='Asia/Tbilisi' {{ (auth()->user()->timezone == 'Asia/Tbilisi')?'selected':'' }}>(UTC+04:00) Tbilisi</option>
+              <option value='Asia/Yerevan' {{ (auth()->user()->timezone == 'Asia/Yerevan')?'selected':'' }}>(UTC+04:00) Yerevan</option>
+              <option value='Asia/Kabul' {{ (auth()->user()->timezone == 'Asia/Kabul')?'selected':'' }}>(UTC+04:30) Kabul</option>
+              <option value='Asia/Karachi' {{ (auth()->user()->timezone == 'Asia/Karachi')?'selected':'' }}>(UTC+05:00) Islamabad</option>
+              <option value='Asia/Karachi' {{ (auth()->user()->timezone == 'Asia/Karachi')?'selected':'' }}>(UTC+05:00) Karachi</option>
+              <option value='Asia/Tashkent' {{ (auth()->user()->timezone == 'Asia/Tashkent')?'selected':'' }}>(UTC+05:00) Tashkent</option>
+              <option value='Asia/Calcutta' {{ (auth()->user()->timezone == 'Asia/Calcutta')?'selected':'' }}>(UTC+05:30) Chennai</option>
+              <option value='Asia/Kolkata' {{ (auth()->user()->timezone == 'Asia/Kolkata')?'selected':'' }}>(UTC+05:30) Kolkata</option>
+              <option value='Asia/Calcutta' {{ (auth()->user()->timezone == 'Asia/Calcutta')?'selected':'' }}>(UTC+05:30) Mumbai</option>
+              <option value='Asia/Calcutta' {{ (auth()->user()->timezone == 'Asia/Calcutta')?'selected':'' }}>(UTC+05:30) New Delhi</option>
+              <option value='Asia/Calcutta' {{ (auth()->user()->timezone == 'Asia/Calcutta')?'selected':'' }}>(UTC+05:30) Sri Jayawardenepura</option>
+              <option value='Asia/Katmandu' {{ (auth()->user()->timezone == 'Asia/Katmandu')?'selected':'' }}>(UTC+05:45) Kathmandu</option>
+              <option value='Asia/Almaty' {{ (auth()->user()->timezone == 'Asia/Almaty')?'selected':'' }}>(UTC+06:00) Almaty</option>
+              <option value='Asia/Dhaka' {{ (auth()->user()->timezone == 'Asia/Dhaka')?'selected':'' }}>(UTC+06:00) Astana</option>
+              <option value='Asia/Dhaka' {{ (auth()->user()->timezone == 'Asia/Dhaka')?'selected':'' }}>(UTC+06:00) Dhaka</option>
+              <option value='Asia/Yekaterinburg' {{ (auth()->user()->timezone == 'Asia/Yekaterinburg')?'selected':'' }}>(UTC+06:00) Ekaterinburg</option>
+              <option value='Asia/Rangoon' {{ (auth()->user()->timezone == 'Asia/Rangoon')?'selected':'' }}>(UTC+06:30) Rangoon</option>
+              <option value='Asia/Bangkok' {{ (auth()->user()->timezone == 'Asia/Bangkok')?'selected':'' }}>(UTC+07:00) Bangkok</option>
+              <option value='Asia/Bangkok' {{ (auth()->user()->timezone == 'Asia/Bangkok')?'selected':'' }}>(UTC+07:00) Hanoi</option>
+              <option value='Asia/Jakarta' {{ (auth()->user()->timezone == 'Asia/Jakarta')?'selected':'' }}>(UTC+07:00) Jakarta</option>
+              <option value='Asia/Novosibirsk' {{ (auth()->user()->timezone == 'Asia/Novosibirsk')?'selected':'' }}>(UTC+07:00) Novosibirsk</option>
+              <option value='Asia/Hong_Kong' {{ (auth()->user()->timezone == 'Asia/Hong_Kong')?'selected':'' }}>(UTC+08:00) Beijing</option>
+              <option value='Asia/Chongqing' {{ (auth()->user()->timezone == 'Asia/Chongqing')?'selected':'' }}>(UTC+08:00) Chongqing</option>
+              <option value='Asia/Hong_Kong' {{ (auth()->user()->timezone == 'Asia/Hong_Kong')?'selected':'' }}>(UTC+08:00) Hong Kong</option>
+              <option value='Asia/Krasnoyarsk' {{ (auth()->user()->timezone == 'Asia/Krasnoyarsk')?'selected':'' }}>(UTC+08:00) Krasnoyarsk</option>
+              <option value='Asia/Kuala_Lumpur' {{ (auth()->user()->timezone == 'Asia/Kuala_Lumpur')?'selected':'' }}>(UTC+08:00) Kuala Lumpur</option>
+              <option value='Australia/Perth' {{ (auth()->user()->timezone == 'Australia/Perth')?'selected':'' }}>(UTC+08:00) Perth</option>
+              <option value='Asia/Singapore' {{ (auth()->user()->timezone == 'Asia/Singapore')?'selected':'' }}>(UTC+08:00) Singapore</option>
+              <option value='Asia/Taipei' {{ (auth()->user()->timezone == 'Asia/Taipei')?'selected':'' }}>(UTC+08:00) Taipei</option>
+              <option value='Asia/Ulan_Bator' {{ (auth()->user()->timezone == 'Asia/Ulan_Bator')?'selected':'' }}>(UTC+08:00) Ulaan Bataar</option>
+              <option value='Asia/Urumqi' {{ (auth()->user()->timezone == 'Asia/Urumqi')?'selected':'' }}>(UTC+08:00) Urumqi</option>
+              <option value='Asia/Irkutsk' {{ (auth()->user()->timezone == 'Asia/Irkutsk')?'selected':'' }}>(UTC+09:00) Irkutsk</option>
+              <option value='Asia/Tokyo' {{ (auth()->user()->timezone == 'Asia/Tokyo')?'selected':'' }}>(UTC+09:00) Osaka</option>
+              <option value='Asia/Tokyo' {{ (auth()->user()->timezone == 'Asia/Tokyo')?'selected':'' }}>(UTC+09:00) Sapporo</option>
+              <option value='Asia/Seoul' {{ (auth()->user()->timezone == 'Asia/Seoul')?'selected':'' }}>(UTC+09:00) Seoul</option>
+              <option value='Asia/Tokyo' {{ (auth()->user()->timezone == 'Asia/Tokyo')?'selected':'' }}>(UTC+09:00) Tokyo</option>
+              <option value='Australia/Adelaide' {{ (auth()->user()->timezone == 'Australia/Adelaide')?'selected':'' }}>(UTC+09:30) Adelaide</option>
+              <option value='Australia/Darwin' {{ (auth()->user()->timezone == 'Australia/Darwin')?'selected':'' }}>(UTC+09:30) Darwin</option>
+              <option value='Australia/Brisbane' {{ (auth()->user()->timezone == 'Australia/Brisbane')?'selected':'' }}>(UTC+10:00) Brisbane</option>
+              <option value='Australia/Canberra' {{ (auth()->user()->timezone == 'Australia/Canberra')?'selected':'' }}>(UTC+10:00) Canberra</option>
+              <option value='Pacific/Guam' {{ (auth()->user()->timezone == 'Pacific/Guam')?'selected':'' }}>(UTC+10:00) Guam</option>
+              <option value='Australia/Hobart' {{ (auth()->user()->timezone == 'Australia/Hobart')?'selected':'' }}>(UTC+10:00) Hobart</option>
+              <option value='Australia/Melbourne' {{ (auth()->user()->timezone == 'Australia/Melbourne')?'selected':'' }}>(UTC+10:00) Melbourne</option>
+              <option value='Pacific/Port_Moresby' {{ (auth()->user()->timezone == 'Pacific/Port_Moresby')?'selected':'' }}>(UTC+10:00) Port Moresby</option>
+              <option value='Australia/Sydney' {{ (auth()->user()->timezone == 'Australia/Sydney')?'selected':'' }}>(UTC+10:00) Sydney</option>
+              <option value='Asia/Yakutsk' {{ (auth()->user()->timezone == 'Asia/Yakutsk')?'selected':'' }}>(UTC+10:00) Yakutsk</option>
+              <option value='Asia/Vladivostok' {{ (auth()->user()->timezone == 'Asia/Vladivostok')?'selected':'' }}>(UTC+11:00) Vladivostok</option>
+              <option value='Pacific/Auckland' {{ (auth()->user()->timezone == 'Pacific/Auckland')?'selected':'' }}>(UTC+12:00) Auckland</option>
+              <option value='Pacific/Fiji' {{ (auth()->user()->timezone == 'Pacific/Fiji')?'selected':'' }}>(UTC+12:00) Fiji</option>
+              <option value='Pacific/Kwajalein' {{ (auth()->user()->timezone == 'Pacific/Kwajalein')?'selected':'' }}>(UTC+12:00) International Date Line West</option>
+              <option value='Asia/Kamchatka' {{ (auth()->user()->timezone == 'Asia/Kamchatka')?'selected':'' }}>(UTC+12:00) Kamchatka</option>
+              <option value='Asia/Magadan' {{ (auth()->user()->timezone == 'Asia/Magadan')?'selected':'' }}>(UTC+12:00) Magadan</option>
+              <option value='Pacific/Fiji' {{ (auth()->user()->timezone == 'Pacific/Fiji')?'selected':'' }}>(UTC+12:00) Marshall Is.</option>
+              <option value='Asia/Magadan' {{ (auth()->user()->timezone == 'Asia/Magadan')?'selected':'' }}>(UTC+12:00) New Caledonia</option>
+              <option value='Asia/Magadan' {{ (auth()->user()->timezone == 'Asia/Magadan')?'selected':'' }}>(UTC+12:00) Solomon Is.</option>
+              <option value='Pacific/Auckland' {{ (auth()->user()->timezone == 'Pacific/Auckland')?'selected':'' }}>(UTC+12:00) Wellington</option>
+              <option value='Pacific/Tongatapu' {{ (auth()->user()->timezone == 'Pacific/Tongatapu')?'selected':'' }}>(UTC+13:00) Nuku'alofa</option>
 
             </select>
           </div>
+
+          {{-- Layout --}}
           <div class="form-group">
             <label for="layout">{{ trans('settings.layout') }}</label>
             <select class="form-control" name="layout" id="layout">
-              <option value='false' {{ (Auth::user()->fluid_container == 'false')?'selected':'' }}>{{ trans('settings.layout_small') }}</option>
-              <option value='true' {{ (Auth::user()->fluid_container == 'true')?'selected':'' }}>{{ trans('settings.layout_big') }}</option>
+              <option value='false' {{ (auth()->user()->fluid_container == 'false')?'selected':'' }}>{{ trans('settings.layout_small') }}</option>
+              <option value='true' {{ (auth()->user()->fluid_container == 'true')?'selected':'' }}>{{ trans('settings.layout_big') }}</option>
             </select>
-          </div>
-
-          <!--currency for user-->
-          <div class="form-group">
-            <label for="layout">{{ trans('settings.currency') }}</label>
-            @include('partials.components.currency-select',['selectionID'=>Auth::user()->currency_id ])
           </div>
 
           <button type="submit" class="btn btn-primary">{{ trans('settings.save') }}</button>

--- a/tests/Unit/ContactTest.php
+++ b/tests/Unit/ContactTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit;
 
+use App\User;
 use App\Contact;
 use Carbon\Carbon;
 use Tests\TestCase;
@@ -32,7 +33,7 @@ class ContactTest extends TestCase
         );
     }
 
-    public function testGetsNamesMethods()
+    public function test_get_name_returns_name()
     {
         $contact = new Contact;
         $contact->first_name = 'Peter';
@@ -87,6 +88,24 @@ class ContactTest extends TestCase
         $this->assertEquals(
             null,
             $contact->getLastName()
+        );
+    }
+
+    public function test_get_name_returns_name_in_the_right_order()
+    {
+        $contact = new Contact;
+        $contact->first_name = 'Peter';
+        $contact->middle_name = 'H';
+        $contact->last_name = 'Gregory';
+
+        $this->assertEquals(
+            'Gregory H Peter',
+            $contact->getCompleteName('lastname_first')
+        );
+
+        $this->assertEquals(
+            'Peter H Gregory',
+            $contact->getCompleteName('firstname_first')
         );
     }
 

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -23,4 +23,22 @@ class UserTest extends TestCase
           $user->updateContactViewPreference('lastnameAZ')
         );
     }
+
+    public function test_name_accessor_returns_name_in_the_user_preferred_way()
+    {
+        $user = new User;
+        $user->first_name = 'John';
+        $user->last_name = 'Doe';
+        $user->name_order = 'firstname_first';
+
+        $this->assertEquals(
+          $user->name, 'John Doe'
+        );
+
+        $user->name_order = 'lastname_first';
+
+        $this->assertEquals(
+          $user->name, 'Doe John'
+        );
+    }
 }


### PR DESCRIPTION
Not everyone lives in the western culture. In some countries, names are not defined in the `firstname lastname` order, but rather the opposite, `lastname firstname`.

You can now define this order in your Settings panel.
