### PR TITLE
fix: fix task remove after events table removal

### DIFF
--- a/app/Http/Controllers/Contacts/TasksController.php
+++ b/app/Http/Controllers/Contacts/TasksController.php
@@ -83,7 +83,5 @@ class TasksController extends Controller
     public function destroy(Contact $contact, Task $task)
     {
         $task->delete();
-
-        $contact->events()->forObject($task)->get()->each->delete();
     }
 }


### PR DESCRIPTION
events table has been removed in #1829. This line has been missed.

Fix #1922