### PR TITLE
fix: fix use of 'json' column type

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ UNRELEASED CHANGES:
 * Add ability to set a reminder for a life event
 * Stop reporting OAuth exceptions
 * Replace karakus/laravel-cloudflare with monicahq/laravel-cloudflare to fix dependencies issues
+* Fix use of 'json' mysql column type
 
 RELEASED VERSIONS:
 

--- a/database/migrations/2018_08_31_020908_create_life_events_table.php
+++ b/database/migrations/2018_08_31_020908_create_life_events_table.php
@@ -27,7 +27,7 @@ class CreateLifeEventsTable extends Migration
             $table->increments('id');
             $table->unsignedInteger('default_life_event_category_id');
             $table->string('translation_key');
-            $table->json('specific_information_structure');
+            $table->text('specific_information_structure');
             $table->boolean('migrated')->default(0);
             $table->timestamps();
             $table->foreign('default_life_event_category_id')->references('id')->on('default_life_event_categories')->onDelete('cascade');
@@ -57,7 +57,7 @@ class CreateLifeEventsTable extends Migration
             $table->string('name');
             $table->string('default_life_event_type_key')->nullable();
             $table->boolean('core_monica_data')->default(0);
-            $table->json('specific_information_structure')->nullable();
+            $table->text('specific_information_structure')->nullable();
             $table->timestamps();
             $table->foreign('account_id')->references('id')->on('accounts')->onDelete('cascade');
             $table->foreign('life_event_category_id')->references('id')->on('life_event_categories')->onDelete('cascade');
@@ -73,7 +73,7 @@ class CreateLifeEventsTable extends Migration
             $table->dateTime('happened_at');
             $table->boolean('happened_at_month_unknown')->default(false);
             $table->boolean('happened_at_day_unknown')->default(false);
-            $table->json('specific_information')->nullable();
+            $table->text('specific_information')->nullable();
             $table->timestamps();
             $table->foreign('account_id')->references('id')->on('accounts')->onDelete('cascade');
             $table->foreign('contact_id')->references('id')->on('contacts')->onDelete('cascade');

--- a/database/migrations/2018_10_07_120133_fix_json_column.php
+++ b/database/migrations/2018_10_07_120133_fix_json_column.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class FixJsonColumn extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $connection = DB::connection();
+
+        if ($connection->getDriverName() != 'mysql') {
+            return;
+        }
+
+        $databasename = $connection->getDatabaseName();
+
+        $columns = $connection->table('information_schema.columns')
+                            ->select('table_name', 'column_name')
+                            ->where([
+                                ['table_schema', '=', $databasename],
+                                ['data_type', '=', 'json']
+                            ])
+                            ->whereIn('table_name', [
+                                'default_life_event_types',
+                                'life_event_types',
+                                'life_events'
+                            ])
+                            ->get();
+        
+        foreach ($columns as $column) {
+            DB::statement('ALTER TABLE `'.$databasename.'`.`'.$column->table_name.'` MODIFY `'.$column->column_name.'` text;');
+        }
+    }
+}

--- a/database/migrations/2018_10_07_120133_fix_json_column.php
+++ b/database/migrations/2018_10_07_120133_fix_json_column.php
@@ -1,8 +1,6 @@
 <?php
 
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
 class FixJsonColumn extends Migration
@@ -26,15 +24,15 @@ class FixJsonColumn extends Migration
                             ->select('table_name', 'column_name')
                             ->where([
                                 ['table_schema', '=', $databasename],
-                                ['data_type', '=', 'json']
+                                ['data_type', '=', 'json'],
                             ])
                             ->whereIn('table_name', [
                                 'default_life_event_types',
                                 'life_event_types',
-                                'life_events'
+                                'life_events',
                             ])
                             ->get();
-        
+
         foreach ($columns as $column) {
             DB::statement('ALTER TABLE `'.$databasename.'`.`'.$column->table_name.'` MODIFY `'.$column->column_name.'` text;');
         }


### PR DESCRIPTION
Fix using the type 'json' for a column type, which is available on mysql > 5.7.8 only.

This fix #1882 