### PR TITLE
Show reminders for the current day on the dashboard

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 UNRELEASED CHANGES:
 
 * Add ability to define custom activity types and activity type categories through the API and the UI
+* Show reminders for the current date on the dashboard
 
 RELEASED VERSIONS:
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -34,3 +34,4 @@ Theo Mathieu @Mokto
 Daniel Pieper @danielpieper <monica@daniel-pieper.com>
 Andrew Paul Smith <github@chucklesthebeard.com>
 Brian Clemens <brian@tiuxo.com>
+Chris Morbitzer @cmorbitzer <chris.morbitzer@gmail.com>

--- a/app/Console/Commands/SendReminders.php
+++ b/app/Console/Commands/SendReminders.php
@@ -66,7 +66,7 @@ class SendReminders extends Command
                 if ($counter == $numberOfUsersInAccount) {
                     // We should only do this when we are sure that this is
                     // the last user who should be warned in this account.
-                    dispatch(new SetNextReminderDate($reminder));
+                    dispatch(new SetNextReminderDate($reminder))->delay(now()->addDay());
                 }
             }
             $counter++;

--- a/app/Models/Account/Account.php
+++ b/app/Models/Account/Account.php
@@ -658,7 +658,7 @@ class Account extends Model
         $startOfMonth = now(DateHelper::getTimezone())->addMonthsNoOverflow($month)->startOfMonth();
         // don't get reminders for past events:
         if ($startOfMonth->isPast()) {
-            $startOfMonth = now(DateHelper::getTimezone());
+            $startOfMonth = now(DateHelper::getTimezone())->startOfDay();
         }
         $endOfMonth = now(DateHelper::getTimezone())->addMonthsNoOverflow($month)->endOfMonth();
 

--- a/tests/Unit/AccountTest.php
+++ b/tests/Unit/AccountTest.php
@@ -344,6 +344,26 @@ class AccountTest extends FeatureTestCase
         );
     }
 
+    public function test_get_reminders_for_month_returns_reminders_for_today()
+    {
+        $user = $this->signIn();
+
+        $account = $user->account;
+
+        Carbon::setTestNow(Carbon::create(2017, 1, 1, 12));
+
+        // add a reminder for today
+        $reminder = factory(Reminder::class)->create([
+            'account_id' => $account->id,
+            'next_expected_date' => '2017-01-01 08:00:00',
+        ]);
+
+        $this->assertEquals(
+            1,
+            $account->getRemindersForMonth(0)->count()
+        );
+    }
+
     public function test_it_gets_the_id_of_the_subscribed_plan()
     {
         $user = $this->signIn();

--- a/tests/Unit/Jobs/SendRemindersTest.php
+++ b/tests/Unit/Jobs/SendRemindersTest.php
@@ -37,7 +37,9 @@ class SendRemindersTest extends TestCase
 
         $exitCode = Artisan::call('send:reminders', []);
 
-        Bus::assertDispatched(SetNextReminderDate::class);
+        Bus::assertDispatched(SetNextReminderDate::class, function ($job) {
+            return $job->delay == now()->addDay();
+        });
     }
 
     public function test_it_schedules_multiple_emails_jobs_but_only_one_set_next_reminder_job()


### PR DESCRIPTION
**Edit** see comment below for discussion point

Fixes #740 and #839 

This delays the SetNextReminderDate job by 48 hours so that reminders'
next_expected_date does not change until after the current day has
passed for users in all timezones. This also changes the condition in
getRemindersForMonth() on the Account model so that reminders for the
current month will be shown from the start of the current day instead
of the current time.

This should not interfere with any recurring reminders because the
minimum interval for a reminder is 1 week.

Users also should not see duplicate reminders because isTheRightTimeToBeReminded() does not return true for past reminders but only when a user is supposed to receive a reminder at that very hour.
