### PR TITLE
Revert Laravel mix to 1.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "hint.css": "^2.3.2",
     "jQuery-Tags-Input": "git://github.com/xoxco/jQuery-Tags-Input.git#v1.3.6",
     "jquery": "^3.2.1",
-    "laravel-mix": "^2.0.0",
+    "laravel-mix": "^1.7.2",
     "list.js": "^1.5.0",
     "lodash": "^4.16.2",
     "marked": "^0.3.9",


### PR DESCRIPTION
Version 2.0.0 does not compile anymore.