### PR TITLE
Remove env calls

### DIFF
--- a/app/Console/Commands/PingVersionServer.php
+++ b/app/Console/Commands/PingVersionServer.php
@@ -44,7 +44,7 @@ class PingVersionServer extends Command
             return false;
         }
 
-        if (env('APP_ENV') != 'production') {
+        if (! \App::environment('production')) {
             return false;
         }
 

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -11,7 +11,7 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        switch(\App::environment()) {
+        switch (\App::environment()) {
             case 'local':
                 $this->call(ActivityTypesTableSeeder::class);
                 $this->call(CountriesSeederTable::class);

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -11,21 +11,21 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        if (env('APP_ENV') == 'local') {
-            $this->call(ActivityTypesTableSeeder::class);
-            $this->call(CountriesSeederTable::class);
-            $this->call(FakeUserTableSeeder::class);
-        }
-
-        if (env('APP_ENV') == 'testing') {
-            $this->call(ActivityTypesTableSeeder::class);
-            $this->call(CountriesSeederTable::class);
-            $this->call(FakeUserTableSeeder::class);
-        }
-
-        if (env('APP_ENV') == 'production') {
-            $this->call(ActivityTypesTableSeeder::class);
-            $this->call(CountriesSeederTable::class);
+        switch(\App::environment()) {
+            case 'local':
+                $this->call(ActivityTypesTableSeeder::class);
+                $this->call(CountriesSeederTable::class);
+                $this->call(FakeUserTableSeeder::class);
+            break;
+            case 'testing':
+                $this->call(ActivityTypesTableSeeder::class);
+                $this->call(CountriesSeederTable::class);
+                $this->call(FakeUserTableSeeder::class);
+            break;
+            case 'production':
+                $this->call(ActivityTypesTableSeeder::class);
+                $this->call(CountriesSeederTable::class);
+            break;
         }
     }
 }


### PR DESCRIPTION
env() calls should not be run outside config/ or tests/ directories.

Laravel doc specify explitely to use `App::environment()`
https://laravel.com/docs/5.5/configuration#determining-the-current-environment