### PR TITLE
fix: tag filter for non-english characters works now

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -36,3 +36,4 @@ Andrew Paul Smith <github@chucklesthebeard.com>
 Brian Clemens <brian@tiuxo.com>
 Christopher Zentgraf @TheZenti <git@the-zenti.de>
 Lorenzo L. Ancora @LorenzoAncora <admin@lorenzoancora.info>
+Benjamin Dowson @lattlay <bdowson7@gmail.com>

--- a/app/Models/Contact/Contact.php
+++ b/app/Models/Contact/Contact.php
@@ -1398,6 +1398,11 @@ class Contact extends Model
         ]);
 
         $tag->name_slug = str_slug($tag->name);
+
+        if(empty($tag->name_slug)) {
+            $tag->name_slug = htmlentities($tag->name);
+        }
+
         $tag->save();
 
         $this->tags()->syncWithoutDetaching([$tag->id => ['account_id' => $this->account_id]]);

--- a/database/migrations/2018_10_27_230346_fix_non_english_tab_slugs.php
+++ b/database/migrations/2018_10_27_230346_fix_non_english_tab_slugs.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+class FixNonEnglishTabSlugs extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::table('tags')->update(['name_slug' => DB::raw('`name`')]);
+    }
+}

--- a/tests/Unit/Models/ContactTest.php
+++ b/tests/Unit/Models/ContactTest.php
@@ -953,6 +953,22 @@ class ContactTest extends FeatureTestCase
         );
     }
 
+    public function test_it_creates_a_non_english_tag_and_sets_it_to_a_contact()
+    {
+        $user = $this->signIn();
+
+        $contact = factory(Contact::class)->create(['account_id' => $user->account->id]);
+        $tag = $contact->setTag('朋友');
+
+        $this->assertDatabaseHas(
+            'tags',
+            [
+                'name' => '朋友',
+                'name_slug' => '朋友',
+            ]
+        );
+    }
+
     public function test_it_uses_an_existing_tag_to_associate_it_with_the_contact()
     {
         $user = $this->signIn();


### PR DESCRIPTION
Previously, adding a non-English tag was not saving the `name_slug` field correctly. This patch fixes that, and included is a migration to fix all currently affected tags.

Fix for: https://github.com/monicahq/monica/issues/1959