### PR TITLE
fix: fix setTag api method which deleted existing tags

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 UNRELEASED CHANGES:
 
+* Fix Set Tag api method which deleted existing tags, which it shouldn't
 * Fix editing relationship not working
 * Fix Storage page not being displayed
 * Add ability to create tasks that are not linked to any contacts

--- a/app/Http/Controllers/Api/ApiContactTagController.php
+++ b/app/Http/Controllers/Api/ApiContactTagController.php
@@ -25,16 +25,6 @@ class ApiContactTagController extends ApiController
             return $contact;
         }
 
-        // detach all existing tags
-        $contactTags = $contact->tags()->get();
-        foreach ($contactTags as $tag) {
-            (new DetachTag)->execute([
-                'account_id' => auth()->user()->account->id,
-                'contact_id' => $contact->id,
-                'tag_id' => $tag->id,
-            ]);
-        }
-
         $tags = $request->get('tags');
         foreach ($tags as $tag) {
             (new AssociateTag)->execute([


### PR DESCRIPTION
This will close #2119 

The problem is that `SetTags` deleted existing tags, which it shouldn't. This method should only add new ones.