### PR TITLE
Make select-date component works with SpecialDate object as an Carbon instance

### DIFF
--- a/resources/views/partials/components/date-select.blade.php
+++ b/resources/views/partials/components/date-select.blade.php
@@ -5,7 +5,11 @@
   <select id="{{ $class }}_month" name="{{ $class }}_month" class="{{ \App\Helpers\LocaleHelper::getDirection() == 'ltr' ? 'mr2' : '' }}">
     @foreach($months as $month)
       <option value="{{ $month['id'] }}"
-        {{ ($specialDate == null) ? '' : (($specialDate->date->month == $month['id']) ? 'selected="selected"': '') }}
+        @if ($specialDate && $specialDate instanceof Carbon\Carbon)
+          {{ ($specialDate->month == $month['id']) ? 'selected="selected"': '' }}
+        @else
+          {{ ($specialDate == null) ? '' : (($specialDate->date->month == $month['id']) ? 'selected="selected"': '') }}
+        @endif
       >
         {{ $month['name'] }}
       </option>
@@ -14,33 +18,35 @@
 
   <select id="{{ $class }}_day" name="{{ $class }}_day" class="mr2">
     @for ($day=1 ; $day < 32 ; $day++)
-    <option value="{{ $day }}"
-      {{ ($specialDate == null) ? '' : (($specialDate->date->day == $day) ? 'selected="selected"': '') }}
-    >
-      {{ $day }}
-    </option>
+      <option value="{{ $day }}"
+        @if ($specialDate && $specialDate instanceof Carbon\Carbon)
+          {{ $specialDate->day == $day ? 'selected="selected"': '' }}
+        @else
+          {{ ($specialDate == null) ? '' : (($specialDate->date->day == $day) ? 'selected="selected"': '') }}
+        @endif
+      >
+        {{ $day }}
+      </option>
     @endfor
   </select>
 
     <select id="{{ $class }}_year" name="{{ $class }}_year" class="{{ \App\Helpers\LocaleHelper::getDirection() == 'ltr' ? '' : 'mr2' }}">
-
-      @if ($specialDate)
+      @if ($specialDate && $specialDate instanceof APP\SpecialDate)
         <option value="0" {{ ! $specialDate->is_year_unknown ? '' : 'selected="selected"' }}>{{ trans('app.unknown') }}</option>
       @else
         <option value="0">{{ trans('app.unknown') }}</option>
       @endif
 
       @foreach($years as $year => $value)
-        @if ($specialDate)
-          <option value="{{ $value }}" {{ $specialDate->is_year_unknown ? '' : (($specialDate->date->year == $value) ? 'selected="selected"': '') }}>
-            {{ $value }}
-          </option>
-        @else
-          <option value="{{ $value }}" >
-            {{ $value }}
-          </option>
-        @endif
+        <option value="{{ $value }}"
+          @if ($specialDate && $specialDate instanceof Carbon\Carbon)
+            {{ $specialDate->year == $value ? 'selected="selected"': '' }}
+          @else
+            {{ ($specialDate == null) ? '' : ($specialDate->is_year_unknown ? '' : (($specialDate->date->year == $value) ? 'selected="selected"': '')) }}
+          @endif
+        >
+          {{ $value }}
+        </option>
       @endforeach
     </select>
-
 </div>

--- a/resources/views/people/dashboard/introductions/edit.blade.php
+++ b/resources/views/people/dashboard/introductions/edit.blade.php
@@ -86,7 +86,7 @@
                       >
 
                       {{ trans('people.introductions_first_met_date_known') }}
-                      @include('partials.components.date-select', ['contact' => $contact, 'specialDate' => $contact->firstMetDate, 'class' => 'first_met'])
+                      @include('partials.components.date-select', ['contact' => $contact, 'specialDate' => $contact->firstMetDate ?? Carbon\Carbon::now(), 'class' => 'first_met'])
                     </label>
                   </div>
                 </fieldset>


### PR DESCRIPTION
Fixes #1058

The original  `select-date` component only accept default date as a `SpecialDate` model object, I update it to accept `Carbon` as well, and give a default value to `how I meet X ` date picker

![image](https://user-images.githubusercontent.com/15082118/39479009-979bd5f6-4d96-11e8-9cdc-bd06b3f95c58.png)