### PR TITLE
Order lastname and middlename parameters correctly for contact->setName call

### DIFF
--- a/app/Http/Controllers/ContactsController.php
+++ b/app/Http/Controllers/ContactsController.php
@@ -240,7 +240,7 @@ class ContactsController extends Controller
                 ->withErrors($validator);
         }
 
-        if (! $contact->setName($request->input('firstname'), $request->input('lastname'), null)) {
+        if (! $contact->setName($request->input('firstname'), $request->input('lastname'))) {
             return back()
                 ->withInput()
                 ->withErrors('There has been a problem with saving the name.');

--- a/app/Http/Controllers/ContactsController.php
+++ b/app/Http/Controllers/ContactsController.php
@@ -240,7 +240,7 @@ class ContactsController extends Controller
                 ->withErrors($validator);
         }
 
-        if (! $contact->setName($request->input('firstname'), null, $request->input('lastname'))) {
+        if (! $contact->setName($request->input('firstname'), $request->input('lastname'), null)) {
             return back()
                 ->withInput()
                 ->withErrors('There has been a problem with saving the name.');


### PR DESCRIPTION
Hello hello,

I bumped into an issue on master when editing a contact, the order of parameters in ContactsController:243 (firstName, middleName, lastName) is different than in the function being called at Contact:729 (firstName, lastName, middleName = null), which results in an exception.

I have not added a test since the whole PR is literally swapping two parameters; I can add it if required, of course.

### Checklist

#### Before submitting the PR
- [X] Read the [CONTRIBUTING document](https://github.com/monicahq/monica/blob/master/CONTRIBUTING.md) before submitting your PR.
- [X] If the PR is related to an issue or fix one, don't forget to indicate it.
- [X] Make sure that the change you propose is the smallest possible.
- [ ] Screenshots are included if the PR changes the UI.
- [ ] If you change the UI, make sure the user experience is consistent with the current interface.

#### Code-related tasks
- [ ] Tests added for this feature/bug.
- [ ] Impact on the seeders.
- [ ] Impact on the API.

#### If the code changes the SQL schema
- [ ] Impact on account export.
- [ ] Impact on importing data with `vCard` and `.csv` files.
- [ ] Impact on account reset and deletion.

#### Other tasks
- [ ] [CHANGELOG](https://github.com/monicahq/monica/blob/master/CHANGELOG) entry added, if necessary, under `UNRELEASED`.
- [ ] [CONTRIBUTORS](https://github.com/monicahq/monica/blob/master/CONTRIBUTORS) entry added, if necessary.
- [ ] If it's relevant, add the documentation about your feature in the README file.
- [ ] Indicate `[wip]` in the title of the PR it is is not final yet. Remove `[wip]` when ready. Otherwise the PR will be considered complete and rejected if it's not working.
