### PR TITLE
Fixes #1338 Contact tags duplicate when filtering contacts. [Needs Review]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ UNRELEASED CHANGES:
 * Fixes Contact search dropdown shows non-contacts that link to nowhere
 * Add ability to sort contact list by untagged contacts
 * Allow multiple imported fields and replace existing contacts
+* Fixes #1338 Contact tags duplicate when filtering contacts
 
 RELEASED VERSIONS:
 

--- a/app/Http/Controllers/ContactsController.php
+++ b/app/Http/Controllers/ContactsController.php
@@ -49,7 +49,9 @@ class ContactsController extends Controller
                             ->where('account_id', auth()->user()->account_id)
                             ->get();
 
-                $tags = $tags->concat($tag);
+                if(!($tags->contains($tag[0]))) {
+                    $tags = $tags->concat($tag);
+                }
 
                 $url = $url.'tag'.$count.'='.$tag[0]->name_slug.'&';
 

--- a/app/Http/Controllers/ContactsController.php
+++ b/app/Http/Controllers/ContactsController.php
@@ -49,7 +49,7 @@ class ContactsController extends Controller
                             ->where('account_id', auth()->user()->account_id)
                             ->get();
 
-                if(!($tags->contains($tag[0]))) {
+                if (! ($tags->contains($tag[0]))) {
                     $tags = $tags->concat($tag);
                 }
 


### PR DESCRIPTION
This fixes #1338 by checking if we already have used that tag, unfortunately the duplicate tags need to stay in the URL unless we want to add more logic to the index method but I believe having a less than pretty URL is better then having a more complicated method. 

@djaiss When ever got get a chance to review. 