### PR TITLE
Restrict people name's length

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 UNRELEASED CHANGES:
 
+* Add restriction of 50 characters for a first name, and 100 characters for a last name.
 * Add support for storing uploaded files on s3
 * Sort contacts by first name, last name when linking significant others and kids
 * Remove beginning / ending spaces in names when adding / saving a contact.

--- a/app/Http/Controllers/PeopleController.php
+++ b/app/Http/Controllers/PeopleController.php
@@ -72,7 +72,8 @@ class PeopleController extends Controller
     public function store(Request $request)
     {
         $validator = Validator::make($request->all(), [
-            'first_name' => 'required|max:255',
+            'first_name' => 'required|max:50',
+            'last_name' => 'required|max:100',
             'gender' => 'required',
         ]);
 
@@ -146,7 +147,8 @@ class PeopleController extends Controller
     public function update(Request $request, Contact $contact)
     {
         $validator = Validator::make($request->all(), [
-            'firstname' => 'required|max:255',
+            'firstname' => 'required|max:50',
+            'lastname' => 'max:100',
             'gender' => 'required',
             'file' => 'max:10240',
         ]);

--- a/app/Http/Requests/People/KidsRequest.php
+++ b/app/Http/Requests/People/KidsRequest.php
@@ -24,8 +24,8 @@ class KidsRequest extends FormRequest
     public function rules()
     {
         return [
-            'first_name' => 'required|string',
-            'last_name' => 'string',
+            'first_name' => 'required|string|max:50',
+            'last_name' => 'string|nullable|max:100',
             'gender' => 'in:male,female,none',
             'is_birthdate_approximate' => 'required|in:unknown,approximate,exact',
             'birthdate' => 'date|nullable',

--- a/app/Http/Requests/People/RelationshipsRequest.php
+++ b/app/Http/Requests/People/RelationshipsRequest.php
@@ -24,8 +24,8 @@ class RelationshipsRequest extends FormRequest
     public function rules()
     {
         return [
-            'first_name' => 'required|string',
-            'last_name' => 'string|nullable',
+            'first_name' => 'required|string|max:50',
+            'last_name' => 'string|nullable|max:100',
             'gender' => 'in:male,female,none',
             'status' => 'in:active,past|nullable',
             'is_birthdate_approximate' => 'required|in:unknown,approximate,exact',


### PR DESCRIPTION
Facebook's longest names are limited to 50 characters. We'll do the same, which will make sure the UI doesn't break when names are too long.