### PR TITLE
Set journal entry from activities based on when they happened

### DIFF
--- a/app/JournalEntry.php
+++ b/app/JournalEntry.php
@@ -49,6 +49,12 @@ class JournalEntry extends Model
     public function add($resourceToLog)
     {
         $this->account_id = $resourceToLog->account_id;
+        if ($resourceToLog instanceof Activity) {                                                                                           
+            $this->date = $resourceToLog->date_it_happened;                                                                             
+        }                                                                                                                                   
+        else {                                                                                                                              
+            $this->date = \Carbon\Carbon::now();                                                                                                
+        } 
         $this->date = now();
         $this->journalable_id = $resourceToLog->id;
         $this->journalable_type = get_class($resourceToLog);

--- a/app/JournalEntry.php
+++ b/app/JournalEntry.php
@@ -49,13 +49,10 @@ class JournalEntry extends Model
     public function add($resourceToLog)
     {
         $this->account_id = $resourceToLog->account_id;
+        $this->date = now();                                                                                                
         if ($resourceToLog instanceof Activity) {                                                                                           
             $this->date = $resourceToLog->date_it_happened;                                                                             
         }                                                                                                                                   
-        else {                                                                                                                              
-            $this->date = \Carbon\Carbon::now();                                                                                                
-        } 
-        $this->date = now();
         $this->journalable_id = $resourceToLog->id;
         $this->journalable_type = get_class($resourceToLog);
         $this->save();

--- a/tests/Unit/JournalEntryTest.php
+++ b/tests/Unit/JournalEntryTest.php
@@ -24,7 +24,7 @@ class JournalEntryTest extends TestCase
     public function test_get_add_adds_data_of_the_right_type()
     {
         $activity = factory(\App\Activity::class)->create();
-        $date = now();
+        $date = $activity->date_it_happened;
 
         $journalEntry = (new JournalEntry)->add($activity);
 
@@ -39,7 +39,6 @@ class JournalEntryTest extends TestCase
     public function test_get_object_data_returns_an_object()
     {
         $activity = factory(\App\Activity::class)->create();
-        $date = now();
 
         $journalEntry = (new JournalEntry)->add($activity);
 


### PR DESCRIPTION
As per #982, the journal entries should be order by when the activities happened, not when they were added.  

This is my first contribution to Monica and my first time working with PHP in a long time, so there might be better ways to do this and I'm open to suggestions. 

### Checklist

#### Before submitting the PR
- [x] Read the [CONTRIBUTING document](https://github.com/monicahq/monica/blob/master/CONTRIBUTING.md) before submitting your PR.
- [x] If the PR is related to an issue or fix one, don't forget to indicate it.
- [x] Make sure that the change you propose is the smallest possible.
- [ ] Screenshots are included if the PR changes the UI.
- [ ] If you change the UI, make sure the user experience is consistent with the current interface.

#### Code-related tasks
- [x] Tests added for this feature/bug.
- [ ] Impact on the seeders.
- [ ] Impact on the API.

#### If the code changes the SQL schema
- [ ] Impact on account export.
- [ ] Impact on importing data with `vCard` and `.csv` files.
- [ ] Impact on account reset and deletion.

#### Other tasks
- [x] [CHANGELOG](https://github.com/monicahq/monica/blob/master/CHANGELOG) entry added, if necessary, under `UNRELEASED`.
- [x] [CONTRIBUTORS](https://github.com/monicahq/monica/blob/master/CONTRIBUTORS) entry added, if necessary.
- [ ] If it's relevant, add the documentation about your feature in the README file.
- [ ] Indicate `[wip]` in the title of the PR it is is not final yet. Remove `[wip]` when ready. Otherwise the PR will be considered complete and rejected if it's not working.
