### PR TITLE
Remove config:cache in the Update command

### DIFF
--- a/app/Console/Commands/Update.php
+++ b/app/Console/Commands/Update.php
@@ -61,7 +61,6 @@ class Update extends Command
                 // Clear or rebuild all cache
                 $this->commandExecutor->artisan('✓ Resetting application cache', 'cache:clear');
                 if ($this->getLaravel()->environment() == 'production') {
-                    $this->commandExecutor->artisan('✓ Resetting config cache', 'config:cache');
                     $this->commandExecutor->artisan('✓ Resetting route cache', 'route:cache');
                     if ($this->getLaravel()->version() > '5.6') {
                         $this->commandExecutor->artisan('✓ Resetting view cache', 'view:cache');


### PR DESCRIPTION
@asbiin I have to remove the config:cache command from your script.

I don't know why, but this option breaks the production environment on Linode. I have to find out why, but in the meantime, if  I want to deploy, I need to remove it.