### PR TITLE
Fix contact deletion

### DIFF
--- a/app/Contact.php
+++ b/app/Contact.php
@@ -1244,6 +1244,8 @@ class Contact extends Model
             }
         }
 
+        $this->delete();
+
         return true;
     }
 

--- a/tests/Unit/ContactTest.php
+++ b/tests/Unit/ContactTest.php
@@ -1134,6 +1134,5 @@ class ContactTest extends FeatureTestCase
         $contact->deleteEverything();
 
         $this->assertEquals(0, Contact::where('id', $id)->count());
-        
     }
 }

--- a/tests/Unit/ContactTest.php
+++ b/tests/Unit/ContactTest.php
@@ -1121,4 +1121,19 @@ class ContactTest extends FeatureTestCase
             $foundContact->id
         );
     }
+
+    public function test_contact_deletion()
+    {
+        $account = factory('App\Account')->create([]);
+        $contact = factory(Contact::class)->create(['account_id' => $account->id]);
+        $contact->save();
+        $id = $contact->id;
+
+        $this->assertEquals(1, Contact::where('id', $id)->count());
+
+        $contact->deleteEverything();
+
+        $this->assertEquals(0, Contact::where('id', $id)->count());
+        
+    }
 }


### PR DESCRIPTION
Introduced with #971 : this line was missed in the new Contact::deleteEverything function:
https://github.com/monicahq/monica/pull/971/files#diff-da2c468a7e44d4976ad8308dbe22e7faL340