### PR TITLE
feat: support papertrail logging

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ UNRELEASED CHANGES:
 * Fix confirm email sent when signup_double_optin is false
 * Fix now() without timezone functions
 * Remove notion of events
+* Support papertrail logging
 
 RELEASED VERSIONS:
 

--- a/config/logging.php
+++ b/config/logging.php
@@ -1,5 +1,8 @@
 <?php
 
+use Monolog\Handler\StreamHandler;
+use Monolog\Handler\SyslogUdpHandler;
+
 return [
     /*
     |--------------------------------------------------------------------------
@@ -48,6 +51,22 @@ return [
             'username' => 'Laravel Log',
             'emoji' => ':boom:',
             'level' => 'critical',
+        ],
+        'papertrail' => [
+            'driver'  => 'monolog',
+            'level' => 'debug',
+            'handler' => SyslogUdpHandler::class,
+            'handler_with' => [
+                'host' => env('PAPERTRAIL_URL'),
+                'port' => env('PAPERTRAIL_PORT'),
+            ],
+        ],
+        'stderr' => [
+            'driver' => 'monolog',
+            'handler' => StreamHandler::class,
+            'with' => [
+                'stream' => 'php://stderr',
+            ],
         ],
         'syslog' => [
             'driver' => 'syslog',


### PR DESCRIPTION
We can use papertrail logging by setting `LOG_CHANNEL=papertrail`