### PR TITLE
fix: fix reminders not showing the right date

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 UNRELEASED CHANGES:
 
+* Fix reminders displaying wrong date
 * Add ability to define the default email address used for support
 * Fix confirm email sent when signup_double_optin is false
 * Fix now() without timezone functions

--- a/app/Models/Contact/Reminder.php
+++ b/app/Models/Contact/Reminder.php
@@ -75,7 +75,7 @@ class Reminder extends Model
      */
     public function getNextExpectedDateAttribute($value)
     {
-        return DateHelper::parseDate($value, DateHelper::getTimezone());
+        return DateHelper::parseDate($value);
     }
 
     /**


### PR DESCRIPTION
When we get the next expected date for a reminder, we shouldn't apply a timezone to it. If it Oct 29th, it's Oct 29th, no matter which timezone.