### PR TITLE
Update index.blade.php, people.php & journal.php

### DIFF
--- a/resources/lang/en/journal.php
+++ b/resources/lang/en/journal.php
@@ -9,4 +9,5 @@ return [
     'journal_add_cta' => 'Save',
     'journal_blank_cta' => 'Add your first journal entry',
     'journal_blank_description' => 'The journal lets you write events that happened to you, and remember them.',
+    'delete_confirmation' => 'Are you sure you want to delete this journal entry?',
 ];

--- a/resources/lang/en/journal.php
+++ b/resources/lang/en/journal.php
@@ -3,7 +3,7 @@
 return [
     'journal_add' => 'Add a journal entry',
     'journal_entry_delete' => 'Delete',
-    'entry_delete_success' => 'The journal entry has been deleted with success.',
+    'entry_delete_success' => 'The journal entry has been successfully deleted.',
     'journal_add_title' => 'Title (optional)',
     'journal_add_post' => 'Entry',
     'journal_add_cta' => 'Save',

--- a/resources/lang/en/people.php
+++ b/resources/lang/en/people.php
@@ -284,5 +284,5 @@ return [
     'debt_add_add_cta' => 'Add debt',
     'debt_edit_update_cta' => 'Update debt',
     'debt_edit_success' => 'The debt has been updated successfully',
-    'debts_blank_title' => 'Manage debts you owe to :name or :name owes you'
+    'debts_blank_title' => 'Manage debts you owe to :name or :name owes you',
 ];

--- a/resources/views/journal/index.blade.php
+++ b/resources/views/journal/index.blade.php
@@ -61,7 +61,7 @@
                       <ul>
                         <li>{{ \App\Helpers\DateHelper::getShortDate($entry->created_at) }}</li>
                         <li>
-                          <a href="/journal/{{ $entry->id }}/delete" onclick="return confirm('{{ trans('people.gifts_delete_confirmation') }}')">{{ trans('journal.journal_entry_delete') }}</a>
+                          <a href="/journal/{{ $entry->id }}/delete" onclick="return confirm('{{ trans('journal.delete_confirmation') }}')">{{ trans('journal.journal_entry_delete') }}</a>
                         </li>
                       </ul>
                     </div>


### PR DESCRIPTION
-- people.php --
added a comma to the end of  line 287

-- journal.php --
created the text for the message box that appears when a user opts to delete a journal entry

-- index.blade.php --
points to the text for the message box that appears when a user opts to delete a journal entry

### Checklist

- [x] Read the [CONTRIBUTING document](https://github.com/monicahq/monica/blob/master/CONTRIBUTING.md) before submitting your PR.
- [ ] If the PR is related to an issue or fix one, don't forget to indicate it.
- [x] Make sure that the change you propose is the smallest possible.
- [ ] Screenshots are included if the PR changes the UI.
- [ ] Tests added for this feature/bug.
- [ ] [CHANGELOG](https://github.com/monicahq/monica/blob/master/CHANGELOG) entry added, if necessary, under `UNRELEASED`.
- [ ] [CONTRIBUTORS](https://github.com/monicahq/monica/blob/master/CONTRIBUTORS) entry added, if necessary.
- [ ] Indicate `[wip]` in the title of the PR it is is not final yet. Remove `[wip]` when ready. Otherwise the PR will be considered complete and rejected if it's not working.
