### PR TITLE
fix: fix editing conversations

### DIFF
--- a/resources/views/people/conversations/edit.blade.php
+++ b/resources/views/people/conversations/edit.blade.php
@@ -27,7 +27,8 @@
 
     @include('partials.errors')
 
-    <form action="{{ route('people.conversations.update', [$contact, $conversation]) }}" method="POST">
+    <form action="{{ route('people.conversations.update', [$contact, $conversation]) }}" method="POST" enctype="multipart/form-data">
+      @method('PUT')
       {{ csrf_field() }}
 
       {{-- When did it take place --}}


### PR DESCRIPTION
Fixing method errors for editing conversations (#2038) by using the right method in the form.