### PR TITLE
Sentry config file: test if .git directory is present

### DIFF
--- a/config/sentry.php
+++ b/config/sentry.php
@@ -4,7 +4,7 @@ return [
     'dsn' => env('SENTRY_DSN'),
 
     // capture release as git sha
-    'release' => trim(exec('git log --pretty="%h" -n1 HEAD')),
+    'release' => is_dir(__DIR__.'/../.git') ? trim(exec('git log --pretty="%h" -n1 HEAD')) : null,
 
     // Capture bindings on SQL queries
     'breadcrumbs.sql_bindings' => true,


### PR DESCRIPTION
This fixes #872.
If you run `php artisan config:cache` the command will be run once.