### PR TITLE
Fix typo related to starred notes

### DIFF
--- a/resources/lang/en/dashboard.php
+++ b/resources/lang/en/dashboard.php
@@ -5,7 +5,7 @@ return [
     'dashboard_blank_description' => 'Monica is the place to organize all the interactions you have with the ones you care about.',
     'dashboard_blank_cta' => 'Add your first contact',
 
-    'notes_title' => 'You don\'t any notes yet.',
+    'notes_title' => 'You don\'t have any starred notes yet.',
     'notes_description' => 'Star a note of one of your contact to list favorite notes here.',
 
     'reminders_title' => 'Upcoming reminders',


### PR DESCRIPTION
Currently if no notes are starred, an incomplete message is shown on the relevant page. This PR fixes that.

### Checklist

- [x] Read the [CONTRIBUTING document](https://github.com/monicahq/monica/blob/master/CONTRIBUTING.md) before submitting your PR.
- [ ] If the PR is related to an issue or fix one, don't forget to indicate it.
- [x] Make sure that the change you propose is the smallest possible.
- [ ] Screenshots are included if the PR changes the UI.
- [ ] Tests added for this feature/bug.
- [ ] [CHANGELOG](https://github.com/monicahq/monica/blob/master/CHANGELOG) entry added, if necessary, under `UNRELEASED`.
- [ ] [CONTRIBUTORS](https://github.com/monicahq/monica/blob/master/CONTRIBUTORS) entry added, if necessary.
- [ ] Indicate `[wip]` in the title of the PR it is is not final yet. Remove `[wip]` when ready. Otherwise the PR will be considered complete and rejected if it's not working.
