### PR TITLE
Voryzen monica journal 1

### DIFF
--- a/resources/lang/en/journal.php
+++ b/resources/lang/en/journal.php
@@ -9,4 +9,5 @@ return [
     'journal_add_cta' => 'Save',
     'journal_blank_cta' => 'Add your first journal entry',
     'journal_blank_description' => 'The journal lets you write events that happened to you, and remember them.',
+    'delete_confirmation' => 'Are you sure you want to delete this journal entry?',
 ];

--- a/resources/views/journal/index.blade.php
+++ b/resources/views/journal/index.blade.php
@@ -61,7 +61,7 @@
                       <ul>
                         <li>{{ \App\Helpers\DateHelper::getShortDate($entry->created_at) }}</li>
                         <li>
-                          <a href="/journal/{{ $entry->id }}/delete" onclick="return confirm('{{ trans('people.gifts_delete_confirmation') }}')">{{ trans('journal.journal_entry_delete') }}</a>
+                          <a href="/journal/{{ $entry->id }}/delete" onclick="return confirm('{{ trans('journal.delete_confirmation') }}')">{{ trans('journal.journal_entry_delete') }}</a>
                         </li>
                       </ul>
                     </div>


### PR DESCRIPTION
corrects the message box that appears when user deletes a journal entry

### Checklist

- [x] Read the [CONTRIBUTING document](https://github.com/monicahq/monica/blob/master/CONTRIBUTING.md) before submitting your PR.
- [ ] If the PR is related to an issue or fix one, don't forget to indicate it.
- [x] Make sure that the change you propose is the smallest possible.
- [ ] Screenshots are included if the PR changes the UI.
- [ ] Tests added for this feature/bug.
- [ ] [CHANGELOG](https://github.com/monicahq/monica/blob/master/CHANGELOG) entry added, if necessary, under `UNRELEASED`.
- [ ] [CONTRIBUTORS](https://github.com/monicahq/monica/blob/master/CONTRIBUTORS) entry added, if necessary.
- [ ] Indicate `[wip]` in the title of the PR it is is not final yet. Remove `[wip]` when ready. Otherwise the PR will be considered complete and rejected if it's not working.
