### PR TITLE
feat: add sentry:release command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ yarn-error.log
 php-extensions-*.tar.bz2
 monicadump.sql
 .scannerwork/
+.sentry-release

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ UNRELEASED CHANGES:
 * Fix confirm email sent when signup_double_optin is false
 * Fix now() without timezone functions
 * Remove notion of events
+* Add sentry:release command
 
 RELEASED VERSIONS:
 

--- a/app/Console/Commands/Helpers/CommandExecutor.php
+++ b/app/Console/Commands/Helpers/CommandExecutor.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands\Helpers;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\Application;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class CommandExecutor implements CommandExecutorInterface
@@ -25,14 +26,12 @@ class CommandExecutor implements CommandExecutorInterface
     public function exec($message, $commandline)
     {
         $this->command->info($message);
-        $this->command->line($commandline);
+        $this->command->line($commandline, null, OutputInterface::VERBOSITY_VERBOSE);
         exec($commandline.' 2>&1', $output);
-        if ($this->command->getOutput()->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
-            foreach ($output as $line) {
-                $this->command->line($line);
-            }
+        foreach ($output as $line) {
+            $this->command->line($line, null, OutputInterface::VERBOSITY_VERY_VERBOSE);
         }
-        $this->command->line('');
+        $this->command->line('', null, OutputInterface::VERBOSITY_VERBOSE);
     }
 
     public function artisan($message, $commandline, array $arguments = [])
@@ -45,6 +44,6 @@ class CommandExecutor implements CommandExecutorInterface
                 $info .= ' '.$value;
             }
         }
-        $this->exec($message, 'php artisan '.$commandline.$info);
+        $this->exec($message, Application::formatCommandString($commandline.$info));
     }
 }

--- a/app/Console/Commands/SentryRelease.php
+++ b/app/Console/Commands/SentryRelease.php
@@ -76,38 +76,7 @@ class SentryRelease extends Command
      */
     public function handle()
     {
-        if (! $this->confirmToProceed()) {
-            return;
-        }
-
-        if (empty(config('sentry.auth_token'))) {
-            $this->error('You must provide an auth_token (SENTRY_AUTH_TOKEN)');
-
-            return;
-        }
-        if (empty(config('sentry.organisation'))) {
-            $this->error('You must provide an organisation slug (SENTRY_ORG)');
-
-            return;
-        }
-        if (empty(config('sentry.project'))) {
-            $this->error('You must set the project (SENTRY_PROJECT)');
-
-            return;
-        }
-        if (empty(config('sentry.repo'))) {
-            $this->error('You must set the repository (SENTRY_REPO)');
-
-            return;
-        }
-        if (empty($this->option('release'))) {
-            $this->error('No release given');
-
-            return;
-        }
-        if (empty($this->option('environment'))) {
-            $this->error('No environment given');
-
+        if (! $this->confirmToProceed() || ! $this->check()) {
             return;
         }
 
@@ -129,6 +98,36 @@ class SentryRelease extends Command
         // Set sentry release
         $this->line('Store release in .sentry-release file', OutputInterface::VERBOSITY_VERBOSE);
         file_put_contents(__DIR__.'/../../../.sentry-release', $this->option('release'));
+    }
+
+    private function check() : bool
+    {
+        $check = true;
+        if (empty(config('sentry.auth_token'))) {
+            $this->error('You must provide an auth_token (SENTRY_AUTH_TOKEN)');
+            $check = false;
+        }
+        if (empty(config('sentry.organisation'))) {
+            $this->error('You must provide an organisation slug (SENTRY_ORG)');
+            $check = false;
+        }
+        if (empty(config('sentry.project'))) {
+            $this->error('You must set the project (SENTRY_PROJECT)');
+            $check = false;
+        }
+        if (empty(config('sentry.repo'))) {
+            $this->error('You must set the repository (SENTRY_REPO)');
+            $check = false;
+        }
+        if (empty($this->option('release'))) {
+            $this->error('No release given');
+            $check = false;
+        }
+        if (empty($this->option('environment'))) {
+            $this->error('No environment given');
+            $check = false;
+        }
+        return $check;
     }
 
     private function getSentryCli()

--- a/app/Console/Commands/SentryRelease.php
+++ b/app/Console/Commands/SentryRelease.php
@@ -4,8 +4,8 @@ namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
-use Symfony\Component\Console\Output\OutputInterface;
 use App\Console\Commands\Helpers\CommandExecutor;
+use Symfony\Component\Console\Output\OutputInterface;
 use App\Console\Commands\Helpers\CommandExecutorInterface;
 
 class SentryRelease extends Command
@@ -30,26 +30,25 @@ class SentryRelease extends Command
     protected $description = 'Create a release for sentry';
 
     /**
-     * Installation path of sentry cli
-     * 
+     * Installation path of sentry cli.
+     *
      * @var string
      */
     private $install_dir;
 
     /**
-     * sentry cli name
-     * 
+     * sentry cli name.
+     *
      * @var string
      */
-    private const SENTRY_CLI = "sentry-cli";
+    private const SENTRY_CLI = 'sentry-cli';
 
     /**
-     * Sentry cli download url
-     * 
+     * Sentry cli download url.
+     *
      * @var string
      */
-    private const SENTRY_URL = "https://sentry.io/get-cli/";
-
+    private const SENTRY_URL = 'https://sentry.io/get-cli/';
 
     /**
      * The Command Executor.
@@ -66,7 +65,7 @@ class SentryRelease extends Command
     public function __construct()
     {
         $this->commandExecutor = new CommandExecutor($this);
-        $this->install_dir = getenv("HOME")."/.local/bin";
+        $this->install_dir = getenv('HOME').'/.local/bin';
         parent::__construct();
     }
 
@@ -83,32 +82,37 @@ class SentryRelease extends Command
 
         if (empty(config('sentry.auth_token'))) {
             $this->error('You must provide an auth_token (SENTRY_AUTH_TOKEN)');
+
             return;
         }
         if (empty(config('sentry.organisation'))) {
-            $this->error('You must provide an organisation slug (SENTRY_ORG)');            
+            $this->error('You must provide an organisation slug (SENTRY_ORG)');
+
             return;
         }
         if (empty(config('sentry.project'))) {
-            $this->error('You must set the project (SENTRY_PROJECT)');            
+            $this->error('You must set the project (SENTRY_PROJECT)');
+
             return;
         }
         if (empty(config('sentry.repo'))) {
-            $this->error('You must set the repository (SENTRY_REPO)');            
+            $this->error('You must set the repository (SENTRY_REPO)');
+
             return;
         }
         if (empty($this->option('release'))) {
-            $this->error('No release given');            
+            $this->error('No release given');
+
             return;
         }
         if (empty($this->option('environment'))) {
-            $this->error('No environment given');            
+            $this->error('No environment given');
+
             return;
         }
 
         $release = $this->option('release');
         $commit = $this->option('commit') ?? (is_dir(__DIR__.'/../../../.git') ? trim(exec('git log --pretty="%H" -n1 HEAD')) : $this->option('release'));
-
 
         // Sentry update
         $this->commandExecutor->exec('Update sentry', $this->getSentryCli().' update');
@@ -127,11 +131,13 @@ class SentryRelease extends Command
         file_put_contents(__DIR__.'/../../../.sentry-release', $this->option('release'));
     }
 
-    private function getSentryCli() {
+    private function getSentryCli()
+    {
         if (! file_exists($this->install_dir.'/'.self::SENTRY_CLI)) {
             mkdir($this->install_dir);
             $this->commandExecutor->exec('Downloading sentry-cli', 'curl -sL '.self::SENTRY_URL.' | INSTALL_DIR='.$this->install_dir.' bash');
         }
+
         return $this->install_dir.'/'.self::SENTRY_CLI;
     }
 

--- a/app/Console/Commands/SentryRelease.php
+++ b/app/Console/Commands/SentryRelease.php
@@ -127,6 +127,7 @@ class SentryRelease extends Command
             $this->error('No environment given');
             $check = false;
         }
+
         return $check;
     }
 

--- a/app/Console/Commands/SentryRelease.php
+++ b/app/Console/Commands/SentryRelease.php
@@ -76,7 +76,7 @@ class SentryRelease extends Command
      */
     public function handle()
     {
-        if (! $this->confirmToProceed() || ! $this->check()) {
+        if (! $this->confirmToProceed() || ! config('monica.sentry_support') || ! $this->check()) {
             return;
         }
 

--- a/app/Console/Commands/SentryRelease.php
+++ b/app/Console/Commands/SentryRelease.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
+use Symfony\Component\Console\Output\OutputInterface;
+use App\Console\Commands\Helpers\CommandExecutor;
+use App\Console\Commands\Helpers\CommandExecutorInterface;
+
+class SentryRelease extends Command
+{
+    use ConfirmableTrait;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'sentry:release
+                            {--release= : release version for sentry}
+                            {--commit= : commit associated with this release}
+                            {--environment= : sentry environment}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a release for sentry';
+
+    /**
+     * Installation path of sentry cli
+     * 
+     * @var string
+     */
+    private $install_dir;
+
+    /**
+     * sentry cli name
+     * 
+     * @var string
+     */
+    private const SENTRY_CLI = "sentry-cli";
+
+    /**
+     * Sentry cli download url
+     * 
+     * @var string
+     */
+    private const SENTRY_URL = "https://sentry.io/get-cli/";
+
+
+    /**
+     * The Command Executor.
+     *
+     * @var CommandExecutorInterface
+     */
+    public $commandExecutor;
+
+    /**
+     * Create a new command.
+     *
+     * @param CommandExecutorInterface
+     */
+    public function __construct()
+    {
+        $this->commandExecutor = new CommandExecutor($this);
+        $this->install_dir = getenv("HOME")."/.local/bin";
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        if (! $this->confirmToProceed()) {
+            return;
+        }
+
+        if (empty(config('sentry.auth_token'))) {
+            $this->error('You must provide an auth_token (SENTRY_AUTH_TOKEN)');
+            return;
+        }
+        if (empty(config('sentry.organisation'))) {
+            $this->error('You must provide an organisation slug (SENTRY_ORG)');            
+            return;
+        }
+        if (empty(config('sentry.project'))) {
+            $this->error('You must set the project (SENTRY_PROJECT)');            
+            return;
+        }
+        if (empty(config('sentry.repo'))) {
+            $this->error('You must set the repository (SENTRY_REPO)');            
+            return;
+        }
+        if (empty($this->option('release'))) {
+            $this->error('No release given');            
+            return;
+        }
+        if (empty($this->option('environment'))) {
+            $this->error('No environment given');            
+            return;
+        }
+
+        $release = $this->option('release');
+        $commit = $this->option('commit') ?? (is_dir(__DIR__.'/../../../.git') ? trim(exec('git log --pretty="%H" -n1 HEAD')) : $this->option('release'));
+
+
+        // Sentry update
+        $this->commandExecutor->exec('Update sentry', $this->getSentryCli().' update');
+
+        // Create a release
+        $this->execSentryCli('Create a release', 'releases new '.$release.' --finalize --project '.config('sentry.project'));
+
+        // Associate commits with the release
+        $this->execSentryCli('Associate commits with the release', 'releases set-commits '.$release.' --commit "'.config('sentry.repo').'@'.$commit.'"');
+
+        // Create a deploy
+        $this->execSentryCli('Create a deploy', 'releases deploys '.$release.' new --env '.$this->option('environment').' --name '.$commit);
+
+        // Set sentry release
+        $this->line('Store release in .sentry-release file', OutputInterface::VERBOSITY_VERBOSE);
+        file_put_contents(__DIR__.'/../../../.sentry-release', $this->option('release'));
+    }
+
+    private function getSentryCli() {
+        if (! file_exists($this->install_dir.'/'.self::SENTRY_CLI)) {
+            mkdir($this->install_dir);
+            $this->commandExecutor->exec('Downloading sentry-cli', 'curl -sL '.self::SENTRY_URL.' | INSTALL_DIR='.$this->install_dir.' bash');
+        }
+        return $this->install_dir.'/'.self::SENTRY_CLI;
+    }
+
+    private function execSentryCli($message, $command)
+    {
+        $this->commandExecutor->exec($message, $this->getSentryCli().' '.$command);
+    }
+}

--- a/app/Console/Commands/SetupTest.php
+++ b/app/Console/Commands/SetupTest.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\Application;
 
 class SetupTest extends Command
 {
@@ -67,7 +68,7 @@ class SetupTest extends Command
     public function artisan($message, $command, array $arguments = [])
     {
         $this->info($message);
-        $this->line('php artisan '.$command);
+        $this->line(Application::formatCommandString($command));
         $this->callSilent($command, $arguments);
         $this->line('');
     }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -23,6 +23,7 @@ class Kernel extends ConsoleKernel
         'App\Console\Commands\SendNotifications',
         'App\Console\Commands\SendReminders',
         'App\Console\Commands\SendStayInTouch',
+        'App\Console\Commands\SentryRelease',
         'App\Console\Commands\SetupProduction',
         'App\Console\Commands\SetupTest',
         'App\Console\Commands\SetupFrontEndTest',

--- a/config/sentry.php
+++ b/config/sentry.php
@@ -1,14 +1,72 @@
 <?php
 
 return [
+    /*
+    |--------------------------------------------------------------------------
+    | Sentry dsn
+    |--------------------------------------------------------------------------
+    |
+    | Do not put your secret!
+    | See https://sentry.io/settings/{slug}/{project}/keys/
+    |
+    */
     'dsn' => env('SENTRY_LARAVEL_DSN'),
 
-    // capture release as git sha
-    'release' => is_dir(__DIR__.'/../.git') ? trim(exec('git log --pretty="%h" -n1 HEAD')) : null,
+    /*
+    |--------------------------------------------------------------------------
+    | Release number
+    |--------------------------------------------------------------------------
+    |
+    | Stored in .sentry-release file, or get from git commit number
+    |
+    */
+    'release' => is_file(__DIR__.'/../.sentry-release') ? file_get_contents(__DIR__.'/../.sentry-release') : (is_dir(__DIR__.'/../.git') ? trim(exec('git log --pretty="%h" -n1 HEAD')) : null),
 
-    // Capture bindings on SQL queries
+    /*
+    |--------------------------------------------------------------------------
+    | Capture bindings on SQL queries
+    |--------------------------------------------------------------------------
+    */
     'breadcrumbs.sql_bindings' => true,
 
-    // Capture default user context
+    /*
+    |--------------------------------------------------------------------------
+    | Capture default user context
+    |--------------------------------------------------------------------------
+    */
     'user_context' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Auth token for api calls
+    |--------------------------------------------------------------------------
+    |
+    | See https://sentry.io/settings/account/api/auth-tokens/
+    |
+    */
+    'auth_token' => env('SENTRY_AUTH_TOKEN'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Organisation slug
+    |--------------------------------------------------------------------------
+    */
+    'organisation' => env('SENTRY_ORG'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Project
+    |--------------------------------------------------------------------------
+    */
+    'project' => env('SENTRY_PROJECT'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Git repository set in sentry
+    |--------------------------------------------------------------------------
+    |
+    | See https://sentry.io/settings/{slug}/repos/
+    |
+    */
+    'repo' => env('SENTRY_REPO', 'monicahq/monica')
 ];

--- a/config/sentry.php
+++ b/config/sentry.php
@@ -68,5 +68,5 @@ return [
     | See https://sentry.io/settings/{slug}/repos/
     |
     */
-    'repo' => env('SENTRY_REPO', 'monicahq/monica')
+    'repo' => env('SENTRY_REPO', 'monicahq/monica'),
 ];

--- a/tests/Browser/Settings/MultiFAControllerTest.php
+++ b/tests/Browser/Settings/MultiFAControllerTest.php
@@ -6,6 +6,7 @@ use Zxing\QrReader;
 use Tests\DuskTestCase;
 use App\Models\User\User;
 use Laravel\Dusk\Browser;
+use Illuminate\Console\Application;
 use Tests\Browser\Pages\SettingsSecurity;
 use Tests\Browser\Pages\DashboardValidate2fa;
 
@@ -16,7 +17,7 @@ class MultiFAControllerTest extends DuskTestCase
      */
     public function cleanup()
     {
-        exec('php artisan 2fa:deactivate --force --email=admin@admin.com', $output);
+        exec(Application::formatCommandString('2fa:deactivate --force --email=admin@admin.com'), $output);
         //$this->log(implode($output));
     }
 


### PR DESCRIPTION
Add a new command to deploy a new release to sentry.

Usage: (example)
`php artisan sentry:release --release=$(php artisan monica:getversion) --environment=production --commit=$(git log --pretty="%H" -n1 HEAD) -vv`
The command will store the 'release' parameter in an new file `.sentry-release` which is then used at runtime (don't forget to run `config:cache` for performances)

This way we can run this command, even if we are not on a git repository (like on fortrabbit ...)