### PR TITLE
show time diff from when action was created to now

### DIFF
--- a/app/Http/Middleware/CheckLocale.php
+++ b/app/Http/Middleware/CheckLocale.php
@@ -3,6 +3,7 @@
 namespace App\Http\Middleware;
 
 use Auth;
+use Carbon\Carbon;
 use Closure;
 
 class CheckLocale
@@ -18,6 +19,7 @@ class CheckLocale
     {
         if (Auth::check()) {
             \App::setLocale(Auth::user()->locale);
+            Carbon::setLocale(config('app.locale'));
         }
 
         return $next($request);

--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -246,8 +246,8 @@
                       </div>
 
                       {{-- DATE --}}
-                      <div class="event-date">
-                        {{ \App\Helpers\DateHelper::getShortDateWithTime($event['date']) }}
+                      <div class="event-date pull-right">
+                        {{ $event['date']->diffForHumans() }}
                       </div>
                     </li>
                   @endforeach


### PR DESCRIPTION
Changed the way the 'Last Actions' tab shows event timestamps, at first glance it's hard to reason how long ago an action took place without counting backwards from the current date, updated to use Carbons diffForHumans.

**Before**
![screen shot 2017-06-27 at 20 36 56](https://user-images.githubusercontent.com/1025914/27606547-ad73aaea-5b78-11e7-8f00-e219f6e33800.png)

**After**
![screen shot 2017-06-27 at 20 36 38](https://user-images.githubusercontent.com/1025914/27606556-b32a58ee-5b78-11e7-99e2-c18976ba5f25.png)
