### PR TITLE
fix: change contact list class to allow following link

### DIFF
--- a/resources/views/people/modal/activity_view.blade.php
+++ b/resources/views/people/modal/activity_view.blade.php
@@ -12,7 +12,7 @@
 
               <label for="summary">{{ trans('people.activities_who_was_involved') }}</label>
                   <ul class="contacts">
-                      <ul class="contacts-list">
+                      <ul class="contacts-list-clickable">
                           @foreach ($activity->contacts as $contact)
                               <li class="pretty-tag"><a href="{{ route('people.show', $contact) }}">{{ $contact->first_name }} {{ $contact->last_name }}</a></li>
                           @endforeach

--- a/resources/views/people/modal/activity_view.blade.php
+++ b/resources/views/people/modal/activity_view.blade.php
@@ -12,11 +12,9 @@
 
               <label for="summary">{{ trans('people.activities_who_was_involved') }}</label>
                   <ul class="contacts">
-                      <ul class="contacts-list-clickable">
-                          @foreach ($activity->contacts as $contact)
-                              <li class="pretty-tag"><a href="{{ route('people.show', $contact) }}">{{ $contact->first_name }} {{ $contact->last_name }}</a></li>
-                          @endforeach
-                      </ul>
+                      @foreach ($activity->contacts as $contact)
+                          <li class="pretty-tag"><a href="{{ route('people.show', $contact) }}">{{ $contact->first_name }} {{ $contact->last_name }}</a></li>
+                      @endforeach
                   </ul>
                   <br>
 


### PR DESCRIPTION
This changes the class of the contact list `ul` element on the modal activity view to allow clicking names to work as intended (closes #2048).