### PR TITLE
fix: fix to display non latin names on the dashboard

### DIFF
--- a/app/Models/Contact/Contact.php
+++ b/app/Models/Contact/Contact.php
@@ -5,6 +5,7 @@ namespace App\Models\Contact;
 use App\Helpers\DBHelper;
 use App\Models\User\User;
 use App\Traits\Searchable;
+use Illuminate\Support\Str;
 use App\Models\Journal\Entry;
 use App\Models\Account\Account;
 use Illuminate\Support\Collection;
@@ -529,7 +530,7 @@ class Contact extends Model
      */
     public function getInitialsAttribute()
     {
-        preg_match_all('/(?<=\s|^)[a-zA-Z0-9]/i', $this->name, $initials);
+        preg_match_all('/(?<=\s|^)[a-zA-Z0-9]/i', Str::ascii($this->name), $initials);
 
         return implode('', $initials[0]);
     }


### PR DESCRIPTION
Quick fix to show latin initials for non-latin names.

Example:
<img width="759" alt="screenshot 2018-10-29 at 18 06 58" src="https://user-images.githubusercontent.com/2152882/47659200-7abb9280-dba5-11e8-8e72-a2bc0e057106.png">

Example:
<img width="748" alt="screenshot 2018-10-29 at 18 08 15" src="https://user-images.githubusercontent.com/2152882/47659269-a9396d80-dba5-11e8-94a2-0ad224c109d4.png">
