### PR TITLE
WIP: Standardise phonenumber format while importing vCard

### DIFF
--- a/app/ImportJob.php
+++ b/app/ImportJob.php
@@ -526,10 +526,29 @@ class ImportJob extends Model
     public function importTel(\App\Contact $contact): void
     {
         if (! is_null($this->formatValue($this->currentEntry->TEL))) {
+            $tel =  (string) $this->currentEntry->TEL;
+
+            $country = \App\Country::where('country', $this->currentEntry->ADR->getParts()[6])
+                ->orwhere('country', ucwords($this->currentEntry->ADR->getParts()[6]))
+                ->orWhere('iso', mb_strtolower($this->currentEntry->ADR->getParts()[6]))
+                ->first();
+
+            if ($country) {
+                try {
+                    $phoneUtil = \libphonenumber\PhoneNumberUtil::getInstance();
+
+                    $phoneInstance = $phoneUtil->parse($tel, strtoupper($country->iso));
+                    // International phone number format eg : +41 44 201 19 20
+                    $tel = $phoneUtil->format($phoneInstance, \libphonenumber\PhoneNumberFormat::INTERNATIONAL);
+                } catch (\libphonenumber\NumberParseException $e) {
+                    // Do nothing if the number cannot be parsed successfully
+                }
+            }
+
             $contactField = new \App\ContactField;
             $contactField->contact_id = $contact->id;
             $contactField->account_id = $contact->account_id;
-            $contactField->data = $this->formatValue($this->currentEntry->TEL);
+            $contactField->data = $this->formatValue($tel);
             $contactField->contact_field_type_id = $this->contactFieldPhoneId();
             $contactField->save();
         }

--- a/app/ImportJob.php
+++ b/app/ImportJob.php
@@ -528,20 +528,22 @@ class ImportJob extends Model
         if (! is_null($this->formatValue($this->currentEntry->TEL))) {
             $tel =  (string) $this->currentEntry->TEL;
 
-            $country = \App\Country::where('country', $this->currentEntry->ADR->getParts()[6])
-                ->orwhere('country', ucwords($this->currentEntry->ADR->getParts()[6]))
-                ->orWhere('iso', mb_strtolower($this->currentEntry->ADR->getParts()[6]))
-                ->first();
+            if (! is_null($this->formatValue($this->currentEntry->ADR))) {
+                $country = \App\Country::where('country', $this->currentEntry->ADR->getParts()[6])
+                    ->orwhere('country', ucwords($this->currentEntry->ADR->getParts()[6]))
+                    ->orWhere('iso', mb_strtolower($this->currentEntry->ADR->getParts()[6]))
+                    ->first();
 
-            if ($country) {
-                try {
-                    $phoneUtil = \libphonenumber\PhoneNumberUtil::getInstance();
+                if ($country) {
+                    try {
+                        $phoneUtil = \libphonenumber\PhoneNumberUtil::getInstance();
 
-                    $phoneInstance = $phoneUtil->parse($tel, strtoupper($country->iso));
-                    // International phone number format eg : +41 44 201 19 20
-                    $tel = $phoneUtil->format($phoneInstance, \libphonenumber\PhoneNumberFormat::INTERNATIONAL);
-                } catch (\libphonenumber\NumberParseException $e) {
-                    // Do nothing if the number cannot be parsed successfully
+                        $phoneInstance = $phoneUtil->parse($tel, strtoupper($country->iso));
+                        // International phone number format eg : +41 44 201 19 20
+                        $tel = $phoneUtil->format($phoneInstance, \libphonenumber\PhoneNumberFormat::INTERNATIONAL);
+                    } catch (\libphonenumber\NumberParseException $e) {
+                        // Do nothing if the number cannot be parsed successfully
+                    }
                 }
             }
 

--- a/app/Traits/VCardImporter.php
+++ b/app/Traits/VCardImporter.php
@@ -98,6 +98,8 @@ trait VCardImporter
             $specialDate->setReminder('year', 1, trans('people.people_add_birthday_reminder', ['name' => $contact->first_name]));
         }
 
+        $country = null;
+
         if ($vcard->ADR) {
             $address = new Address();
             $address->street = $this->formatValue($vcard->ADR->getParts()[2]);
@@ -106,6 +108,7 @@ trait VCardImporter
             $address->postal_code = $this->formatValue($vcard->ADR->getParts()[5]);
 
             $country = Country::where('country', $vcard->ADR->getParts()[6])
+                ->orwhere('country', ucwords($this->currentEntry->ADR->getParts()[6]))
                 ->orWhere('iso', mb_strtolower($vcard->ADR->getParts()[6]))
                 ->first();
 
@@ -134,11 +137,26 @@ trait VCardImporter
         }
 
         if (! is_null($this->formatValue($vcard->TEL))) {
+            $tel = (string) $vcard->TEL;
+
+            if ($country) {
+                try {
+                    $phoneUtil = \libphonenumber\PhoneNumberUtil::getInstance();
+
+                    $phoneInstance = $phoneUtil->parse($tel, strtoupper($country->iso));
+
+                    // International phone number format eg : +41 44 201 19 20
+                    $tel = $phoneUtil->format($phoneInstance, \libphonenumber\PhoneNumberFormat::INTERNATIONAL);
+                } catch (\libphonenumber\NumberParseException $e) {
+                    // Do nothing if the number cannot be parsed successfully
+                }
+            }
+
             // Saves the phone number
             $contactField = new ContactField;
             $contactField->contact_id = $contact->id;
             $contactField->account_id = $contact->account_id;
-            $contactField->data = $this->formatValue($vcard->TEL);
+            $contactField->data = $this->formatValue($tel);
             $contactField->contact_field_type_id = $this->contactFieldPhoneId();
             $contactField->save();
         }

--- a/app/Traits/VCardImporter.php
+++ b/app/Traits/VCardImporter.php
@@ -108,7 +108,7 @@ trait VCardImporter
             $address->postal_code = $this->formatValue($vcard->ADR->getParts()[5]);
 
             $country = Country::where('country', $vcard->ADR->getParts()[6])
-                ->orwhere('country', ucwords($this->currentEntry->ADR->getParts()[6]))
+                ->orwhere('country', ucwords($vcard->ADR->getParts()[6]))
                 ->orWhere('iso', mb_strtolower($vcard->ADR->getParts()[6]))
                 ->first();
 

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "doctrine/dbal": "^2.5",
         "erusev/parsedown": "~1.7",
         "fideloper/proxy": "^4.0",
+        "giggsey/libphonenumber-for-php": "^8.9",
         "guzzlehttp/guzzle": "^6.2",
         "intervention/image": "^2.3",
         "ircop/antiflood": "^0.1.4",


### PR DESCRIPTION
Fixes #981 

Enhaced by https://github.com/giggsey/libphonenumber-for-php, while importing vCard check and format the phone number as international phone number format `eg +44 117 496 0123` if the country of the contact can be recognized, the format of the number is open for discussion.

Since we need the `country` to tell which format the number should be, I left the phone number input field of contact (On `CONTACT INFORMATION` area) untouched because we have no `country` field for phone number, and it's awkward to add it.

![image](https://user-images.githubusercontent.com/15082118/39664458-0a38deb6-50b6-11e8-9722-bbdf35d8a32c.png)