### PR TITLE
fix: fix how comparing version is done

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,7 @@ UNRELEASED CHANGES:
 * Add helper function htmldir()
 * Fix login remember with 2fa and u2f enabled
 * Fix gender update
+* Fix how version compare is done
 
 RELEASED VERSIONS:
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,7 +8,7 @@ UNRELEASED CHANGES:
 * Add helper function htmldir()
 * Fix login remember with 2fa and u2f enabled
 * Fix gender update
-* Fix how version compare is done
+* Fix how comparing version is done
 
 RELEASED VERSIONS:
 

--- a/resources/views/partials/check.blade.php
+++ b/resources/views/partials/check.blade.php
@@ -2,7 +2,7 @@
 
 @if (config('monica.check_version'))
 
-    @if (\App\Models\Instance\Instance::first()->latest_version != config('monica.app_version'))
+    @if (version_compare(\App\Models\Instance\Instance::first()->latest_version, config('monica.app_version')) > 0)
     <li>
         <a href="#showVersion" data-toggle="modal" class="badge badge-success">{{ trans('app.footer_new_version') }}</a>
     </li>


### PR DESCRIPTION
Avoid displaying "New version available" if current deploy is in advance.