### PR TITLE
Add/Delete activity types

### DIFF
--- a/app/Console/Commands/ActivitiesClear.php
+++ b/app/Console/Commands/ActivitiesClear.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Support\Facades\DB;
+
+class ActivitiesClear extends MonicaCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'monica:clear-activities {--confirm}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Remove all existing activities and activity groups from your installation';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        // If they added the confirm flag, we assume they know what they're doing
+        if (! $this->option('confirm')) {
+            // Do we really want to do this?
+            if (! $this->confirm('This will delete all contact activities and activity types. Are you sure you want to do this?')) {
+                return;
+            }
+
+            // Give them 10 seconds to think about it
+            $this->countDownFrom(10);
+        }
+
+        // Empty tables
+        DB::table('activities')->delete();
+        DB::table('activity_types')->delete();
+        DB::table('activity_type_groups')->delete();
+
+        $this->info('All activity entries deleted');
+    }
+}

--- a/app/Console/Commands/AddActivity.php
+++ b/app/Console/Commands/AddActivity.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Carbon\Carbon;
+use App\ActivityTypeGroup;
+use InvalidArgumentException;
+use Illuminate\Support\Facades\DB;
+
+class AddActivity extends MonicaCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'monica:add-activity {name} {location_type} {icon} {group}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Add a new activity';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $name = $this->argument('name');
+        $location_type = $this->argument('location_type');
+        $icon = $this->argument('icon');
+        $group = $this->argument('group');
+
+        $groupType = ActivityTypeGroup::where('key', '=', $group)->first();
+
+        if (! $groupType) {
+            throw new InvalidArgumentException("Unknown group type '".$group."'");
+        }
+
+        DB::table('activity_types')->insert([
+            'key' => $name,
+            'location_type' => $location_type,
+            'icon' => $icon,
+            'activity_type_group_id' => $groupType->id,
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ]);
+
+        $this->info("Created activity type '".$name."'");
+    }
+
+    /**
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => 'required',
+            'location_type' => 'required|in:his_place,my_place,outside',
+            'icon' => 'required|in:ate_his_place,ate_home,bar,concert,hang_out,movie_home,museum,picknicked,play,restaurant,sport,talk_home,theater',
+            'group' => 'required',
+        ];
+    }
+}

--- a/app/Console/Commands/AddActivityGroup.php
+++ b/app/Console/Commands/AddActivityGroup.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+
+class AddActivityGroup extends MonicaCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'monica:add-activity-group {name}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Add a new activity group';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $name = $this->argument('name');
+
+        DB::table('activity_type_groups')->insert([
+            'key' => $name,
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ]);
+
+        $this->info("Created activity group '".$name."'");
+    }
+
+    /**
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => 'required',
+        ];
+    }
+}

--- a/app/Console/Commands/MonicaCommand.php
+++ b/app/Console/Commands/MonicaCommand.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Cerbero\CommandValidator\ValidatesInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+abstract class MonicaCommand extends Command
+{
+    use ValidatesInput;
+
+    protected function rules()
+    {
+        // No validation rules by default
+        return [];
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if ($this->validator()->passes()) {
+            return parent::execute($input, $output);
+        }
+        throw new \InvalidArgumentException(implode("\n", $this->validator()->errors()->all()));
+        return $this->error($this->getFormattedErrors());
+    }
+
+    protected function countDownFrom($seconds)
+    {
+        $seconds = 10;
+        $this->line('Deleting all contact activities in '.$seconds.' seconds. THIS CAN NOT BE UNDONE (ctrl+c to cancel)');
+        while ($seconds--) {
+            $this->line(($seconds + 1).'...');
+            sleep(1);
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -14,6 +14,9 @@ class Kernel extends ConsoleKernel
      */
     protected $commands = [
         // Commands\Inspire::class,
+        'App\Console\Commands\AddActivity',
+        'App\Console\Commands\AddActivityGroup',
+        'App\Console\Commands\ActivitiesClear',
         'App\Console\Commands\ResetTestDB',
         'App\Console\Commands\SendNotifications',
         'App\Console\Commands\CalculateStatistics',

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "roave/security-advisories": "dev-master",
         "laravel/dusk": "^1.1",
         "sentry/sentry-laravel": "^0.7.0",
-        "league/flysystem-aws-s3-v3": "~1.0"
+        "league/flysystem-aws-s3-v3": "~1.0",
+        "cerbero/command-validator": "^1.0"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "7e085b766f9c8dad64d874af56a4e6c9",
+    "content-hash": "2e510db40cc364fd739e049ebdfbe7c7",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -134,6 +134,65 @@
                 "webprofiler"
             ],
             "time": "2017-07-21T11:56:48+00:00"
+        },
+        {
+            "name": "cerbero/command-validator",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cerbero90/command-validator.git",
+                "reference": "b8385f7452dcfd44d4455cde1a7670d2f7e32609"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cerbero90/command-validator/zipball/b8385f7452dcfd44d4455cde1a7670d2f7e32609",
+                "reference": "b8385f7452dcfd44d4455cde1a7670d2f7e32609",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~5.5|~7.0"
+            },
+            "require-dev": {
+                "behat/behat": "^3.1",
+                "behat/mink": "^1.7",
+                "behat/mink-extension": "^2.2",
+                "cerbero/behat-laravel-extension": "^1.0",
+                "laravel/framework": "5.2.*",
+                "squizlabs/php_codesniffer": "^2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Cerbero\\CommandValidator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andrea Marco Sartori",
+                    "email": "andrea.marco.sartori@gmail.com",
+                    "homepage": "https://github.com/cerbero90",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Validates Laravel console commands input.",
+            "homepage": "https://github.com/cerbero90/command-validator",
+            "keywords": [
+                "cerbero",
+                "command-validator",
+                "commands",
+                "console",
+                "validation"
+            ],
+            "time": "2016-09-29T04:25:55+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -2506,12 +2565,12 @@
             "version": "2.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/fruux/sabre-uri.git",
+                "url": "https://github.com/sabre-io/uri.git",
                 "reference": "a42126042c7dcb53e2978dadb6d22574d1359b4c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fruux/sabre-uri/zipball/a42126042c7dcb53e2978dadb6d22574d1359b4c",
+                "url": "https://api.github.com/repos/sabre-io/uri/zipball/a42126042c7dcb53e2978dadb6d22574d1359b4c",
                 "reference": "a42126042c7dcb53e2978dadb6d22574d1359b4c",
                 "shasum": ""
             },
@@ -2557,12 +2616,12 @@
             "version": "4.1.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/fruux/sabre-vobject.git",
+                "url": "https://github.com/sabre-io/vobject.git",
                 "reference": "d0fde2fafa2a3dad1f559c2d1c2591d4fd75ae3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fruux/sabre-vobject/zipball/d0fde2fafa2a3dad1f559c2d1c2591d4fd75ae3c",
+                "url": "https://api.github.com/repos/sabre-io/vobject/zipball/d0fde2fafa2a3dad1f559c2d1c2591d4fd75ae3c",
                 "reference": "d0fde2fafa2a3dad1f559c2d1c2591d4fd75ae3c",
                 "shasum": ""
             },
@@ -2654,12 +2713,12 @@
             "version": "2.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/fruux/sabre-xml.git",
+                "url": "https://github.com/sabre-io/xml.git",
                 "reference": "054292959a1f2b64c10c9c7a03a816ba1872b8a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fruux/sabre-xml/zipball/054292959a1f2b64c10c9c7a03a816ba1872b8a3",
+                "url": "https://api.github.com/repos/sabre-io/xml/zipball/054292959a1f2b64c10c9c7a03a816ba1872b8a3",
                 "reference": "054292959a1f2b64c10c9c7a03a816ba1872b8a3",
                 "shasum": ""
             },
@@ -5275,7 +5334,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.0",
+        "php": ">=7.0.0",
         "ext-intl": "*"
     },
     "platform-dev": []

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,8 @@
       * [The API](#the-api)
    * [Why Open Source?](#why-open-source)
    * [Patreon](#patreon)
+* [Advanced Usage](#advanced-usage)
+   * [Activities](#activities)
 * [Contact](#contact)
 * [License](#license)
 
@@ -302,6 +304,64 @@ users will follow.
 
 You can support the development of this tool
 [on Patreon](https://www.patreon.com/monicahq). Thanks for your help.
+
+## Advanced Usage
+
+Whilst testing new features, we may implement them as `artisan` commands instead
+of creating a UI within the application for them. This section will document the
+available advanced features
+
+### Activities
+
+You can change the activities shown in your Monica instance by creating your own
+set of activity groups and activity types. To do this:
+
+First, empty the existing actitivity list (*this will remove all activities from
+your contacts. BE CAREFUL*):
+
+```bash
+php artisan monica:clear-activities
+```
+
+Next, register a new activity group:
+
+```bash
+php artisan monica:add-activity-group "My New Group"
+```
+
+Finally, add an activity type within that group:
+
+```bash
+php artisan monica:add-activity "Did Something" "location_type" "icon" "My New Group"
+```
+
+There are limited options available for `location_type` and `icon` due to existing design constraints:
+
+`location_type`:
+* `his_place`
+* `my_place`
+* `outside`
+
+`icon`:
+* `ate_his_place`
+* `ate_home`
+* `bar`
+* `concert`
+* `hang_out`
+* `movie_home`
+* `museum`
+* `picknicked`
+* `play`
+* `restaurant`
+* `sport`
+* `talk_home`
+* `theater`
+
+The last thing to do is add translations for your new activities. The way
+to do this is create a `resources/lang/<lang>/people.php` file, and add
+some new keys for your new activities. They will be prefixed with either
+`people.activity_type_group_` or `people.activity_type_`. *These will be deleted
+each time you update Monica*
 
 ## Contact
 


### PR DESCRIPTION
This PR allows users to create their own activity groups + activity types and is related to #346.

Instead of creating a whole UI for something that is likely to be infrequently used, I've implemented the functionality as `artisan` commands. There are instructions in `readme.md` how to use it under `Advanced Usage`, and I've recreated here to show how the commands can be used:

### Activities

You can change the activities shown in your Monica instance by creating your own
set of activity groups and activity types. To do this:

First, empty the existing actitivity list (*this will remove all activities from
your contacts. BE CAREFUL*):

```bash
php artisan monica:clear-activities
```

Next, register a new activity group:

```bash
php artisan monica:add-activity-group "My New Group"
```

Finally, add an activity type within that group:

```bash
php artisan monica:add-activity "Did Something" "location_type" "icon" "My New Group"
```

There are limited options available for `location_type` and `icon` due to existing design constraints:

`location_type`:
* `his_place`
* `my_place`
* `outside`

`icon`:
* `ate_his_place`
* `ate_home`
* `bar`
* `concert`
* `hang_out`
* `movie_home`
* `museum`
* `picknicked`
* `play`
* `restaurant`
* `sport`
* `talk_home`
* `theater`

The last thing to do is add translations for your new activities. The way
to do this is create a `resources/lang/<lang>/people.php` file, and add
some new keys for your new activities. They will be prefixed with either
`people.activity_type_group_` or `people.activity_type_`. *These will be deleted
each time you update Monica*

### Checklist

- [x] Read the [CONTRIBUTING document](https://github.com/monicahq/monica/blob/master/CONTRIBUTING.md) before submitting your PR.
- [x] If the PR is related to an issue or fix one, don't forget to indicate it.
- [x] Make sure that the change you propose is the smallest possible.
- [x] Screenshots are included if the PR changes the UI.
- [ ] Tests added for this feature/bug.
- [ ] [CHANGELOG](https://github.com/monicahq/monica/blob/master/CHANGELOG) entry added, if necessary, under `UNRELEASED`.
- [x] [CONTRIBUTORS](https://github.com/monicahq/monica/blob/master/CONTRIBUTORS) entry added, if necessary.
- [x] Indicate `[wip]` in the title of the PR it is is not final yet. Remove `[wip]` when ready. Otherwise the PR will be considered complete and rejected if it's not working.
