### PR TITLE
Add command to process old reminders

### DIFF
--- a/app/Console/Commands/Reminder/ProcessOldReminders.php
+++ b/app/Console/Commands/Reminder/ProcessOldReminders.php
@@ -2,14 +2,14 @@
 
 namespace App\Console\Commands\Reminder;
 
-use App\Models\Contact\Reminder;
 use Illuminate\Console\Command;
+use App\Models\Contact\Reminder;
 
 /**
  * Because of an old bug, some reminders have never been sent and sit on the
  * database, with very old `next_expected` date. This command
  * - delete one time reminders
- * - calculate the next expected date of the reminder based on its frequency
+ * - calculate the next expected date of the reminder based on its frequency.
  */
 class ProcessOldReminders extends Command
 {
@@ -40,7 +40,7 @@ class ProcessOldReminders extends Command
         foreach ($reminders as $reminder) {
             // Skip the reminder if the contact has been deleted (and for some
             // reasons, the reminder hasn't)
-            if (!$reminder->contact) {
+            if (! $reminder->contact) {
                 $reminder->delete();
                 continue;
             }

--- a/app/Console/Commands/Reminder/ProcessOldReminders.php
+++ b/app/Console/Commands/Reminder/ProcessOldReminders.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Console\Commands\Reminder;
+
+use App\Models\Contact\Reminder;
+use Illuminate\Console\Command;
+
+/**
+ * Because of an old bug, some reminders have never been sent and sit on the
+ * database, with very old `next_expected` date. This command
+ * - delete one time reminders
+ * - calculate the next expected date of the reminder based on its frequency
+ */
+class ProcessOldReminders extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'process:old_reminders';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Schedule the next expected date for reminders which have never been sent';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $reminders = Reminder::where('next_expected_date', '<', now()->subDays(1))
+                                ->get();
+
+        foreach ($reminders as $reminder) {
+            // Skip the reminder if the contact has been deleted (and for some
+            // reasons, the reminder hasn't)
+            if (!$reminder->contact) {
+                $reminder->delete();
+                continue;
+            }
+
+            if ($reminder->frequency_type == 'one_time') {
+                $reminder->delete();
+            }
+
+            if ($reminder->frequency_type != 'one_time') {
+                $reminder->calculateNextExpectedDate('UTC');
+                $reminder->save();
+            }
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -27,6 +27,7 @@ class Kernel extends ConsoleKernel
         'App\Console\Commands\SetupTest',
         'App\Console\Commands\Update',
         'App\Console\Commands\MigrateDatabaseCollation',
+        'App\Console\Commands\Reminder\ProcessOldReminders',
     ];
 
     /**
@@ -41,6 +42,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('send:reminders')->hourly();
         $schedule->command('send:stay_in_touch')->hourly();
         $schedule->command('monica:calculatestatistics')->daily();
+        $schedule->command('process:old_reminders')->daily();
         $schedule->command('monica:ping')->daily();
     }
 }


### PR DESCRIPTION
Because of an old bug, some reminders have never been sent and sit on the database, with very old `next_expected` date. This command
 * delete one time reminders
 * calculate the next expected date of the reminder based on its frequency

