### PR TITLE
Add check to prevent sending reminder to a contact that does not exist

### DIFF
--- a/app/Console/Commands/SendNotifications.php
+++ b/app/Console/Commands/SendNotifications.php
@@ -49,6 +49,11 @@ class SendNotifications extends Command
                                 ->orderBy('next_expected_date', 'asc')->get();
 
         foreach ($reminders as $reminder) {
+            
+            if (! $reminder->contact) {
+                continue;
+            }
+
             $account = $reminder->contact->account;
             $reminderDate = $reminder->next_expected_date->hour(0)->minute(0)->second(0)->toDateString();
             $sendEmailToUser = false;

--- a/app/Console/Commands/SendNotifications.php
+++ b/app/Console/Commands/SendNotifications.php
@@ -49,7 +49,6 @@ class SendNotifications extends Command
                                 ->orderBy('next_expected_date', 'asc')->get();
 
         foreach ($reminders as $reminder) {
-            
             if (! $reminder->contact) {
                 continue;
             }

--- a/docs/contribute/contribute.md
+++ b/docs/contribute/contribute.md
@@ -167,7 +167,8 @@ Emails are an important part of Monica. Emails are still the most significant me
 For development purposes, you have two choices to test emails:
 
 1. You can use [Mailtrap](https://mailtrap.io/). This is an amazing service that provides a free plan that is plenty enough to test all the emails that are sent.
-1. If you use Homestead to code on your local machine, you can use [mailhog](https://github.com/mailhog/MailHog) that is built-in. To use it, you first need to start mailhog (`sudo service mailhog restart`) inside your Vagrant. Then, head up to [http://localhost:8025](http://localhost:8025) in your local browser to load Mailhog's UI.
+1. You can use [mailhog](https://github.com/mailhog/MailHog) to test locally. On macOS, you can install via Homebrew (`brew install mailhog`). Then, run `mailhog` and point the browser to `http://127.0.0.1:8025` ([more complete instructions](https://github.com/maijs/homebrew-mailhog)).
+1. If you use [Homestead](https://laravel.com/docs/homestead), [mailhog](https://github.com/mailhog/MailHog) is actually built-in. To use it, you first need to start mailhog (`sudo service mailhog restart`) inside your Vagrant. Then, head up to [http://localhost:8025](http://localhost:8025) in your local browser to load Mailhog's UI.
 
 Note: if you want to use mailhog, you need the following settings in your `.env` file:
 


### PR DESCRIPTION
Fix https://github.com/monicahq/monica/issues/771 

The database has currently reminders with no contacts associated. I don't know why, this sucks, but in the meantime, we need to filter out reminders which do not have contacts.