### PR TITLE
Remove url form text to translate

### DIFF
--- a/resources/lang/en/app.php
+++ b/resources/lang/en/app.php
@@ -85,7 +85,7 @@ return [
     'default_save_success' => 'The data has been saved.',
 
     'compliance_title' => 'Sorry for the interruption.',
-    'compliance_desc' => 'We have changed our <a href="https://monicahq.com/terms">terms of use</a> and <a href="https://monicahq.com/privacy">privacy policy</a>. By law we have to ask you to review them and accept them so you can continue to use your account.',
+    'compliance_desc' => 'We have changed our <a href=":urlterm" hreflang=":hreflang">Terms of Use</a> and <a href=":url" hreflang=":hreflang">Privacy Policy</a>. By law we have to ask you to review them and accept them so you can continue to use your account.',
     'compliance_desc_end' => 'We don’t do anything nasty with your data or account and will never do.',
     'compliance_terms' => 'Accept new terms and privacy policy',
 

--- a/resources/views/compliance/index.blade.php
+++ b/resources/views/compliance/index.blade.php
@@ -5,7 +5,7 @@
 
     <div class="mw7 center br3 ba b--gray-monica bg-white mb5 pa5">
       <h2 class="mb4">{{ trans('app.compliance_title') }}</h2>
-      <p>{!! trans('app.compliance_desc') !!}</p>
+      <p>{!! trans('app.compliance_desc', ['url' => 'https://monicahq.com/privacy', 'urlterm' => 'https://monicahq.com/terms', 'hreflang' => 'en', ]) !!}</p>
       <p>{{ trans('app.compliance_desc_end') }}</p>
 
       <form action="/compliance/sign" method="POST" class="tc mt4">


### PR DESCRIPTION
These url should not be in the text to translate.
Also added a hreflang to inform the user of the language of the destination text.