### PR TITLE
Add php7-curl dependency to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.6
 
 EXPOSE 80:80
 
-RUN apk update && apk add apache2 curl git make netcat-openbsd nodejs-current-npm openssl php7 php7-apache2 php7-ctype php7-dom php7-fileinfo php7-gd php7-iconv php7-intl php7-json php7-mbstring php7-mysqli php7-openssl php7-pdo_mysql php7-phar php7-session php7-tokenizer php7-xml php7-xmlreader php7-xmlwriter php7-zip php7-zlib php7-pgsql php7-pdo_pgsql
+RUN apk update && apk add apache2 curl git make netcat-openbsd nodejs-current-npm openssl php7 php7-apache2 php7-ctype php7-dom php7-fileinfo php7-gd php7-iconv php7-intl php7-json php7-mbstring php7-mysqli php7-openssl php7-pdo_mysql php7-phar php7-session php7-tokenizer php7-xml php7-xmlreader php7-xmlwriter php7-zip php7-zlib php7-pgsql php7-pdo_pgsql php7-curl
 
 RUN npm install -g bower
 RUN mkdir -p /run/apache2


### PR DESCRIPTION
To prevent this error from happening during ```docker-compose build```

```
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for stripe/stripe-php v4.13.0 -> satisfiable by stripe/stripe-php[v4.13.0].
    - stripe/stripe-php v4.13.0 requires ext-curl * -> the requested PHP extension curl is missing from your system.
  Problem 2
    - stripe/stripe-php v4.13.0 requires ext-curl * -> the requested PHP extension curl is missing from your system.
    - laravel/cashier v7.0.9 requires stripe/stripe-php ~4.0 -> satisfiable by stripe/stripe-php[v4.13.0].
    - Installation request for laravel/cashier v7.0.9 -> satisfiable by laravel/cashier[v7.0.9].

  To enable extensions, verify that they are enabled in your .ini files:
    - /etc/php7/php.ini
    - /etc/php7/conf.d/00_ctype.ini
    - /etc/php7/conf.d/00_dom.ini
    - /etc/php7/conf.d/00_fileinfo.ini
    - /etc/php7/conf.d/00_gd.ini
    - /etc/php7/conf.d/00_iconv.ini
    - /etc/php7/conf.d/00_intl.ini
    - /etc/php7/conf.d/00_json.ini
    - /etc/php7/conf.d/00_mbstring.ini
    - /etc/php7/conf.d/00_openssl.ini
    - /etc/php7/conf.d/00_pdo.ini
    - /etc/php7/conf.d/00_pgsql.ini
    - /etc/php7/conf.d/00_session.ini
    - /etc/php7/conf.d/00_tokenizer.ini
    - /etc/php7/conf.d/00_xml.ini
    - /etc/php7/conf.d/00_xmlwriter.ini
    - /etc/php7/conf.d/00_zip.ini
    - /etc/php7/conf.d/00_zlib.ini
    - /etc/php7/conf.d/01_mysqlnd.ini
    - /etc/php7/conf.d/01_pdo_pgsql.ini
    - /etc/php7/conf.d/01_phar.ini
    - /etc/php7/conf.d/01_xmlreader.ini
    - /etc/php7/conf.d/02_mysqli.ini
    - /etc/php7/conf.d/02_pdo_mysql.ini
  You can also run `php --ini` inside terminal to see which files are used by PHP in CLI mode.
```