### PR TITLE
Remove stopOnFirstError from psalm.xml.

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <psalm
     name="Example Psalm config with recommended defaults"
-    stopOnFirstError="false"
     useDocblockTypes="true"
     totallyTyped="false"
 >


### PR DESCRIPTION
Should help #1465 go forward.

See https://github.com/vimeo/psalm/commit/b0f3992f36c048e628b7a326cae77cc876cd67e4.

Apparently `stopOnFirstError` was removed from the configuration options.