### PR TITLE
Use the config helper instead of putenv

### DIFF
--- a/tests/Feature/InstanceTest.php
+++ b/tests/Feature/InstanceTest.php
@@ -14,7 +14,7 @@ class InstanceTest extends TestCase
      */
     public function test_disable_signup_set_to_false_shows_signup_button()
     {
-        putenv('APP_DISABLE_SIGNUP=false');
+        config(['monica.disable_signup' => false]);
 
         $response = $this->get('/');
 
@@ -32,11 +32,7 @@ class InstanceTest extends TestCase
      */
     public function test_disable_signup_set_to_true_hides_signup_button_and_register_page()
     {
-        putenv('APP_DISABLE_SIGNUP=true');
-
-        // reload the environment as we've changed the ENV variable
-        $app = require __DIR__.'/../../bootstrap/app.php';
-        $app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
+        config(['monica.disable_signup' => true]);
 
         $response = $this->get('/');
         $response->assertDontSee(

--- a/tests/Feature/VersionCheckTest.php
+++ b/tests/Feature/VersionCheckTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature;
 
-use App\Instance;
 use Tests\FeatureTestCase;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
@@ -18,11 +17,7 @@ class VersionCheckTest extends FeatureTestCase
      */
     public function test_check_version_set_to_false_disables_the_check()
     {
-        putenv('CHECK_VERSION=false');
-
-        // reload the environment as we've changed the ENV variable
-        $app = require __DIR__.'/../../bootstrap/app.php';
-        $app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
+        config(['monica.check_version' => false]);
 
         $resultCommand = $this->artisan('monica:ping');
         $this->assertEquals(0, $resultCommand);

--- a/tests/Unit/AccountTest.php
+++ b/tests/Unit/AccountTest.php
@@ -98,11 +98,7 @@ class AccountTest extends TestCase
             'has_access_to_paid_version_for_free' => false,
         ]);
 
-        putenv('REQUIRES_SUBSCRIPTION=false');
-
-        // reload the environment as we've changed the ENV variable
-        $app = require __DIR__.'/../../bootstrap/app.php';
-        $app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
+        config(['monica.requires_subscription' => false]);
 
         $this->assertEquals(
             false,


### PR DESCRIPTION
We've used putenv() to set environment variables in tests forcing us
to reload the environment. We don't have to if we use the config
helper in Laravel instead.