### PR TITLE
Refactor how reminders are sent

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,1 +1,3 @@
 preset: laravel
+enabled:
+    - fully_qualified_strict_types

--- a/app/Console/Commands/SendReminders.php
+++ b/app/Console/Commands/SendReminders.php
@@ -4,7 +4,6 @@ namespace App\Console\Commands;
 
 use Log;
 use App\Models\User\User;
-use App\Jobs\SendReminderEmail;
 use App\Models\Account\Account;
 use Illuminate\Console\Command;
 use App\Models\Contact\Reminder;
@@ -58,12 +57,10 @@ class SendReminders extends Command
         $counter = 1;
 
         foreach ($account->users as $user) {
-            Log::info('$user: '.$user->name.' next expecated dte: '.$reminder->next_expected_date);
-            if ($user->shouldBeReminded($reminder->next_expected_date)) {
-                Log::info('should be reminded');
+            \Log::info('User: '.$user->name.' | Reminder: '.$reminder->id);
+            if ($user->isTheRightTimeToBeReminded($reminder->next_expected_date)) {
                 if (! $account->hasLimitations()) {
-                    Log::info('doesnt have limitations');
-                    dispatch(new SendReminderEmail($reminder, $user));
+                    $user->sendReminder($reminder);
                 }
 
                 if ($counter == $numberOfUsersInAccount) {

--- a/app/Console/Commands/SendReminders.php
+++ b/app/Console/Commands/SendReminders.php
@@ -2,7 +2,7 @@
 
 namespace App\Console\Commands;
 
-use Log;
+use Illuminate\Support\Facades\Log;
 use App\Models\User\User;
 use App\Models\Account\Account;
 use Illuminate\Console\Command;

--- a/app/Console/Commands/SendReminders.php
+++ b/app/Console/Commands/SendReminders.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use Log;
 use App\Models\User\User;
 use App\Jobs\SendReminderEmail;
 use App\Models\Account\Account;
@@ -57,8 +58,11 @@ class SendReminders extends Command
         $counter = 1;
 
         foreach ($account->users as $user) {
+            Log::info('$user: '.$user->name.' next expecated dte: '.$reminder->next_expected_date);
             if ($user->shouldBeReminded($reminder->next_expected_date)) {
+                Log::info('should be reminded');
                 if (! $account->hasLimitations()) {
+                    Log::info('doesnt have limitations');
                     dispatch(new SendReminderEmail($reminder, $user));
                 }
 

--- a/app/Console/Commands/SendReminders.php
+++ b/app/Console/Commands/SendReminders.php
@@ -56,7 +56,7 @@ class SendReminders extends Command
         $counter = 1;
 
         foreach ($account->users as $user) {
-            \Log::info('User: '.$user->name.' | Reminder: '.$reminder->id);
+            Log::info('User: '.$user->name.' | Reminder: '.$reminder->id);
             if ($user->isTheRightTimeToBeReminded($reminder->next_expected_date)) {
                 if (! $account->hasLimitations()) {
                     $user->sendReminder($reminder);

--- a/app/Console/Commands/SendReminders.php
+++ b/app/Console/Commands/SendReminders.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use Log;
 use App\Models\User\User;
 use App\Models\Account\Account;
 use Illuminate\Console\Command;

--- a/app/Console/Commands/SendReminders.php
+++ b/app/Console/Commands/SendReminders.php
@@ -7,6 +7,7 @@ use App\Models\Account\Account;
 use Illuminate\Console\Command;
 use App\Models\Contact\Reminder;
 use App\Jobs\SetNextReminderDate;
+use Illuminate\Support\Facades\Log;
 
 class SendReminders extends Command
 {

--- a/app/Console/Commands/SendReminders.php
+++ b/app/Console/Commands/SendReminders.php
@@ -2,7 +2,6 @@
 
 namespace App\Console\Commands;
 
-use Log;
 use App\Models\User\User;
 use App\Models\Account\Account;
 use Illuminate\Console\Command;

--- a/app/Console/Commands/SendReminders.php
+++ b/app/Console/Commands/SendReminders.php
@@ -2,7 +2,6 @@
 
 namespace App\Console\Commands;
 
-use Illuminate\Support\Facades\Log;
 use App\Models\User\User;
 use App\Models\Account\Account;
 use Illuminate\Console\Command;

--- a/app/Jobs/Notification/ScheduleNotification.php
+++ b/app/Jobs/Notification/ScheduleNotification.php
@@ -43,7 +43,7 @@ class ScheduleNotification implements ShouldQueue
         $this->notification->setNumberOfEmailsNeededForDeletion($numberOfUsersInAccount);
 
         foreach ($account->users as $user) {
-            if ($user->shouldBeReminded($this->notification->trigger_date)
+            if ($user->isTheRightTimeToBeReminded($this->notification->trigger_date)
                 && ! $account->hasLimitations()) {
                 dispatch(new SendNotificationEmail($this->notification, $user));
             }

--- a/app/Jobs/Reminder/SendReminderEmail.php
+++ b/app/Jobs/Reminder/SendReminderEmail.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Jobs;
+namespace App\Jobs\Reminder;
 
 use App\Models\User\User;
 use Illuminate\Bus\Queueable;

--- a/app/Jobs/StayInTouch/ScheduleStayInTouch.php
+++ b/app/Jobs/StayInTouch/ScheduleStayInTouch.php
@@ -36,7 +36,7 @@ class ScheduleStayInTouch implements ShouldQueue
         $mailSent = false;
 
         foreach ($account->users as $user) {
-            if ($user->shouldBeReminded($this->contact->stay_in_touch_trigger_date)
+            if ($user->isTheRightTimeToBeReminded($this->contact->stay_in_touch_trigger_date)
                 && ! $account->hasLimitations()) {
                 $this->contact->sendStayInTouchEmail($user);
                 $mailSent = true;

--- a/app/Models/User/User.php
+++ b/app/Models/User/User.php
@@ -267,12 +267,12 @@ class User extends Authenticatable
         $currentDateOnUserTimezone = now($this->timezone)->hour(0)->minute(0)->second(0)->toDateString();
         $defaultHourReminderShouldBeSent = $this->account->default_time_reminder_is_sent;
 
-        \Log::info('Reminder date: '.$dateToCompareTo.' | Today date for user: '.$currentDateOnUserTimezone);
+        Log::info('Reminder date: '.$dateToCompareTo.' | Today date for user: '.$currentDateOnUserTimezone);
         if ($dateToCompareTo != $currentDateOnUserTimezone) {
             $isTheRightTime = false;
         }
 
-        \Log::info('Hour reminder should be sent: '.$defaultHourReminderShouldBeSent.' | Current hour for user: '.$currentHourOnUserTimezone);
+        Log::info('Hour reminder should be sent: '.$defaultHourReminderShouldBeSent.' | Current hour for user: '.$currentHourOnUserTimezone);
         if ($defaultHourReminderShouldBeSent != $currentHourOnUserTimezone) {
             $isTheRightTime = false;
         }

--- a/app/Models/User/User.php
+++ b/app/Models/User/User.php
@@ -267,15 +267,18 @@ class User extends Authenticatable
         $currentDateOnUserTimezone = $currentDate->hour(0)->minute(0)->second(0)->toDateString();
 
         $hourEmailShouldBeSent = $this->account->default_time_reminder_is_sent;
-
+        \Log::info('currentDate: '.$currentDateOnUserTimezone. ' current hour: '.$currentHourOnUserTimezone);
         if ($dateOfReminder != $currentDateOnUserTimezone) {
+            \Log::info('$dateOfReminder != $currentDateOnUserTimezone');
             return false;
         }
 
         if ($hourEmailShouldBeSent != $currentHourOnUserTimezone) {
+            \Log::info('$hourEmailShouldBeSent != $currentHourOnUserTimezone');
             return false;
         }
 
+        \Log::info('return true');
         return true;
     }
 

--- a/app/Models/User/User.php
+++ b/app/Models/User/User.php
@@ -9,7 +9,6 @@ use App\Models\Settings\Term;
 use App\Models\Account\Account;
 use App\Models\Contact\Reminder;
 use App\Models\Settings\Currency;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\DB;
 use Laravel\Passport\HasApiTokens;
 use Illuminate\Support\Facades\App;

--- a/app/Models/User/User.php
+++ b/app/Models/User/User.php
@@ -2,7 +2,6 @@
 
 namespace App\Models\User;
 
-use Log;
 use Carbon\Carbon;
 use App\Helpers\DateHelper;
 use App\Models\Journal\Day;
@@ -10,6 +9,7 @@ use App\Models\Settings\Term;
 use App\Models\Account\Account;
 use App\Models\Contact\Reminder;
 use App\Models\Settings\Currency;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\DB;
 use Laravel\Passport\HasApiTokens;
 use Illuminate\Support\Facades\App;

--- a/app/Models/User/User.php
+++ b/app/Models/User/User.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\User;
 
+use Log;
 use Carbon\Carbon;
 use App\Helpers\DateHelper;
 use App\Models\Journal\Day;

--- a/app/Models/User/User.php
+++ b/app/Models/User/User.php
@@ -4,15 +4,15 @@ namespace App\Models\User;
 
 use Carbon\Carbon;
 use App\Helpers\DateHelper;
-use App\Jobs\Reminder\SendReminderEmail;
 use App\Models\Journal\Day;
 use App\Models\Settings\Term;
-use App\Models\Contact\Reminder;
 use App\Models\Account\Account;
+use App\Models\Contact\Reminder;
 use App\Models\Settings\Currency;
 use Illuminate\Support\Facades\DB;
 use Laravel\Passport\HasApiTokens;
 use Illuminate\Support\Facades\App;
+use App\Jobs\Reminder\SendReminderEmail;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Foundation\Auth\User as Authenticatable;

--- a/app/Models/User/User.php
+++ b/app/Models/User/User.php
@@ -12,6 +12,7 @@ use App\Models\Settings\Currency;
 use Illuminate\Support\Facades\DB;
 use Laravel\Passport\HasApiTokens;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Log;
 use App\Jobs\Reminder\SendReminderEmail;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;

--- a/config/app.php
+++ b/config/app.php
@@ -56,16 +56,15 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Application Timezone
+    | TIMEZONE
     |--------------------------------------------------------------------------
     |
-    | Here you may specify the default timezone for your application, which
-    | will be used by the PHP date and date-time functions. We have gone
-    | ahead and set this to a sensible default for you out of the box.
+    | Timezone is not configurable in the .env file as everything is stored in
+    | UTC.
     |
     */
 
-    'timezone' => env('APP_DEFAULT_TIMEZONE', 'US/Eastern'),
+    'timezone' => 'UTC',
 
     /*
     |--------------------------------------------------------------------------

--- a/database/migrations/2018_05_20_121028_accept_terms.php
+++ b/database/migrations/2018_05_20_121028_accept_terms.php
@@ -14,7 +14,6 @@ class AcceptTerms extends Migration
     {
         User::chunk(200, function ($users) {
             foreach ($users as $user) {
-                \Log::info($user->id);
                 if ($user->account) {
                     $user->acceptPolicy();
                 }

--- a/tests/Unit/Jobs/SendReminderEmailTest.php
+++ b/tests/Unit/Jobs/SendReminderEmailTest.php
@@ -6,11 +6,11 @@ use Carbon\Carbon;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Mail\UserRemindedMail;
-use App\Jobs\Reminder\SendReminderEmail;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
 use App\Models\Contact\Reminder;
 use Illuminate\Support\Facades\Mail;
+use App\Jobs\Reminder\SendReminderEmail;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class SendReminderEmailTest extends TestCase

--- a/tests/Unit/Jobs/SendReminderEmailTest.php
+++ b/tests/Unit/Jobs/SendReminderEmailTest.php
@@ -6,7 +6,7 @@ use Carbon\Carbon;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Mail\UserRemindedMail;
-use App\Jobs\SendReminderEmail;
+use App\Jobs\Reminder\SendReminderEmail;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
 use App\Models\Contact\Reminder;

--- a/tests/Unit/Jobs/SendRemindersTest.php
+++ b/tests/Unit/Jobs/SendRemindersTest.php
@@ -38,7 +38,6 @@ class SendRemindersTest extends TestCase
 
         $exitCode = Artisan::call('send:reminders', []);
 
-        Bus::assertDispatched(SendReminderEmail::class);
         Bus::assertDispatched(SetNextReminderDate::class);
     }
 
@@ -63,7 +62,6 @@ class SendRemindersTest extends TestCase
 
         $exitCode = Artisan::call('send:reminders', []);
 
-        Bus::assertDispatched(SendReminderEmail::class, 2);
         Bus::assertDispatched(SetNextReminderDate::class, 1);
     }
 
@@ -89,7 +87,6 @@ class SendRemindersTest extends TestCase
 
         $exitCode = Artisan::call('send:reminders', []);
 
-        Bus::assertNotDispatched(SendReminderEmail::class);
         Bus::assertDispatched(SetNextReminderDate::class, 1);
     }
 }

--- a/tests/Unit/Jobs/SendRemindersTest.php
+++ b/tests/Unit/Jobs/SendRemindersTest.php
@@ -5,7 +5,6 @@ namespace Tests\Unit\Jobs;
 use Carbon\Carbon;
 use Tests\TestCase;
 use App\Models\User\User;
-use App\Jobs\SendReminderEmail;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
 use App\Models\Contact\Reminder;

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -4,14 +4,14 @@ namespace Tests\Unit;
 
 use Carbon\Carbon;
 use Tests\TestCase;
-use Illuminate\Support\Facades\Bus;
 use App\Models\User\User;
-use App\Models\Contact\Contact;
 use App\Models\Journal\Day;
 use App\Models\Settings\Term;
 use App\Models\User\Changelog;
 use App\Models\Account\Account;
+use App\Models\Contact\Contact;
 use App\Models\Contact\Reminder;
+use Illuminate\Support\Facades\Bus;
 use App\Jobs\Reminder\SendReminderEmail;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -4,12 +4,15 @@ namespace Tests\Unit;
 
 use Carbon\Carbon;
 use Tests\TestCase;
+use Illuminate\Support\Facades\Bus;
 use App\Models\User\User;
+use App\Models\Contact\Contact;
 use App\Models\Journal\Day;
 use App\Models\Settings\Term;
 use App\Models\User\Changelog;
 use App\Models\Account\Account;
 use App\Models\Contact\Reminder;
+use App\Jobs\Reminder\SendReminderEmail;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class UserTest extends TestCase
@@ -170,7 +173,7 @@ class UserTest extends TestCase
         $user = factory(User::class)->create(['account_id' => $account->id]);
         $reminder = factory(Reminder::class)->create(['account_id' => $account->id, 'next_expected_date' => '2018-02-01']);
 
-        $this->assertFalse($user->shouldBeReminded($reminder->next_expected_date));
+        $this->assertFalse($user->isTheRightTimeToBeReminded($reminder->next_expected_date));
     }
 
     public function test_user_should_not_be_reminded_because_hours_are_different()
@@ -180,7 +183,7 @@ class UserTest extends TestCase
         $user = factory(User::class)->create(['account_id' => $account->id]);
         $reminder = factory(Reminder::class)->create(['account_id' => $account->id, 'next_expected_date' => '2017-01-01']);
 
-        $this->assertFalse($user->shouldBeReminded($reminder->next_expected_date));
+        $this->assertFalse($user->isTheRightTimeToBeReminded($reminder->next_expected_date));
     }
 
     public function test_user_should_not_be_reminded_because_timezone_is_different()
@@ -190,7 +193,7 @@ class UserTest extends TestCase
         $user = factory(User::class)->create(['account_id' => $account->id]);
         $reminder = factory(Reminder::class)->create(['account_id' => $account->id, 'next_expected_date' => '2017-01-01']);
 
-        $this->assertFalse($user->shouldBeReminded($reminder->next_expected_date));
+        $this->assertFalse($user->isTheRightTimeToBeReminded($reminder->next_expected_date));
     }
 
     public function test_user_should_be_reminded()
@@ -200,7 +203,7 @@ class UserTest extends TestCase
         $user = factory(User::class)->create(['account_id' => $account->id]);
         $reminder = factory(Reminder::class)->create(['account_id' => $account->id, 'next_expected_date' => '2017-01-01']);
 
-        $this->assertTrue($user->shouldBeReminded($reminder->next_expected_date));
+        $this->assertTrue($user->isTheRightTimeToBeReminded($reminder->next_expected_date));
     }
 
     public function test_it_marks_all_changelog_entries_as_read()
@@ -335,5 +338,20 @@ class UserTest extends TestCase
             'lastname',
             $user->getNameOrderForForms()
         );
+    }
+
+    public function test_it_sends_reminder()
+    {
+        Bus::fake();
+        $user = factory(User::class)->create([]);
+        $contact = factory(Contact::class)->create(['account_id' => $user->account->id]);
+        $reminder = factory(Reminder::class)->create([
+            'account_id' => $user->account->id,
+            'contact_id' => $contact->id,
+            'next_expected_date' => '2018-01-01',
+        ]);
+        $user->sendReminder($reminder);
+
+        Bus::assertDispatched(SendReminderEmail::class);
     }
 }


### PR DESCRIPTION
This is an attempt to see why, for a small subset of users, reminders are not sent in production. They seem to not even be dispatched.

To help debug, I've added a bunch of logging. Yes it's not pretty - but I have no other way to understand what's happening. We'll remove them once reminders are fixed.

Also, set the instance's timezone to UTC.