### PR TITLE
Remove delay on tooltips

### DIFF
--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -24,7 +24,9 @@ Vue.use(Notifications);
 // Tooltip
 import Tooltip from 'vue-directive-tooltip';
 import 'vue-directive-tooltip/css/index.css';
-Vue.use(Tooltip);
+Vue.use(Tooltip, {
+    delay: 0,
+});
 
 // Toggle Buttons
 import ToggleButton from 'vue-js-toggle-button';


### PR DESCRIPTION
Fixes #1457.

By default, the delay on all tooltips will be 0, which means that as soon as you move your mouse away, the tooltip will disappear.