### PR TITLE
Add ability to discover cloudflare trusted proxies automatically

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,9 @@ APP_SIGNUP_DOUBLE_OPTIN=false
 # To trust one or more specific proxies that connect directly to your server, use a comma separated list of IP addresses.
 APP_TRUSTED_PROXIES=
 
+# Enable automatic cloudflare trusted proxy discover
+APP_TRUSTED_CLOUDFLARE=false
+
 # Frequency of creation of new log files. Logs are written when an error occurs.
 # Refer to config/logging.php for the possible values.
 LOG_CHANNEL=daily

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -44,5 +44,8 @@ class Kernel extends ConsoleKernel
         $schedule->command('monica:calculatestatistics')->daily();
         $schedule->command('process:old_reminders')->daily();
         $schedule->command('monica:ping')->daily();
+        if (config('trustedproxy.cloudflare')) {
+            $schedule->command('cloudflare:reload')->daily();
+        }
     }
 }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -16,6 +16,7 @@ class Kernel extends HttpKernel
     protected $middleware = [
         \Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+        \Karakus\Cloudflare\Http\Middleware\TrustProxies::class,
         \App\Http\Middleware\TrustProxies::class,
     ];
 

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "ircop/antiflood": "^0.1.4",
         "jenssegers/date": "^3.3",
         "jeroendesloovere/vcard": "^1.5",
+        "karakus/laravel-cloudflare": "^1.0",
         "lahaxearnaud/laravel-u2f": "^1.3",
         "laravel/cashier": "~7.0",
         "laravel/framework": "5.6.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "91b01291060e6795e5bb19748f77b743",
+    "content-hash": "c374d2a70b96a84a87d1e20858185436",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -1486,6 +1486,59 @@
             "time": "2017-07-28T13:16:03+00:00"
         },
         {
+            "name": "ixudra/curl",
+            "version": "6.16.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ixudra/curl.git",
+                "reference": "1ab270e48082ee6e7f32fa72412c2c81eb974516"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ixudra/curl/zipball/1ab270e48082ee6e7f32fa72412c2c81eb974516",
+                "reference": "1ab270e48082ee6e7f32fa72412c2c81eb974516",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": ">=4.0",
+                "php": ">=5.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Ixudra\\Curl\\CurlServiceProvider"
+                    ],
+                    "aliases": {
+                        "Curl": "Ixudra\\Curl\\Facades\\Curl"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ixudra\\Curl\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Oris",
+                    "email": "jan.oris@ixudra.be"
+                }
+            ],
+            "description": "Custom PHP Curl library for the Laravel 5 framework - developed by Ixudra",
+            "homepage": "http://ixudra.be",
+            "keywords": [
+                "Ixudra",
+                "curl",
+                "laravel"
+            ],
+            "time": "2017-12-08T14:31:13+00:00"
+        },
+        {
             "name": "jenssegers/date",
             "version": "v3.4.0",
             "source": {
@@ -1598,6 +1651,62 @@
                 "vCard"
             ],
             "time": "2018-07-04T09:44:33+00:00"
+        },
+        {
+            "name": "karakus/laravel-cloudflare",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ogunkarakus/laravel-cloudflare.git",
+                "reference": "ec4b0e342463bdfbd793f676b59b8a70ba8d2053"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ogunkarakus/laravel-cloudflare/zipball/ec4b0e342463bdfbd793f676b59b8a70ba8d2053",
+                "reference": "ec4b0e342463bdfbd793f676b59b8a70ba8d2053",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/console": "5.6.*",
+                "illuminate/http": "5.6.*",
+                "illuminate/support": "5.6.*",
+                "ixudra/curl": "6.16.*"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Karakus\\Cloudflare\\TrustedProxyServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Karakus\\Cloudflare\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ogün Karakuş",
+                    "email": "kirk5bucuk@gmail.com",
+                    "homepage": "https://github.com/ogunkarakus",
+                    "role": "developer"
+                }
+            ],
+            "description": "Loads IP blocks of Cloudflare to trusted proxies for Laravel.",
+            "homepage": "https://github.com/ogunkarakus",
+            "keywords": [
+                "cloudflare",
+                "laravel",
+                "load balancing",
+                "proxy",
+                "trusted proxy"
+            ],
+            "time": "2018-07-16T23:31:04+00:00"
         },
         {
             "name": "lahaxearnaud/laravel-u2f",
@@ -3021,16 +3130,16 @@
         },
         {
             "name": "phenx/php-svg-lib",
-            "version": "v0.3.0",
+            "version": "v0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PhenX/php-svg-lib.git",
-                "reference": "8f543ede60386faec9b0012833536de4b6083bb9"
+                "reference": "a85f7fe9fe08d093a4a8583cdd306b553ff918aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PhenX/php-svg-lib/zipball/8f543ede60386faec9b0012833536de4b6083bb9",
-                "reference": "8f543ede60386faec9b0012833536de4b6083bb9",
+                "url": "https://api.github.com/repos/PhenX/php-svg-lib/zipball/a85f7fe9fe08d093a4a8583cdd306b553ff918aa",
+                "reference": "a85f7fe9fe08d093a4a8583cdd306b553ff918aa",
                 "shasum": ""
             },
             "require": {
@@ -3057,7 +3166,7 @@
             ],
             "description": "A library to read, parse and export to PDF SVG files.",
             "homepage": "https://github.com/PhenX/php-svg-lib",
-            "time": "2018-04-14T14:36:18+00:00"
+            "time": "2017-05-24T10:07:27+00:00"
         },
         {
             "name": "phpseclib/phpseclib",

--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -41,4 +41,9 @@ return [
      */
     'headers' => Illuminate\Http\Request::HEADER_X_FORWARDED_ALL,
 
+    /*
+     * Enable cloudflare trusted proxies
+     */
+    'cloudflare' => env('APP_TRUSTED_CLOUDFLARE', false)
+
 ];

--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -44,6 +44,6 @@ return [
     /*
      * Enable cloudflare trusted proxies
      */
-    'cloudflare' => env('APP_TRUSTED_CLOUDFLARE', false)
+    'cloudflare' => env('APP_TRUSTED_CLOUDFLARE', false),
 
 ];


### PR DESCRIPTION
Trusted proxy permits a request to be recognize as secured.
This is needed for U2F.
These pull request add ability to add proxies from CloudFlare to trusted proxies.