### PR TITLE
Fixes #1209 Add journal entry with date != today does not work

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ UNRELEASED CHANGES:
 
 * Remove automatic birthday reminder creation when editing a contact
 * Use external list of countries, with translations and reliability
+* Fixes 1209 Add journal entry with date != today does not work
 
 RELEASED VERSIONS:
 

--- a/app/JournalEntry.php
+++ b/app/JournalEntry.php
@@ -53,6 +53,9 @@ class JournalEntry extends Model
         if ($resourceToLog instanceof Activity) {
             $this->date = $resourceToLog->date_it_happened;
         }
+        if ($resourceToLog instanceof Entry) {
+            $this->date = $resourceToLog->date;
+        }
         $this->journalable_id = $resourceToLog->id;
         $this->journalable_type = get_class($resourceToLog);
         $this->save();


### PR DESCRIPTION
This fixes #1209 by getting that date when the Journal entry is an instance of Entry 
