### PR TITLE
fix: fix reminder link in email sent

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@ UNRELEASED CHANGES:
 * Fix search with wrong search field
 * Fix gift recipient relation
 * Fix subscription cancel on account deletion
+* Fix reminder link in email sent
 
 RELEASED VERSIONS:
 

--- a/resources/views/emails/reminder/notification.blade.php
+++ b/resources/views/emails/reminder/notification.blade.php
@@ -17,4 +17,4 @@ COMMENT:
 -------
 
 {{ trans('mail.footer_contact_info') }}
-{{ config('app.url') }}{{ route('people.show', $contact) }}
+{{ route('people.show', $contact) }}

--- a/resources/views/emails/reminder/reminder.blade.php
+++ b/resources/views/emails/reminder/reminder.blade.php
@@ -17,4 +17,4 @@ COMMENT:
 -------
 
 {{ trans('mail.footer_contact_info') }}
-{{ config('app.url') }}{{ route('people.show', $contact) }}
+{{ route('people.show', $contact) }}

--- a/resources/views/emails/reminder/stayintouch.blade.php
+++ b/resources/views/emails/reminder/stayintouch.blade.php
@@ -5,4 +5,4 @@
 -------
 
 {{ trans('mail.footer_contact_info') }}
-{{ config('app.url') }}{{ route('people.show', $contact) }}
+{{ route('people.show', $contact) }}


### PR DESCRIPTION
Fix the link in reminder mails, currently the host appears twice:
![image](https://user-images.githubusercontent.com/25419741/44953230-4e7be200-ae92-11e8-896d-b82c42869640.png)
