### PR TITLE
Fix account deletion

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -40,6 +40,7 @@ class SettingsController extends Controller
         'oauth_personal_access_clients',
         'oauth_refresh_tokens',
         'password_resets',
+        'pet_categories',
         'sessions',
         'statistics',
         'subscriptions',

--- a/resources/views/partials/components/people-upgrade-sidebar.blade.php
+++ b/resources/views/partials/components/people-upgrade-sidebar.blade.php
@@ -1,5 +1,5 @@
 @if (auth()->user()->account->hasLimitations())
-  <div class="">
+  <div class="mb4">
     <img src="/img/people/upgrade_account.png">
     <div class="pa3 br bl bb br2 b--black-10 br--bottom">
       <p class="mb3">{{ trans('people.people_list_account_upgrade_title') }}</p>


### PR DESCRIPTION
```php
Illuminate\Database\QueryException
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'account_id' in 'where clause' (SQL: delete from `pet_categories` where `account_id` = 10177)
```