### PR TITLE
Fix missing storage link

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ UNRELEASED CHANGES:
 * Add the TrimStrings middleware to trim all inputs
 * Call to monica:ping when updating instance
 * Fix idHasher decode function
+* Fix storage folder not being linked to public if migrations fail
 
 RELEASED VERSIONS:
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -34,3 +34,4 @@ Theo Mathieu @Mokto
 Daniel Pieper @danielpieper <monica@daniel-pieper.com>
 Andrew Paul Smith <github@chucklesthebeard.com>
 Brian Clemens <brian@tiuxo.com>
+Christopher Zentgraf @TheZenti <git@the-zenti.de>

--- a/app/Console/Commands/Update.php
+++ b/app/Console/Commands/Update.php
@@ -81,14 +81,15 @@ class Update extends Command
                     $this->commandExecutor->exec('✓ Updating composer dependencies', 'composer install --no-interaction --no-suggest --ignore-platform-reqs'.($this->option('dev') === false ? '--no-dev' : ''));
                 }
 
-                if ($this->migrateCollationTest()) {
-                    $this->commandExecutor->artisan('✓ Performing collation migrations', 'migrate:collation', ['--force' => 'true']);
-                }
-                $this->commandExecutor->artisan('✓ Performing migrations', 'migrate', ['--force' => 'true']);
-
                 if ($this->getLaravel()->environment() != 'testing' && ! file_exists(public_path('storage'))) {
                     $this->commandExecutor->artisan('✓ Symlink the storage folder', 'storage:link');
                 }
+
+                if ($this->migrateCollationTest()) {
+                    $this->commandExecutor->artisan('✓ Performing collation migrations', 'migrate:collation', ['--force' => 'true']);
+                }
+
+                $this->commandExecutor->artisan('✓ Performing migrations', 'migrate', ['--force' => 'true']);
 
                 $this->commandExecutor->artisan('✓ Ping for new version', 'monica:ping', ['--force' => 'true']);
             } finally {


### PR DESCRIPTION
Fixes #1622.

If migrations fail, the storage directory will not be linked to $MONICA_DIR/public/storage, which breaks uploaded avatars. This PR moves the linking command so migrations will be executed at the end.

### Checklist

#### Before submitting the PR
- [X] Read the [CONTRIBUTING document](https://github.com/monicahq/monica/blob/master/CONTRIBUTING.md) before submitting your PR.
- [X] If the PR is related to an issue or fix one, don't forget to indicate it.
- [X] Make sure that the change you propose is the smallest possible.
- [n/a] Screenshots are included if the PR changes the UI.
- [n/a] If you change the UI, make sure the user experience is consistent with the current interface.

#### Code-related tasks
- [n/a] Tests added for this feature/bug. - Storage linking was disabled in testing environments before.
- [n/a] Impact on the seeders.
- [n/a] Impact on the API.

#### Other tasks
- [X] [CHANGELOG](https://github.com/monicahq/monica/blob/master/CHANGELOG) entry added, if necessary, under `UNRELEASED`.
- [X] [CONTRIBUTORS](https://github.com/monicahq/monica/blob/master/CONTRIBUTORS) entry added, if necessary.
- [n/a] If it's relevant and worth mentioning, create a changelog entry for this change. The changelog entry will appear inside the UI for all users to see. To know if your change is worth the creation of a changelog entry, [read the documentation](https://github.com/monicahq/monica/blob/master/docs/administrators/tips.md#when-is-it-relevant-to-create-a-changelog-entry).