### PR TITLE
Add ability to sort tasks by completed_at

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 UNRELEASED CHANGES:
 
+* Add ability to sort tasks by completed_at attribute in the API
 * Redirect to registration page if there is no account
 * Improve heroku integration
 * Add bullet points to lists in call log
@@ -140,7 +141,7 @@ v1.0.0 - 2017-11-09
 * Add a button to `Save and add another contact` straight from the Add contact screen
 * Add the ability to indicate how you've met someone
 * Replace former front-end build system by mix (which is the new default with Laravel 5.5)
-* Add a first part of the API
+* Add the first part of the API
 * Fix the access to upgrade account view
 * Add security.txt file
 * Upgrade codebase to Laravel 5.5

--- a/app/Http/Controllers/Api/ApiContactController.php
+++ b/app/Http/Controllers/Api/ApiContactController.php
@@ -25,20 +25,28 @@ class ApiContactController extends ApiController
         if ($request->get('query')) {
             $needle = $request->get('query');
 
-            $contacts = SearchHelper::searchContacts(
-                $needle,
-                $this->getLimitPerPage(),
-                $this->sort.' '.$this->sortDirection
-            );
+            try {
+                $contacts = SearchHelper::searchContacts(
+                    $needle,
+                    $this->getLimitPerPage(),
+                    $this->sort . ' ' . $this->sortDirection
+                );
+            } catch (QueryException $e) {
+                return $this->respondInvalidQuery();
+            }
 
             return ContactResource::collection($contacts)->additional(['meta' => [
                     'query' => $needle,
                 ]]);
         }
 
-        $contacts = auth()->user()->account->contacts()->real()
-                                        ->orderBy($this->sort, $this->sortDirection)
-                                        ->paginate($this->getLimitPerPage());
+        try {
+            $contacts = auth()->user()->account->contacts()->real()
+                            ->orderBy($this->sort, $this->sortDirection)
+                            ->paginate($this->getLimitPerPage());
+        } catch (QueryException $e) {
+            return $this->respondInvalidQuery();
+        }
 
         return ContactResource::collection($contacts);
     }

--- a/app/Http/Controllers/Api/ApiContactController.php
+++ b/app/Http/Controllers/Api/ApiContactController.php
@@ -29,7 +29,7 @@ class ApiContactController extends ApiController
                 $contacts = SearchHelper::searchContacts(
                     $needle,
                     $this->getLimitPerPage(),
-                    $this->sort . ' ' . $this->sortDirection
+                    $this->sort .' '. $this->sortDirection
                 );
             } catch (QueryException $e) {
                 return $this->respondInvalidQuery();

--- a/app/Http/Controllers/Api/ApiContactController.php
+++ b/app/Http/Controllers/Api/ApiContactController.php
@@ -29,7 +29,7 @@ class ApiContactController extends ApiController
                 $contacts = SearchHelper::searchContacts(
                     $needle,
                     $this->getLimitPerPage(),
-                    $this->sort .' '. $this->sortDirection
+                    $this->sort.' '.$this->sortDirection
                 );
             } catch (QueryException $e) {
                 return $this->respondInvalidQuery();

--- a/app/Http/Controllers/Api/ApiController.php
+++ b/app/Http/Controllers/Api/ApiController.php
@@ -170,6 +170,8 @@ class ApiController extends Controller
             'updated_at',
             '-created_at',
             '-updated_at',
+            'completed_at',
+            '-completed_at',
         ];
 
         if (in_array($criteria, $acceptedCriteria)) {
@@ -219,6 +221,17 @@ class ApiController extends Controller
         return $this->setHTTPStatusCode(404)
                     ->setErrorCode(31)
                     ->respondWithError($message);
+    }
+
+    /**
+     * Sends a response invalid query to the request.
+     * @param string $message
+     */
+    public function respondInvalidQuery($message = 'Invalid query')
+    {
+        return $this->setHTTPStatusCode(500)
+            ->setErrorCode(40)
+            ->respondWithError($message);
     }
 
     /**

--- a/app/Http/Controllers/Api/ApiTaskController.php
+++ b/app/Http/Controllers/Api/ApiTaskController.php
@@ -19,8 +19,13 @@ class ApiTaskController extends ApiController
      */
     public function index(Request $request)
     {
-        $tasks = auth()->user()->account->tasks()
-                                ->paginate($this->getLimitPerPage());
+        try {
+            $tasks = auth()->user()->account->tasks()
+                ->orderBy($this->sort, $this->sortDirection)
+                ->paginate($this->getLimitPerPage());
+        } catch (QueryException $e) {
+            return $this->respondInvalidQuery();
+        }
 
         return TaskResource::collection($tasks);
     }

--- a/config/api.php
+++ b/config/api.php
@@ -39,5 +39,6 @@ return [
         '37' => 'Problems parsing JSON',
         '38' => 'Date should be in the future',
         '39' => 'The sorting criteria is invalid',
+        '40' => 'Invalid query',
     ],
 ];


### PR DESCRIPTION
This PR adds the ability to sort tasks by the `completed_at` attribute. This will close https://github.com/monicahq/chandler/issues/127