### PR TITLE
Typehead

### DIFF
--- a/app/Http/Controllers/Contacts/RelationshipsController.php
+++ b/app/Http/Controllers/Contacts/RelationshipsController.php
@@ -18,25 +18,10 @@ class RelationshipsController extends Controller
      */
     public function new(Request $request, Contact $contact)
     {
-        // getting the list of existing contacts
-        $existingContacts = auth()->user()->account->contacts()
-                                        ->real()
-                                        ->select(['id', 'first_name', 'last_name'])
-                                        ->sortedBy('name')
-                                        ->get();
-
-        // Building the list of contacts specifically for the dropdown which asks
-        // for an id and a name. Also filter out the current contact.
-        $arrayContacts = collect();
-        foreach ($existingContacts as $existingContact) {
-            if ($existingContact->id == $contact->id) {
-                continue;
-            }
-            $arrayContacts->push([
-                'id' => $existingContact->id,
-                'name' => $existingContact->getCompleteName(),
-            ]);
-        }
+        // getting the amount of existing contacts
+        $existingContactCount = auth()->user()->account->contacts()
+            ->real()
+            ->count();
 
         // Building the list of relationship types specifically for the dropdown which asks
         // for an id and a name.
@@ -56,7 +41,7 @@ class RelationshipsController extends Controller
             ->withDays(\App\Helpers\DateHelper::getListOfDays())
             ->withMonths(\App\Helpers\DateHelper::getListOfMonths())
             ->withBirthdate(now()->format('Y-m-d'))
-            ->withExistingContacts($arrayContacts)
+            ->withExistingContactCount($existingContactCount)
             ->withType($request->get('type'));
     }
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "tachyons": "^4.9.1",
     "typeahead.js": "^0.11.1",
     "vue": "^2.5.16",
+    "vue2-bootstrap4-typeahead": "^1.0.3",
     "vue-checkbox-radio": "^0.6.0",
     "vue-directive-tooltip": "^1.4.2",
     "vue-i18n": "^7.6.0",

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -34,6 +34,12 @@ Vue.use(ToggleButton);
 import PrettyCheckbox from 'pretty-checkbox-vue';
 Vue.use(PrettyCheckbox);
 
+// Autocompletes / TypeAHead
+Vue.component(
+    'add-exist-relationship-typeahead',
+    require('./components/autocomplete/AddExistRelationship.vue')
+);
+
 // Custom components
 Vue.component(
     'passport-clients',

--- a/resources/assets/js/components/autocomplete/AddExistRelationship.vue
+++ b/resources/assets/js/components/autocomplete/AddExistRelationship.vue
@@ -1,0 +1,125 @@
+<template>
+    <div>
+        <p class="mb2" v-bind:class="{ b: required }" v-if="title">{{ title }}</p>
+        <input type="hidden" :name="name" :value="contactIdSelected"/>
+        <TypeAhead
+                v-model="data"
+                src="/people/search"
+                :getResponse="getResponse"
+                :onHit="onHit"
+                :highlighting="highlighting"
+                :render="onRender"
+                :fetch="fetch"
+        ></TypeAhead>
+    </div>
+</template>
+
+<script>
+    import TypeAhead from 'vue2-bootstrap4-typeahead'
+    import axios from 'axios'
+    export default {
+        name: 'add-exist-relationship-typeahead',
+        props: {
+            name: {
+                type: String,
+            },
+            title: {
+                type: String,
+            },
+            required: {
+                type: Boolean,
+            }
+        },
+        data () {
+            return {
+                msg: 'Add relationship from exist',
+                data: '',
+                showConfig: false,
+                selectFirst: false,
+                limit: 20,
+                queryParamName: ':keyword',
+                minChars: 2,
+                delayTime: 500,
+                classes: 'typeahead',
+                contactIdSelected : '',
+                userContactId : ''
+            }
+        },
+        methods: {
+            getResponse: function (response) {
+                let data = [];
+                let that = this;
+                if (response.data.data) {
+                    response.data.data.forEach(function (contact) {
+                        // Exclude myself
+                        if (contact.hash === that.userContactId) {
+                            return;
+                        }
+
+                        let middleName = contact.middle_name || '';
+                        let lastName = contact.last_name || '';
+                        contact.name = contact.first_name + (middleName ? ' ' + middleName : '') + (lastName ? ' ' + lastName : '');
+                        data.push(contact);
+                    });
+                }
+
+                return data;
+            },
+            onHit: function (item, vue, index) {
+                vue.query = vue.data[index].name;
+                this.contactIdSelected = vue.data[index].id;
+            },
+            highlighting: function (item, vue) {
+                let escapes = vue.query.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+                let regExp = new RegExp(escapes, 'ig');
+                return item.toString().replace(regExp, `<b>${vue.query}</b>`);
+            },
+            onRender: function (items, vue) {
+                let results = this.prepareResult(items);
+                results = this.prepareHTML(results);
+                return results;
+            },
+            prepareHTML: function(persons) {
+                let html = [];
+
+                persons.forEach(function(person) {
+                    html.push(`<li>${person.name}</li>`);
+                });
+
+                return html;
+            },
+            prepareResult: function(items) {
+                return items;
+            },
+            fetch: function (url) {
+                return axios.post(url, {
+                    needle: this.data,
+                    accountId: $('body').attr("data-account-id")
+                },{
+                    headers: {
+                        'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+                    }
+                });
+            }
+        },
+        components: {
+            TypeAhead
+        }
+    }
+</script>
+
+<style>
+    .typeahead {
+        margin: 0 auto;
+        width: 50%;
+        height: 22px;
+    }
+
+    .dropdown-menu-list {
+        position : relative!important;
+    }
+
+    .dropdown-item {
+        text-decoration: none!important;
+    }
+</style>

--- a/resources/lang/en/people.php
+++ b/resources/lang/en/people.php
@@ -168,7 +168,7 @@ return [
     'relationship_form_add_choice' => 'Who is the relationship with?',
     'relationship_form_create_contact' => 'Add a new person',
     'relationship_form_associate_contact' => 'An existing contact',
-    'relationship_form_associate_dropdown' => 'Select an existing contact from the dropdown below',
+    'relationship_form_associate_dropdown' => 'Search and select an existing contact from the dropdown below',
     'relationship_form_also_create_contact' => 'Create a Contact entry for this person.',
     'relationship_form_add_description' => 'This will let you treat this significant other like any other contact.',
     'relationship_form_add_no_existing_contact' => 'You don’t have any contacts who can be related to :name at the moment.',

--- a/resources/views/people/relationship/new.blade.php
+++ b/resources/views/people/relationship/new.blade.php
@@ -124,18 +124,18 @@
 
       <div v-if="!global_relationship_form_new_contact">
         <div class="pa4-ns ph3 pv2 mb3 mb0-ns bb b--gray-monica">
-          @if ($existingContacts->count() == 0)
+          @if ($existingContactCount == 0)
             <div class="mb1 mt2 tc">
               <img src="/img/people/no_record_found.svg">
               <p>{{ trans('people.relationship_form_add_no_existing_contact', ['name' => $contact->first_name]) }}</p>
             </div>
           @else
-            <form-select
-              :options="{{ $existingContacts }}"
+            <add-exist-relationship-typeahead
               v-bind:required="true"
               v-bind:title="'{{ trans('people.relationship_form_associate_dropdown') }}'"
-              v-bind:id="'existing_contact_id'">
-            </form-select>
+              v-bind:name="'existing_contact_id'"
+              v-bind:user-contact-id="'{{ $contact->hashID() }}'">
+            </add-exist-relationship-typeahead>
           @endif
         </div>
       </div>
@@ -158,7 +158,7 @@
             <a href="/people/{{ $contact->hashID() }}" class="btn btn-secondary w-auto-ns w-100 mb2 pb0-ns">{{ trans('app.cancel') }}</a>
           </div>
           <div class="">
-            @if ($existingContacts->count() == 0)
+            @if ($existingContactCount == 0)
             <button class="btn btn-primary w-auto-ns w-100 mb2 pb0-ns" disabled v-if="!global_relationship_form_new_contact" name="save" type="submit">{{ trans('app.add') }}</button>
             <button class="btn btn-primary w-auto-ns w-100 mb2 pb0-ns" v-if="global_relationship_form_new_contact" name="save" type="submit">{{ trans('app.add') }}</button>
             @else


### PR DESCRIPTION
Add `typeahead` component to meet autocomplete requirements, the PR includes.

* add [vue2-bootstrap4-typeahead](https://github.com/r0bdiabl0/vue2-bootstrap4-typeahead) 
* replace `select` with `typeahead` on `add a new relation` page

Adding a relationship from existing contact could be frustrating if one has many contacts, image a dropdown with 100+ items, to solve the issue, my idea is to replace the dropdown box with  `typeahead` component. 

![a](https://user-images.githubusercontent.com/15082118/40276966-30a164e4-5c49-11e8-88fb-85067801c923.gif)

ref #1058
