### PR TITLE
fix: remove useless try catch

### DIFF
--- a/app/Http/Controllers/Api/Contact/ApiConversationController.php
+++ b/app/Http/Controllers/Api/Contact/ApiConversationController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use App\Models\Contact\Conversation;
 use Illuminate\Database\QueryException;
 use App\Http\Controllers\Api\ApiController;
+use App\Exceptions\MissingParameterException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use App\Services\Contact\Conversation\CreateConversation;
 use App\Services\Contact\Conversation\UpdateConversation;
@@ -68,7 +69,7 @@ class ApiConversationController extends ApiController
             );
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (\Exception $e) {
+        } catch (MissingParameterException $e) {
             return $this->setHTTPStatusCode(500)
                         ->setErrorCode(41)
                         ->respondWithError(config('api.error_codes.41'));
@@ -99,7 +100,7 @@ class ApiConversationController extends ApiController
             );
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (\Exception $e) {
+        } catch (MissingParameterException $e) {
             return $this->setHTTPStatusCode(500)
                         ->setErrorCode(41)
                         ->respondWithError(config('api.error_codes.41'));
@@ -126,10 +127,10 @@ class ApiConversationController extends ApiController
             ]);
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (\Exception $e) {
+        } catch (MissingParameterException $e) {
             return $this->setHTTPStatusCode(500)
-                ->setErrorCode(41)
-                ->respondWithError(config('api.error_codes.41'));
+                        ->setErrorCode(41)
+                        ->respondWithError(config('api.error_codes.41'));
         } catch (QueryException $e) {
             return $this->respondInvalidQuery();
         }

--- a/app/Http/Controllers/Api/Contact/ApiMessageController.php
+++ b/app/Http/Controllers/Api/Contact/ApiMessageController.php
@@ -7,6 +7,7 @@ use App\Models\Contact\Message;
 use App\Models\Contact\Conversation;
 use Illuminate\Database\QueryException;
 use App\Http\Controllers\Api\ApiController;
+use App\Exceptions\MissingParameterException;
 use App\Services\Contact\Conversation\UpdateMessage;
 use App\Services\Contact\Conversation\DestroyMessage;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -41,7 +42,7 @@ class ApiMessageController extends ApiController
             );
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (\Exception $e) {
+        } catch (MissingParameterException $e) {
             return $this->setHTTPStatusCode(500)
                         ->setErrorCode(41)
                         ->respondWithError(config('api.error_codes.41'));
@@ -82,7 +83,7 @@ class ApiMessageController extends ApiController
             );
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (\Exception $e) {
+        } catch (MissingParameterException $e) {
             return $this->setHTTPStatusCode(500)
                         ->setErrorCode(41)
                         ->respondWithError(config('api.error_codes.41'));
@@ -118,7 +119,7 @@ class ApiMessageController extends ApiController
             ]);
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (\Exception $e) {
+        } catch (MissingParameterException $e) {
             return $this->setHTTPStatusCode(500)
                 ->setErrorCode(41)
                 ->respondWithError(config('api.error_codes.41'));

--- a/app/Services/Contact/Conversation/AddMessageToConversation.php
+++ b/app/Services/Contact/Conversation/AddMessageToConversation.php
@@ -10,8 +10,7 @@ namespace App\Services\Contact\Conversation;
 use App\Services\BaseService;
 use App\Models\Contact\Message;
 use App\Models\Contact\Conversation;
-use Illuminate\Database\QueryException;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
+use App\Exceptions\MissingParameterException;
 
 class AddMessageToConversation extends BaseService
 {
@@ -38,23 +37,13 @@ class AddMessageToConversation extends BaseService
     public function execute(array $data): Message
     {
         if (! $this->validateDataStructure($data, $this->structure)) {
-            throw new \Exception('Missing parameters');
+            throw new MissingParameterException('Missing parameters');
         }
 
-        try {
-            Conversation::where('contact_id', $data['contact_id'])
-                                ->where('account_id', $data['account_id'])
-                                ->findOrFail($data['conversation_id']);
-        } catch (ModelNotFoundException $e) {
-            throw $e;
-        }
+        Conversation::where('contact_id', $data['contact_id'])
+                        ->where('account_id', $data['account_id'])
+                        ->findOrFail($data['conversation_id']);
 
-        try {
-            $message = Message::create($data);
-        } catch (QueryException $e) {
-            throw $e;
-        }
-
-        return $message;
+        return Message::create($data);
     }
 }

--- a/app/Services/Contact/Conversation/CreateConversation.php
+++ b/app/Services/Contact/Conversation/CreateConversation.php
@@ -10,9 +10,8 @@ namespace App\Services\Contact\Conversation;
 use App\Services\BaseService;
 use App\Models\Contact\Contact;
 use App\Models\Contact\Conversation;
-use Illuminate\Database\QueryException;
 use App\Models\Contact\ContactFieldType;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
+use App\Exceptions\MissingParameterException;
 
 class CreateConversation extends BaseService
 {
@@ -37,29 +36,15 @@ class CreateConversation extends BaseService
     public function execute(array $data): Conversation
     {
         if (! $this->validateDataStructure($data, $this->structure)) {
-            throw new \Exception('Missing parameters');
+            throw new MissingParameterException('Missing parameters');
         }
 
-        try {
-            Contact::where('account_id', $data['account_id'])
-                    ->where($data['contact_id']);
-        } catch (ModelNotFoundException $e) {
-            throw $e;
-        }
+        Contact::where('account_id', $data['account_id'])
+                ->findOrFail($data['contact_id']);
 
-        try {
-            ContactFieldType::where('account_id', $data['account_id'])
-                            ->findOrFail($data['contact_field_type_id']);
-        } catch (ModelNotFoundException $e) {
-            throw $e;
-        }
+        ContactFieldType::where('account_id', $data['account_id'])
+                        ->findOrFail($data['contact_field_type_id']);
 
-        try {
-            $conversation = Conversation::create($data);
-        } catch (QueryException $e) {
-            throw $e;
-        }
-
-        return $conversation;
+        return Conversation::create($data);
     }
 }

--- a/app/Services/Contact/Conversation/DestroyConversation.php
+++ b/app/Services/Contact/Conversation/DestroyConversation.php
@@ -9,8 +9,7 @@ namespace App\Services\Contact\Conversation;
 
 use App\Services\BaseService;
 use App\Models\Contact\Conversation;
-use Illuminate\Database\QueryException;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
+use App\Exceptions\MissingParameterException;
 
 class DestroyConversation extends BaseService
 {
@@ -33,21 +32,13 @@ class DestroyConversation extends BaseService
     public function execute(array $data) : bool
     {
         if (! $this->validateDataStructure($data, $this->structure)) {
-            throw new \Exception('Missing parameters');
+            throw new MissingParameterException('Missing parameters');
         }
 
-        try {
-            $conversation = Conversation::where('account_id', $data['account_id'])
-                ->findOrFail($data['conversation_id']);
-        } catch (ModelNotFoundException $e) {
-            throw $e;
-        }
+        $conversation = Conversation::where('account_id', $data['account_id'])
+                                    ->findOrFail($data['conversation_id']);
 
-        try {
-            $conversation->delete();
-        } catch (QueryException $e) {
-            throw $e;
-        }
+        $conversation->delete();
 
         return true;
     }

--- a/app/Services/Contact/Conversation/DestroyMessage.php
+++ b/app/Services/Contact/Conversation/DestroyMessage.php
@@ -9,8 +9,7 @@ namespace App\Services\Contact\Conversation;
 
 use App\Services\BaseService;
 use App\Models\Contact\Message;
-use Illuminate\Database\QueryException;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
+use App\Exceptions\MissingParameterException;
 
 class DestroyMessage extends BaseService
 {
@@ -34,22 +33,14 @@ class DestroyMessage extends BaseService
     public function execute(array $data) : bool
     {
         if (! $this->validateDataStructure($data, $this->structure)) {
-            throw new \Exception('Missing parameters');
+            throw new MissingParameterException('Missing parameters');
         }
 
-        try {
-            $message = Message::where('account_id', $data['account_id'])
-                ->where('conversation_id', $data['conversation_id'])
-                ->findOrFail($data['message_id']);
-        } catch (ModelNotFoundException $e) {
-            throw $e;
-        }
+        $message = Message::where('account_id', $data['account_id'])
+                            ->where('conversation_id', $data['conversation_id'])
+                            ->findOrFail($data['message_id']);
 
-        try {
-            $message->delete();
-        } catch (QueryException $e) {
-            throw $e;
-        }
+        $message->delete();
 
         return true;
     }

--- a/app/Services/Contact/Conversation/UpdateConversation.php
+++ b/app/Services/Contact/Conversation/UpdateConversation.php
@@ -9,9 +9,8 @@ namespace App\Services\Contact\Conversation;
 
 use App\Services\BaseService;
 use App\Models\Contact\Conversation;
-use Illuminate\Database\QueryException;
 use App\Models\Contact\ContactFieldType;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
+use App\Exceptions\MissingParameterException;
 
 class UpdateConversation extends BaseService
 {
@@ -36,31 +35,19 @@ class UpdateConversation extends BaseService
     public function execute(array $data): Conversation
     {
         if (! $this->validateDataStructure($data, $this->structure)) {
-            throw new \Exception('Missing parameters');
+            throw new MissingParameterException('Missing parameters');
         }
 
-        try {
-            $conversation = Conversation::where('account_id', $data['account_id'])
-                        ->findOrFail($data['conversation_id']);
-        } catch (ModelNotFoundException $e) {
-            throw $e;
-        }
+        $conversation = Conversation::where('account_id', $data['account_id'])
+                                    ->findOrFail($data['conversation_id']);
 
-        try {
-            ContactFieldType::where('account_id', $data['account_id'])
-                                ->findOrFail($data['contact_field_type_id']);
-        } catch (ModelNotFoundException $e) {
-            throw $e;
-        }
+        ContactFieldType::where('account_id', $data['account_id'])
+                            ->findOrFail($data['contact_field_type_id']);
 
-        try {
-            $conversation->update([
-                'happened_at' => $data['happened_at'],
-                'contact_field_type_id' => $data['contact_field_type_id'],
-            ]);
-        } catch (QueryException $e) {
-            throw $e;
-        }
+        $conversation->update([
+            'happened_at' => $data['happened_at'],
+            'contact_field_type_id' => $data['contact_field_type_id'],
+        ]);
 
         return $conversation;
     }

--- a/app/Services/Contact/Conversation/UpdateMessage.php
+++ b/app/Services/Contact/Conversation/UpdateMessage.php
@@ -10,8 +10,7 @@ namespace App\Services\Contact\Conversation;
 use App\Services\BaseService;
 use App\Models\Contact\Message;
 use App\Models\Contact\Conversation;
-use Illuminate\Database\QueryException;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
+use App\Exceptions\MissingParameterException;
 
 class UpdateMessage extends BaseService
 {
@@ -39,27 +38,19 @@ class UpdateMessage extends BaseService
     public function execute(array $data): Message
     {
         if (! $this->validateDataStructure($data, $this->structure)) {
-            throw new \Exception('Missing parameters');
+            throw new MissingParameterException('Missing parameters');
         }
 
-        try {
-            $message = Message::where('contact_id', $data['contact_id'])
-                                ->where('conversation_id', $data['conversation_id'])
-                                ->where('account_id', $data['account_id'])
-                                ->findOrFail($data['message_id']);
-        } catch (ModelNotFoundException $e) {
-            throw $e;
-        }
+        $message = Message::where('contact_id', $data['contact_id'])
+                            ->where('conversation_id', $data['conversation_id'])
+                            ->where('account_id', $data['account_id'])
+                            ->findOrFail($data['message_id']);
 
-        try {
-            $message->update([
-                'written_at' => $data['written_at'],
-                'written_by_me' => $data['written_by_me'],
-                'content' => $data['content'],
-            ]);
-        } catch (QueryException $e) {
-            throw $e;
-        }
+        $message->update([
+            'written_at' => $data['written_at'],
+            'written_by_me' => $data['written_by_me'],
+            'content' => $data['content'],
+        ]);
 
         return $message;
     }

--- a/database/seeds/FakeContentTableSeeder.php
+++ b/database/seeds/FakeContentTableSeeder.php
@@ -50,7 +50,6 @@ class FakeContentTableSeeder extends Seeder
         $arrayPictures = json_decode($res->getBody());
 
         for ($i = 0; $i < $this->numberOfContacts; $i++) {
-            $timezone = config('app.timezone');
             $gender = (rand(1, 2) == 1) ? 'male' : 'female';
 
             $this->contact = new Contact;
@@ -59,7 +58,7 @@ class FakeContentTableSeeder extends Seeder
             $this->contact->first_name = $this->faker->firstName($gender);
             $this->contact->last_name = (rand(1, 2) == 1) ? $this->faker->lastName : null;
             $this->contact->nickname = (rand(1, 2) == 1) ? $this->faker->name : null;
-            $this->contact->is_starred = (rand(1, 5) == 1) ? true : false;
+            $this->contact->is_starred = (rand(1, 5) == 1);
             $this->contact->has_avatar = false;
             $this->contact->setAvatarColor();
             $this->contact->save();
@@ -257,7 +256,7 @@ class FakeContentTableSeeder extends Seeder
                     'account_id' => $this->contact->account_id,
                 ], ['account_id' => $this->contact->account_id]);
 
-                $entry = DB::table('journal_entries')->insertGetId([
+                DB::table('journal_entries')->insertGetId([
                     'account_id' => $this->account->id,
                     'date' => $date,
                     'journalable_id' => $activity->id,
@@ -326,7 +325,7 @@ class FakeContentTableSeeder extends Seeder
     public function populateAddresses()
     {
         if (rand(1, 3) == 1) {
-            $address = $this->contact->addresses()->create([
+            $this->contact->addresses()->create([
                 'account_id' => $this->contact->account_id,
                 'country' => $this->getRandomCountry(),
                 'name' => $this->faker->word,
@@ -386,7 +385,7 @@ class FakeContentTableSeeder extends Seeder
                     break;
                 }
 
-                $contactField = $this->contact->contactFields()->create([
+                $this->contact->contactFields()->create([
                     'contact_field_type_id' => $contactFieldType->id,
                     'data' => $data,
                     'account_id' => $this->contact->account->id,
@@ -407,7 +406,7 @@ class FakeContentTableSeeder extends Seeder
                 'created_at' => $date,
             ]);
 
-            $journalEntry = DB::table('journal_entries')->insertGetId([
+            DB::table('journal_entries')->insertGetId([
                 'account_id' => $this->account->id,
                 'date' => $date,
                 'journalable_id' => $entryId,
@@ -423,7 +422,7 @@ class FakeContentTableSeeder extends Seeder
             for ($j = 0; $j < rand(1, 3); $j++) {
                 $date = $this->faker->dateTimeThisYear();
 
-                $petId = DB::table('pets')->insertGetId([
+                DB::table('pets')->insertGetId([
                     'account_id' => $this->account->id,
                     'contact_id' => $this->contact->id,
                     'pet_category_id' => rand(1, 11),
@@ -446,7 +445,7 @@ class FakeContentTableSeeder extends Seeder
                 'created_at' => $date,
             ]);
 
-            $journalEntry = DB::table('journal_entries')->insertGetId([
+            DB::table('journal_entries')->insertGetId([
                 'account_id' => $this->account->id,
                 'date' => $date,
                 'journalable_id' => $dayId,
@@ -465,7 +464,7 @@ class FakeContentTableSeeder extends Seeder
     public function populateCalls()
     {
         if (rand(1, 3) == 1) {
-            $calls = $this->contact->calls()->create([
+            $this->contact->calls()->create([
                 'account_id' => $this->contact->account_id,
                 'called_at' => $this->faker->dateTimeThisYear(),
             ]);
@@ -486,12 +485,12 @@ class FakeContentTableSeeder extends Seeder
                 ]);
 
                 for ($k = 0; $k < rand(1, 20); $k++) {
-                    $message = (new AddMessageToConversation)->execute([
+                    (new AddMessageToConversation)->execute([
                         'account_id' => $this->contact->account->id,
                         'contact_id' => $this->contact->id,
                         'conversation_id' => $conversation->id,
                         'written_at' => $this->faker->dateTimeThisCentury(),
-                        'written_by_me' => (rand(1, 2) == 1 ? true : false),
+                        'written_by_me' => (rand(1, 2) == 1),
                         'content' => $this->faker->realText(),
                     ]);
                 }

--- a/tests/Unit/Services/Contact/Conversation/AddMessageToConversationTest.php
+++ b/tests/Unit/Services/Contact/Conversation/AddMessageToConversationTest.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Tests\TestCase;
 use App\Models\Contact\Message;
 use App\Models\Contact\Conversation;
+use App\Exceptions\MissingParameterException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use App\Services\Contact\Conversation\AddMessageToConversation;
@@ -21,7 +22,7 @@ class AddMessageToConversationTest extends TestCase
             'happened_at' => Carbon::now(),
         ];
 
-        $this->expectException(\Exception::class);
+        $this->expectException(MissingParameterException::class);
 
         $addMessageToConversation = new AddMessageToConversation;
         $conversation = $addMessageToConversation->execute($request);

--- a/tests/Unit/Services/Contact/Conversation/CreateConversationTest.php
+++ b/tests/Unit/Services/Contact/Conversation/CreateConversationTest.php
@@ -7,6 +7,7 @@ use Tests\TestCase;
 use App\Models\Contact\Contact;
 use App\Models\Contact\Conversation;
 use App\Models\Contact\ContactFieldType;
+use App\Exceptions\MissingParameterException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use App\Services\Contact\Conversation\CreateConversation;
@@ -54,7 +55,7 @@ class CreateConversationTest extends TestCase
             'happened_at' => Carbon::now(),
         ];
 
-        $this->expectException(\Exception::class);
+        $this->expectException(MissingParameterException::class);
 
         $createConversation = new CreateConversation;
         $conversation = $createConversation->execute($request);

--- a/tests/Unit/Services/Contact/Conversation/DestroyConversationTest.php
+++ b/tests/Unit/Services/Contact/Conversation/DestroyConversationTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Services\Contact\Conversation;
 use Tests\TestCase;
 use App\Models\Contact\Message;
 use App\Models\Contact\Conversation;
+use App\Exceptions\MissingParameterException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use App\Services\Contact\Conversation\DestroyConversation;
@@ -78,7 +79,7 @@ class DestroyConversationTest extends TestCase
             'account_id' => $conversation->account->id,
         ];
 
-        $this->expectException(\Exception::class);
+        $this->expectException(MissingParameterException::class);
 
         $conversationService = new DestroyConversation;
         $bool = $conversationService->execute($request);

--- a/tests/Unit/Services/Contact/Conversation/DestroyMessageTest.php
+++ b/tests/Unit/Services/Contact/Conversation/DestroyMessageTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Services\Contact\Conversation;
 use Tests\TestCase;
 use App\Models\Contact\Message;
 use App\Models\Contact\Conversation;
+use App\Exceptions\MissingParameterException;
 use App\Services\Contact\Conversation\DestroyMessage;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -47,12 +48,11 @@ class DestroyMessageTest extends TestCase
     public function test_it_fails_if_wrong_parameters_are_given()
     {
         $request = [
-            'account_id' => 1,
             'conversation_id' => 2,
             'message_id' => 3,
         ];
 
-        $this->expectException(\Exception::class);
+        $this->expectException(MissingParameterException::class);
 
         $destroyMessage = new DestroyMessage;
         $result = $destroyMessage->execute($request);
@@ -63,9 +63,9 @@ class DestroyMessageTest extends TestCase
         $conversation = factory(Conversation::class)->create([]);
 
         $request = [
-            'account_id' => 231,
+            'account_id' => $conversation->account->id,
             'conversation_id' => $conversation->id,
-            'message_id' => 1293,
+            'message_id' => -1,
         ];
 
         $this->expectException(ModelNotFoundException::class);

--- a/tests/Unit/Services/Contact/Conversation/UpdateConversationTest.php
+++ b/tests/Unit/Services/Contact/Conversation/UpdateConversationTest.php
@@ -7,6 +7,7 @@ use Tests\TestCase;
 use App\Models\Contact\Contact;
 use App\Models\Contact\Conversation;
 use App\Models\Contact\ContactFieldType;
+use App\Exceptions\MissingParameterException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use App\Services\Contact\Conversation\UpdateConversation;
@@ -55,7 +56,7 @@ class UpdateConversationTest extends TestCase
             'happened_at' => Carbon::now(),
         ];
 
-        $this->expectException(\Exception::class);
+        $this->expectException(MissingParameterException::class);
 
         $updateConversation = new UpdateConversation;
         $conversation = $updateConversation->execute($request);

--- a/tests/Unit/Services/Contact/Conversation/UpdateMessageTest.php
+++ b/tests/Unit/Services/Contact/Conversation/UpdateMessageTest.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Tests\TestCase;
 use App\Models\Contact\Message;
 use App\Models\Contact\Conversation;
+use App\Exceptions\MissingParameterException;
 use App\Services\Contact\Conversation\UpdateMessage;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -66,7 +67,7 @@ class UpdateMessageTest extends TestCase
             'content' => 'lorem',
         ];
 
-        $this->expectException(\Exception::class);
+        $this->expectException(MissingParameterException::class);
 
         $updateMessage = new UpdateMessage;
         $conversation = $updateMessage->execute($request);


### PR DESCRIPTION
These try/catch are useless. Use the `MissingParameterException` instead of `\Exception` as well.