### PR TITLE
fix: fix dashboard stats spacing

### DIFF
--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -68,15 +68,15 @@
           <div class="br3 ba b--gray-monica bg-white mb3">
             <div class="pa3 bb b--gray-monica tc">
               <ul>
-                <li class="tc dib mr5">
+                <li class="tc dib fl w-third">
                   <span class="db f3 fw5 green">{{ $number_of_contacts }}</span>
                   <span class="stat-description">{{ trans('dashboard.statistics_contacts') }}</span>
                 </li>
-                <li class="tc dib mr5">
+                <li class="tc dib fl w-third">
                   <span class="db f3 fw5 blue">{{ $number_of_activities }}</span>
                   <span class="stat-description">{{ trans('dashboard.statistics_activities') }}</span>
                 </li>
-                <li class="tc dib mr5">
+                <li class="tc dib w-third">
                   <span class="db f3 fw5 orange">{{ $number_of_gifts }}</span>
                   <span class="stat-description">{{ trans('dashboard.statistics_gifts') }}</span>
                 </li>


### PR DESCRIPTION
fixes #2109 

Currently the numerical stats on the dashboard are not spaced out correctly resulting in misaligned stats on desktop and an overflow on mobile. This PR fixes the problem by replacing the previous fixed-width borders with a responsive tachyons grid. The screenshots show the current and new situation:

**Desktop:**
Current:
<img width="485" alt="screenshot 2018-11-27 at 11 09 44" src="https://user-images.githubusercontent.com/19996174/49075115-7337e980-f236-11e8-95dc-c1503efd4530.png">

New:
<img width="491" alt="screenshot 2018-11-27 at 11 09 23" src="https://user-images.githubusercontent.com/19996174/49075120-759a4380-f236-11e8-88ee-8357800a2b9b.png">

**Mobile:**
Current:
<img width="377" alt="screenshot 2018-11-27 at 11 08 22" src="https://user-images.githubusercontent.com/19996174/49075128-7b902480-f236-11e8-91cf-0b5b72b4acc2.png">

New:
<img width="380" alt="screenshot 2018-11-27 at 11 07 42" src="https://user-images.githubusercontent.com/19996174/49075140-7fbc4200-f236-11e8-872e-fd012fa3b43f.png">

Pinging @djaiss as this is a UI change.