### PR TITLE
Use strict mode for mysql

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -62,7 +62,7 @@ $db = [
             'charset' => 'utf8',
             'collation' => 'utf8_unicode_ci',
             'prefix' => env('DB_PREFIX', ''),
-            'strict' => false,
+            'strict' => true,
             'engine' => null,
         ],
 
@@ -75,7 +75,7 @@ $db = [
             'charset'   => 'utf8',
             'collation' => 'utf8_unicode_ci',
             'prefix'    => '',
-            'strict'    => false,
+            'strict'    => true,
         ],
 
         'pgsql' => [


### PR DESCRIPTION
Use strict mode in mysql. I suspect a couple of errors that are reported when using postgresql result from the fact that testing doesn't enforce strict rules in the first place.