### PR TITLE
Notifications should not be sent if reminder rule is set to off

### DIFF
--- a/app/Console/Commands/SendNotifications.php
+++ b/app/Console/Commands/SendNotifications.php
@@ -29,7 +29,7 @@ class SendNotifications extends Command
      */
     public function handle()
     {
-        // we had two days to make sure we cover all timezones
+        // we add two days to make sure we cover all timezones
         $notifications = Notification::where('trigger_date', '<', now()->addDays(2))
                                 ->orderBy('trigger_date', 'asc')->get();
 

--- a/app/Http/Controllers/Settings/ReminderRulesController.php
+++ b/app/Http/Controllers/Settings/ReminderRulesController.php
@@ -30,9 +30,7 @@ class ReminderRulesController extends Controller
 
     public function toggle(Request $request, ReminderRule $reminderRule)
     {
-        $reminderRule->active = ! $reminderRule->active;
-        $reminderRule->save();
-
+        $reminderRule->toggle();
         return trans('settings.personalization_reminder_rule_save');
     }
 }

--- a/app/Jobs/Notification/SendNotificationEmail.php
+++ b/app/Jobs/Notification/SendNotificationEmail.php
@@ -36,7 +36,11 @@ class SendNotificationEmail implements ShouldQueue
      */
     public function handle()
     {
-        Mail::to($this->user->email)->send(new NotificationEmail($this->notification, $this->user));
+        // send notification only if the reminder rule is ON
+        if ($this->notification->shouldBeSent()) {
+            Mail::to($this->user->email)->send(new NotificationEmail($this->notification, $this->user));
+        }
+
         $this->notification->incrementNumberOfEmailsSentAndCheckDeletioNStatus();
     }
 }

--- a/app/Notification.php
+++ b/app/Notification.php
@@ -91,4 +91,23 @@ class Notification extends Model
             $this->delete();
         }
     }
+
+    /**
+     * Indicate whether a notification should be sent, as this should be
+     * dictated by the reminder rule (on or off).
+     *
+     * @return boolean
+     */
+    public function shouldBeSent()
+    {
+        $reminderRule = $this->account->reminderRules()
+                            ->where('number_of_days_before', $this->scheduled_number_days_before)
+                            ->first();
+
+        if (! $reminderRule) {
+            return false;
+        }
+
+        return $reminderRule->active;
+    }
 }

--- a/app/ReminderRule.php
+++ b/app/ReminderRule.php
@@ -55,4 +55,15 @@ class ReminderRule extends Model
     {
         $this->attributes['number_of_days_before'] = $value;
     }
+
+    /**
+     * Toggle the active status.
+     *
+     * @return void
+     */
+    public function toggle(): void
+    {
+        $this->active = ! $this->active;
+        $this->save();
+    }
 }

--- a/database/migrations/2018_05_06_194710_delete_reminder_sent_table.php
+++ b/database/migrations/2018_05_06_194710_delete_reminder_sent_table.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class DeleteReminderSentTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::dropIfExists('reminders_sent');
+    }
+}

--- a/tests/Unit/Jobs/SendNotificationEmailTest.php
+++ b/tests/Unit/Jobs/SendNotificationEmailTest.php
@@ -32,16 +32,68 @@ class SendNotificationEmailTest extends TestCase
             'contact_id' => $contact->id,
             'next_expected_date' => '2017-01-01',
         ]);
+        $reminderRule = factory('App\ReminderRule')->create([
+            'account_id' => $account->id,
+            'number_of_days_before' => 7,
+            'active' => true,
+        ]);
         $notification = factory('App\Notification')->create([
             'account_id' => $account->id,
             'contact_id' => $contact->id,
             'reminder_id' => $reminder->id,
             'delete_after_number_of_emails_sent' => 1,
+            'scheduled_number_days_before' => 7,
         ]);
 
         dispatch(new SendNotificationEmail($notification, $user));
 
         Mail::assertSent(NotificationEmail::class, function ($mail) {
+            return $mail->hasTo('john@doe.com');
+        });
+
+        $this->assertDatabaseMissing('notifications', [
+            'id' => $notification->id,
+        ]);
+    }
+
+    /**
+     * It doesn't send the reminder if reminder rule is set to off
+     */
+    public function test_it_doesnt_send_a_notification()
+    {
+        Mail::fake();
+
+        Carbon::setTestNow(Carbon::create(2017, 1, 1, 7, 0, 0));
+
+        $account = factory('App\Account')->create([
+            'default_time_reminder_is_sent' => '07:00',
+        ]);
+        $contact = factory('App\Contact')->create(['account_id' => $account->id]);
+        $user = factory('App\User')->create([
+            'account_id' => $account->id,
+            'email' => 'john@doe.com',
+        ]);
+        $reminder = factory('App\Reminder')->create([
+            'account_id' => $account->id,
+            'contact_id' => $contact->id,
+            'next_expected_date' => '2017-01-01',
+        ]);
+        $reminderRule = factory('App\ReminderRule')->create([
+            'account_id' => $account->id,
+            'number_of_days_before' => 7,
+            'active' => false,
+        ]);
+        $notification = factory('App\Notification')->create([
+            'account_id' => $account->id,
+            'contact_id' => $contact->id,
+            'reminder_id' => $reminder->id,
+            'delete_after_number_of_emails_sent' => 1,
+            'scheduled_number_days_before' => 7,
+        ]);
+
+        dispatch(new SendNotificationEmail($notification, $user));
+
+        Mail::assertNotSent(NotificationEmail::class, function ($mail) {
             return $mail->hasTo('john@doe.com');
         });
 

--- a/tests/Unit/NotificationTest.php
+++ b/tests/Unit/NotificationTest.php
@@ -74,4 +74,35 @@ class NotificationTest extends TestCase
             'id' => $notification->id,
         ]);
     }
+
+    public function test_it_indicates_if_a_notification_should_be_sent()
+    {
+        $account = factory('App\Account')->create([]);
+        $notification = factory('App\Notification')->create([
+            'account_id' => $account->id,
+            'scheduled_number_days_before' => 7,
+        ]);
+        $reminderRule = factory('App\ReminderRule')->create([
+            'account_id' => $account->id,
+            'number_of_days_before' => 8,
+            'active' => true,
+        ]);
+        $this->assertFalse($notification->shouldBeSent());
+        $reminderRule->delete();
+
+        $reminderRule = factory('App\ReminderRule')->create([
+            'account_id' => $account->id,
+            'number_of_days_before' => 7,
+            'active' => true,
+        ]);
+        $this->assertTrue($notification->shouldBeSent());
+        $reminderRule->delete();
+
+        $reminderRule = factory('App\ReminderRule')->create([
+            'account_id' => $account->id,
+            'number_of_days_before' => 7,
+            'active' => false,
+        ]);
+        $this->assertFalse($notification->shouldBeSent());
+    }
 }

--- a/tests/Unit/ReminderRuleTest.php
+++ b/tests/Unit/ReminderRuleTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Unit;
 
-use App\Account;
 use Tests\TestCase;
+use App\ReminderRule;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class ReminderRuleTest extends TestCase
@@ -30,12 +30,29 @@ class ReminderRuleTest extends TestCase
 
     public function test_it_sets_number_of_days_before_attribute()
     {
-        $reminderRule = new Account;
+        $reminderRule = new ReminderRule;
         $reminderRule->number_of_days_before = '14';
 
         $this->assertEquals(
             14,
             $reminderRule->number_of_days_before
+        );
+    }
+
+    public function test_it_toggles_the_status()
+    {
+        $reminderRule = new ReminderRule;
+        $reminderRule->active = true;
+        $reminderRule->save();
+
+        $reminderRule->toggle();
+        $this->assertFalse(
+            $reminderRule->active
+        );
+
+        $reminderRule->toggle();
+        $this->assertTrue(
+            $reminderRule->active
         );
     }
 }


### PR DESCRIPTION
This fixes a bug.

The bug is:

* reminder rules are set to ON (either the 7 or 30 days),
* you create a reminder, the system creates notifications (ie the emails that should be send 7 and 30 days in advance the event will happen),
* before the notifications are sent, set reminder rules to OFF (either the 7 or 30 days),
* currently, the notifications will still be sent (despite being to OFF), as they have been scheduled in the past

So, basically, I've changed it so that if reminder rules are disabled, notifications are not sent.