### PR TITLE
feat: carddav: support sync-token

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@ New features:
 *
 
 Enhancements:
-*
+* Carddav: support sync-token (rfc6578)
 
 Fixes:
 * Fix exception when user is logged out (again)

--- a/app/Http/Controllers/CardDAV/CardDAVController.php
+++ b/app/Http/Controllers/CardDAV/CardDAVController.php
@@ -10,6 +10,7 @@ use Sabre\DAV\Server as SabreServer;
 use Sabre\DAVACL\Plugin as AclPlugin;
 use Sabre\DAVACL\PrincipalCollection;
 use Sabre\DAV\Auth\Plugin as AuthPlugin;
+use Sabre\DAV\Sync\Plugin as SyncPlugin;
 use Barryvdh\Debugbar\Facade as Debugbar;
 use Sabre\CardDAV\Plugin as CardDAVPlugin;
 use App\Models\CardDAV\MonicaAddressBookRoot;
@@ -102,6 +103,9 @@ class CardDAVController extends Controller
 
         // CardDAV plugin
         $server->addPlugin(new CardDAVPlugin());
+
+        // Sync Plugin - rfc6578
+        $server->addPlugin(new SyncPlugin());
 
         // ACL plugnin
         $aclPlugin = new AclPlugin();

--- a/app/Models/CardDAV/Backends/MonicaCardDAVBackend.php
+++ b/app/Models/CardDAV/Backends/MonicaCardDAVBackend.php
@@ -3,15 +3,19 @@
 namespace App\Models\CardDAV\Backends;
 
 use Sabre\DAV;
+use App\Helpers\DateHelper;
+use App\Models\User\SyncToken;
 use App\Models\Contact\Contact;
 use Sabre\VObject\Component\VCard;
 use App\Services\VCard\ExportVCard;
 use App\Services\VCard\ImportVCard;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Auth;
+use Sabre\CardDAV\Backend\SyncSupport;
+use Sabre\CardDAV\Plugin as CardDAVPlugin;
 use Sabre\CardDAV\Backend\AbstractBackend;
 
-class MonicaCardDAVBackend extends AbstractBackend
+class MonicaCardDAVBackend extends AbstractBackend implements SyncSupport
 {
     /**
      * Returns the list of addressbooks for a specific user.
@@ -32,13 +36,182 @@ class MonicaCardDAVBackend extends AbstractBackend
      */
     public function getAddressBooksForUser($principalUri)
     {
+        $name = Auth::user()->name;
+        $token = $this->getSyncToken();
         return [
             [
-                'id'                => '0',
-                'uri'               => 'contacts',
-                'principaluri'      => MonicaPrincipalBackend::getPrincipalUser(),
-                '{DAV:}displayname' => Auth::user()->name,
+                'id'                                 => '0',
+                'uri'                                => 'contacts',
+                'principaluri'                       => MonicaPrincipalBackend::getPrincipalUser(),
+                '{DAV:}displayname'                  => $name,
+                '{http://sabredav.org/ns}sync-token' => $token,
+                '{DAV:}sync-token'                   => $token,
+                '{' . CardDAVPlugin::NS_CARDDAV . '}addressbook-description' => $name,
             ],
+        ];
+    }
+
+    /**
+     * This method returns a sync-token for this collection.
+     *
+     * If null is returned from this function, the plugin assumes there's no
+     * sync information available.
+     *
+     * @return string|null
+     */
+    public function getSyncToken()
+    {
+        $tokens = SyncToken::where([
+            ['account_id', Auth::user()->account_id],
+            ['user_id', Auth::user()->id]
+        ])
+            ->orderBy('created_at')
+            ->get();
+        
+        if ($tokens->count() <= 0) {
+            $token = $this->createSyncToken();
+        } else {
+            $token = $tokens->last();
+        }
+
+        return $token->id;
+    }
+
+    /**
+     * Create a token
+     * 
+     * @return SyncToken
+     */
+    private function createSyncToken()
+    {
+        $max = $this->getLastModified();
+        return SyncToken::create([
+            'account_id' => Auth::user()->account_id,
+            'user_id' => Auth::user()->id,
+            'timestamp' => $max
+        ]);
+    }
+
+    /**
+     * Returns the collection of all active contacts.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    private function getContacts()
+    {
+        return Auth::user()->account
+                    ->contacts()
+                    ->real()
+                    ->active()
+                    ->get();
+    }
+
+    /**
+     * Returns the last modification date as a unix timestamp.
+     *
+     * @return string
+     */
+    public function getLastModified()
+    {
+        return $this->getContacts()->max('updated_at');
+    }
+
+    /**
+     * The getChanges method returns all the changes that have happened, since
+     * the specified syncToken in the specified address book.
+     *
+     * This function should return an array, such as the following:
+     *
+     * [
+     *   'syncToken' => 'The current synctoken',
+     *   'added'   => [
+     *      'new.txt',
+     *   ],
+     *   'modified'   => [
+     *      'modified.txt',
+     *   ],
+     *   'deleted' => [
+     *      'foo.php.bak',
+     *      'old.txt'
+     *   ]
+     * ];
+     *
+     * The returned syncToken property should reflect the *current* syncToken
+     * of the calendar, as reported in the {http://sabredav.org/ns}sync-token
+     * property. This is needed here too, to ensure the operation is atomic.
+     *
+     * If the $syncToken argument is specified as null, this is an initial
+     * sync, and all members should be reported.
+     *
+     * The modified property is an array of nodenames that have changed since
+     * the last token.
+     *
+     * The deleted property is an array with nodenames, that have been deleted
+     * from collection.
+     *
+     * The $syncLevel argument is basically the 'depth' of the report. If it's
+     * 1, you only have to report changes that happened only directly in
+     * immediate descendants. If it's 2, it should also include changes from
+     * the nodes below the child collections. (grandchildren)
+     *
+     * The $limit argument allows a client to specify how many results should
+     * be returned at most. If the limit is not specified, it should be treated
+     * as infinite.
+     *
+     * If the limit (infinite or not) is higher than you're willing to return,
+     * you should throw a Sabre\DAV\Exception\TooMuchMatches() exception.
+     *
+     * If the syncToken is expired (due to data cleanup) or unknown, you must
+     * return null.
+     *
+     * The limit is 'suggestive'. You are free to ignore it.
+     *
+     * @param string $addressBookId
+     * @param string $syncToken
+     * @param int $syncLevel
+     * @param int $limit
+     * @return array
+     */
+    public function getChangesForAddressBook($addressBookId, $syncToken, $syncLevel, $limit = null)
+    {
+        $token = null;
+        $timestamp = null;
+        if (!empty($syncToken)) {
+            $token = SyncToken::where([
+                'account_id' => Auth::user()->account_id,
+                'user_id' => Auth::user()->id
+            ])->find($syncToken);
+
+            if (is_null($token)) {
+                // syncToken is not recognized
+                return null;
+            }
+
+            $timestamp = $token->timestamp;
+        } else {
+            $token = $this->createSyncToken();
+            $timestamp = DateHelper::parseDateTime('0001-01-01 00:00:00');
+        }
+
+        $contacts = $this->getContacts();
+
+        $modified = $contacts->filter(function ($contact) use ($timestamp) {
+            return $contact->updated_at > $timestamp &&
+                   $contact->created_at < $timestamp;
+        });
+        $added = $contacts->filter(function ($contact) use ($timestamp) {
+            return $contact->created_at >= $timestamp;
+        });
+
+        return [
+            'syncToken' => $token->id,
+            'added' => $added->map(function($contact) {
+                return $this->encodeUri($contact);
+            })->toArray(),
+            'modified' => $modified->map(function($contact) {
+                return $this->encodeUri($contact);
+            })->toArray(),
+            'deleted' => []
         ];
     }
 

--- a/app/Models/CardDAV/Backends/MonicaCardDAVBackend.php
+++ b/app/Models/CardDAV/Backends/MonicaCardDAVBackend.php
@@ -3,7 +3,6 @@
 namespace App\Models\CardDAV\Backends;
 
 use Sabre\DAV;
-use App\Helpers\DateHelper;
 use App\Models\User\SyncToken;
 use App\Models\Contact\Contact;
 use Sabre\VObject\Component\VCard;
@@ -298,7 +297,7 @@ class MonicaCardDAVBackend extends AbstractBackend implements SyncSupport
 
     /**
      * Returns the contact for the specific uri.
-     * 
+     *
      * @param string  $uri
      * @return Contact
      */

--- a/app/Models/CardDAV/Backends/MonicaCardDAVBackend.php
+++ b/app/Models/CardDAV/Backends/MonicaCardDAVBackend.php
@@ -44,8 +44,8 @@ class MonicaCardDAVBackend extends AbstractBackend implements SyncSupport
                 'uri'                                => 'contacts',
                 'principaluri'                       => MonicaPrincipalBackend::getPrincipalUser(),
                 '{DAV:}displayname'                  => $name,
-                '{http://sabredav.org/ns}sync-token' => $token,
-                '{DAV:}sync-token'                   => $token,
+                '{http://sabredav.org/ns}sync-token' => $token->id,
+                '{DAV:}sync-token'                   => $token->id,
                 '{' . CardDAVPlugin::NS_CARDDAV . '}addressbook-description' => $name,
             ],
         ];
@@ -57,7 +57,7 @@ class MonicaCardDAVBackend extends AbstractBackend implements SyncSupport
      * If null is returned from this function, the plugin assumes there's no
      * sync information available.
      *
-     * @return string|null
+     * @return SyncToken
      */
     public function getSyncToken()
     {
@@ -72,9 +72,13 @@ class MonicaCardDAVBackend extends AbstractBackend implements SyncSupport
             $token = $this->createSyncToken();
         } else {
             $token = $tokens->last();
+
+            if ($token->timestamp < $this->getLastModified()) {
+                $token = $this->createSyncToken();
+            }
         }
 
-        return $token->id;
+        return $token;
     }
 
     /**
@@ -188,6 +192,7 @@ class MonicaCardDAVBackend extends AbstractBackend implements SyncSupport
             }
 
             $timestamp = $token->timestamp;
+            $token = $this->getSyncToken();
         } else {
             $token = $this->createSyncToken();
             $timestamp = DateHelper::parseDateTime('0001-01-01 00:00:00');

--- a/app/Models/CardDAV/MonicaAddressBook.php
+++ b/app/Models/CardDAV/MonicaAddressBook.php
@@ -50,16 +50,10 @@ class MonicaAddressBook extends AddressBook
     /**
      * Returns the last modification date as a unix timestamp.
      *
-     * @return void
+     * @return string
      */
     public function getLastModified()
     {
-        $contacts = Auth::user()->account
-                        ->contacts()
-                        ->real()
-                        ->active()
-                        ->get();
-
-        return $contacts->max('updated_at');
+        return $this->carddavBackend->getLastModified();
     }
 }

--- a/app/Models/CardDAV/MonicaAddressBook.php
+++ b/app/Models/CardDAV/MonicaAddressBook.php
@@ -4,6 +4,7 @@ namespace App\Models\CardDAV;
 
 use Sabre\CardDAV\AddressBook;
 use Illuminate\Support\Facades\Auth;
+use App\Models\CardDAV\Backends\MonicaCardDAVBackend;
 
 class MonicaAddressBook extends AddressBook
 {
@@ -54,6 +55,8 @@ class MonicaAddressBook extends AddressBook
      */
     public function getLastModified()
     {
-        return $this->carddavBackend->getLastModified();
+        if ($this->carddavBackend instanceof MonicaCardDAVBackend) {
+            return $this->carddavBackend->getLastModified();
+        }
     }
 }

--- a/app/Models/CardDAV/MonicaAddressBook.php
+++ b/app/Models/CardDAV/MonicaAddressBook.php
@@ -48,9 +48,9 @@ class MonicaAddressBook extends AddressBook
     }
 
     /**
-     * Returns the last modification date as a unix timestamp.
+     * Returns the last modification date.
      *
-     * @return string
+     * @return \Carbon\Carbon
      */
     public function getLastModified()
     {

--- a/app/Models/User/SyncToken.php
+++ b/app/Models/User/SyncToken.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models\User;
+
+use App\Models\ModelBinding as Model;
+
+class SyncToken extends Model
+{
+    protected $table = 'synctoken';
+
+    /**
+     * The attributes that aren't mass assignable.
+     *
+     * @var array
+     */
+    protected $guarded = ['id'];
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'account_id',
+        'user_id',
+        'timestamp',
+    ];
+}

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -573,3 +573,11 @@ $factory->define(App\Models\Account\Weather::class, function (Faker\Generator $f
         'created_at' => now(),
     ];
 });
+
+$factory->define(App\Models\User\SyncToken::class, function (Faker\Generator $faker) {
+    return [
+        'account_id' => factory(App\Models\Account\Account::class)->create()->id,
+        'user_id' => factory(App\Models\User\User::class)->create()->id,
+        'timestamp' => \App\Helpers\DateHelper::parseDateTime($faker->dateTimeThisCentury()),
+    ];
+});

--- a/database/migrations/2018_12_29_135516_sync_token.php
+++ b/database/migrations/2018_12_29_135516_sync_token.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class SyncToken extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('synctoken', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('account_id');
+            $table->unsignedInteger('user_id');
+            $table->timestamp('timestamp');
+            $table->timestamps();
+            $table->foreign('account_id')->references('id')->on('accounts')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+}

--- a/tests/Api/Carddav/CarddavContactTest.php
+++ b/tests/Api/Carddav/CarddavContactTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Api\Carddav;
 
 use Tests\ApiTestCase;
+use App\Helpers\DateHelper;
 use App\Models\Contact\Contact;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
@@ -79,6 +80,127 @@ class CarddavContactTest extends ApiTestCase
             'first_name' => 'John',
             'last_name' => 'Doex',
         ]);
+    }
+
+    /**
+     * @group carddav
+     */
+    public function test_carddav_update_existing_contact_if_modified()
+    {
+        $user = $this->signin();
+        $contact = factory(Contact::class)->create([
+            'account_id' => $user->account->id,
+        ]);
+        $filename = urlencode($contact->uuid.'.vcf');
+
+        $response = $this->call('PUT', "/carddav/addressbooks/{$user->email}/contacts/{$filename}", [], [], [],
+            [
+                'HTTP_If-Modified-Since' => $contact->updated_at->addDays(-1)->toRfc7231String(),
+                'content-type' => 'application/xml; charset=utf-8'
+            ],
+            "BEGIN:VCARD\nVERSION:4.0\nFN:John Doex\nN:Doex;John;;;\nEND:VCARD"
+        );
+
+        $response->assertStatus(204);
+        $response->assertHeader('X-Sabre-Version');
+        $response->assertHeaderMissing('ETag');
+
+        $this->assertDatabaseHas('contacts', [
+            'account_id' => $user->account->id,
+            'first_name' => 'John',
+            'last_name' => 'Doex',
+        ]);
+    }
+
+    /**
+     * @group carddav
+     */
+    public function test_carddav_update_existing_contact_if_modified_not_modified()
+    {
+        $user = $this->signin();
+        $contact = factory(Contact::class)->create([
+            'account_id' => $user->account->id,
+        ]);
+        $filename = urlencode($contact->uuid.'.vcf');
+
+        $response = $this->call('PUT', "/carddav/addressbooks/{$user->email}/contacts/{$filename}", [], [], [],
+            [
+                'HTTP_If-Modified-Since' => $contact->updated_at->addDays(1)->toRfc7231String(),
+                'content-type' => 'application/xml; charset=utf-8'
+            ],
+            "BEGIN:VCARD\nVERSION:4.0\nFN:John Doex\nN:Doex;John;;;\nEND:VCARD"
+        );
+
+        // Not modified
+        $response->assertStatus(304);
+
+        $response->assertHeader('X-Sabre-Version');
+        
+        // see http://tools.ietf.org/html/rfc2616#section-10.3.5
+        $response->assertHeaderMissing('Last-Modified');
+
+        $response->assertHeaderMissing('ETag');
+    }
+
+    /**
+     * @group carddav
+     */
+    public function test_carddav_update_existing_contact_if_unmodified()
+    {
+        $user = $this->signin();
+        $contact = factory(Contact::class)->create([
+            'account_id' => $user->account->id,
+        ]);
+        $filename = urlencode($contact->uuid.'.vcf');
+
+        $response = $this->call('PUT', "/carddav/addressbooks/{$user->email}/contacts/{$filename}", [], [], [],
+            [
+                'HTTP_If-Unmodified-Since' => $contact->updated_at->addDays(1)->toRfc7231String(),
+                'content-type' => 'application/xml; charset=utf-8'
+            ],
+            "BEGIN:VCARD\nVERSION:4.0\nFN:John Doex\nN:Doex;John;;;\nEND:VCARD"
+        );
+
+        $response->assertStatus(204);
+        $response->assertHeader('X-Sabre-Version');
+        $response->assertHeaderMissing('ETag');
+
+        $this->assertDatabaseHas('contacts', [
+            'account_id' => $user->account->id,
+            'first_name' => 'John',
+            'last_name' => 'Doex',
+        ]);
+    }
+
+    /**
+     * @group carddav
+     */
+    public function test_carddav_update_existing_contact_if_unmodified_error()
+    {
+        $user = $this->signin();
+        $contact = factory(Contact::class)->create([
+            'account_id' => $user->account->id,
+        ]);
+        $filename = urlencode($contact->uuid.'.vcf');
+
+        $response = $this->call('PUT', "/carddav/addressbooks/{$user->email}/contacts/{$filename}", [], [], [],
+            [
+                'HTTP_If-Unmodified-Since' => $contact->updated_at->addDays(-1)->toRfc7231String(),
+                'content-type' => 'application/xml; charset=utf-8'
+            ],
+            "BEGIN:VCARD\nVERSION:4.0\nFN:John Doex\nN:Doex;John;;;\nEND:VCARD"
+        );
+
+        // PRECONDITION FAILED
+        $response->assertStatus(412);
+
+        $response->assertHeader('X-Sabre-Version');
+
+        $sabreversion = \Sabre\DAV\Version::VERSION;
+        $response->assertSee("<d:error xmlns:d=\"DAV:\" xmlns:s=\"http://sabredav.org/ns\">
+  <s:sabredav-version>{$sabreversion}</s:sabredav-version>
+  <s:exception>Sabre\DAV\Exception\PreconditionFailed</s:exception>
+  <s:message>An If-Unmodified-Since header was specified, but the entity has been changed since the specified date.</s:message>");
     }
 
     /**

--- a/tests/Api/Carddav/CarddavContactTest.php
+++ b/tests/Api/Carddav/CarddavContactTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Api\Carddav;
 
 use Tests\ApiTestCase;
-use App\Helpers\DateHelper;
 use App\Models\Contact\Contact;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
@@ -96,7 +95,7 @@ class CarddavContactTest extends ApiTestCase
         $response = $this->call('PUT', "/carddav/addressbooks/{$user->email}/contacts/{$filename}", [], [], [],
             [
                 'HTTP_If-Modified-Since' => $contact->updated_at->addDays(-1)->toRfc7231String(),
-                'content-type' => 'application/xml; charset=utf-8'
+                'content-type' => 'application/xml; charset=utf-8',
             ],
             "BEGIN:VCARD\nVERSION:4.0\nFN:John Doex\nN:Doex;John;;;\nEND:VCARD"
         );
@@ -126,7 +125,7 @@ class CarddavContactTest extends ApiTestCase
         $response = $this->call('PUT', "/carddav/addressbooks/{$user->email}/contacts/{$filename}", [], [], [],
             [
                 'HTTP_If-Modified-Since' => $contact->updated_at->addDays(1)->toRfc7231String(),
-                'content-type' => 'application/xml; charset=utf-8'
+                'content-type' => 'application/xml; charset=utf-8',
             ],
             "BEGIN:VCARD\nVERSION:4.0\nFN:John Doex\nN:Doex;John;;;\nEND:VCARD"
         );
@@ -135,7 +134,7 @@ class CarddavContactTest extends ApiTestCase
         $response->assertStatus(304);
 
         $response->assertHeader('X-Sabre-Version');
-        
+
         // see http://tools.ietf.org/html/rfc2616#section-10.3.5
         $response->assertHeaderMissing('Last-Modified');
 
@@ -156,7 +155,7 @@ class CarddavContactTest extends ApiTestCase
         $response = $this->call('PUT', "/carddav/addressbooks/{$user->email}/contacts/{$filename}", [], [], [],
             [
                 'HTTP_If-Unmodified-Since' => $contact->updated_at->addDays(1)->toRfc7231String(),
-                'content-type' => 'application/xml; charset=utf-8'
+                'content-type' => 'application/xml; charset=utf-8',
             ],
             "BEGIN:VCARD\nVERSION:4.0\nFN:John Doex\nN:Doex;John;;;\nEND:VCARD"
         );
@@ -186,7 +185,7 @@ class CarddavContactTest extends ApiTestCase
         $response = $this->call('PUT', "/carddav/addressbooks/{$user->email}/contacts/{$filename}", [], [], [],
             [
                 'HTTP_If-Unmodified-Since' => $contact->updated_at->addDays(-1)->toRfc7231String(),
-                'content-type' => 'application/xml; charset=utf-8'
+                'content-type' => 'application/xml; charset=utf-8',
             ],
             "BEGIN:VCARD\nVERSION:4.0\nFN:John Doex\nN:Doex;John;;;\nEND:VCARD"
         );

--- a/tests/Api/Carddav/CarddavServerTest.php
+++ b/tests/Api/Carddav/CarddavServerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Api\Carddav;
 
 use Tests\ApiTestCase;
+use App\Models\User\SyncToken;
 use App\Models\Contact\Contact;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
@@ -264,5 +265,136 @@ class CarddavServerTest extends ApiTestCase
                 '</d:propstat>'.
             '</d:response>'.
         '</d:multistatus>');
+    }
+
+    public function test_carddav_getctag()
+    {
+        $user = $this->signin();
+        $contact = factory(Contact::class)->create([
+            'account_id' => $user->account->id,
+        ]);
+
+        $response = $this->call('PROPFIND', "/carddav/addressbooks/{$user->email}/", [], [], [],
+            [
+                'HTTP_DEPTH' => '1',
+                'content-type' => 'application/xml; charset=utf-8',
+            ],
+            "<propfind xmlns='DAV:' xmlns:cs='http://calendarserver.org/ns/'>
+                <prop>
+                    <cs:getctag  />
+                    <sync-token />
+                </prop>
+            </propfind>"
+        );
+
+        $response->assertStatus(207);
+        $response->assertHeader('X-Sabre-Version');
+
+        $tokens = SyncToken::where([
+            ['account_id', $user->account_id],
+            ['user_id', $user->id]
+        ])->orderBy('created_at')->get();
+
+        $this->assertGreaterThan(0, $tokens->count());
+        $token = $tokens->last();
+        
+        $response->assertSee('<d:response>'.
+            "<d:href>/carddav/addressbooks/{$user->email}/contacts/</d:href>".
+            '<d:propstat>'.
+                '<d:prop>'.
+                    "<x1:getctag xmlns:x1=\"http://calendarserver.org/ns/\">http://sabre.io/ns/sync/{$token->id}</x1:getctag>".
+                    "<d:sync-token>http://sabre.io/ns/sync/{$token->id}</d:sync-token>".
+                '</d:prop>'.
+                '<d:status>HTTP/1.1 200 OK</d:status>'.
+            '</d:propstat>'.
+        '</d:response>'
+        );
+    }
+
+    public function test_carddav_getctag_contacts()
+    {
+        $user = $this->signin();
+        $contact = factory(Contact::class)->create([
+            'account_id' => $user->account->id,
+        ]);
+
+        $response = $this->call('PROPFIND', "/carddav/addressbooks/{$user->email}/contacts/", [], [], [],
+            [
+                'HTTP_DEPTH' => '0',
+                'content-type' => 'application/xml; charset=utf-8',
+            ],
+            "<propfind xmlns='DAV:' xmlns:cs='http://calendarserver.org/ns/'>
+                <prop>
+                    <cs:getctag  />
+                    <sync-token />
+                </prop>
+            </propfind>"
+        );
+
+        $response->assertStatus(207);
+        $response->assertHeader('X-Sabre-Version');
+
+        $tokens = SyncToken::where([
+            ['account_id', $user->account_id],
+            ['user_id', $user->id]
+        ])->orderBy('created_at')->get();
+
+        $this->assertGreaterThan(0, $tokens->count());
+        $token = $tokens->last();
+        
+        $response->assertSee('<d:response>'.
+            "<d:href>/carddav/addressbooks/{$user->email}/contacts/</d:href>".
+            '<d:propstat>'.
+                '<d:prop>'.
+                    "<x1:getctag xmlns:x1=\"http://calendarserver.org/ns/\">http://sabre.io/ns/sync/{$token->id}</x1:getctag>".
+                    "<d:sync-token>http://sabre.io/ns/sync/{$token->id}</d:sync-token>".
+                '</d:prop>'.
+                '<d:status>HTTP/1.1 200 OK</d:status>'.
+            '</d:propstat>'.
+        '</d:response>'
+        );
+    }
+
+    public function test_carddav_sync_collection()
+    {
+        $user = $this->signin();
+        $token = factory(SyncToken::class)->create([
+            'account_id' => $user->account->id,
+            'user_id' => $user->id,
+            'timestamp' => \App\Helpers\DateHelper::parseDateTime(now()),
+        ]);
+        $contact = factory(Contact::class)->create([
+            'account_id' => $user->account->id,
+        ]);
+
+        $response = $this->call('REPORT', "/carddav/addressbooks/{$user->email}/contacts/", [], [], [],
+            [
+                'content-type' => 'application/xml; charset=utf-8',
+            ],
+            "<sync-collection xmlns='DAV:'>
+                <sync-token>http://sabre.io/ns/sync/{$token->id}</sync-token>
+                <sync-level>1</sync-level>
+                <prop>
+                    <getetag/>
+                </prop>
+            </sync-collection>"
+        );
+
+        $response->assertStatus(207);
+        $response->assertHeader('X-Sabre-Version');
+
+        $response->assertSee("<d:multistatus xmlns:d=\"DAV:\" xmlns:s=\"http://sabredav.org/ns\" xmlns:card=\"urn:ietf:params:xml:ns:carddav\">
+ <d:response>
+  <d:href>/carddav/addressbooks/{$user->email}/contacts/{$contact->uuid}.vcf</d:href>
+  <d:propstat>
+   <d:prop>
+    <d:getetag>&quot;");
+        $response->assertSee("&quot;</d:getetag>
+   </d:prop>
+   <d:status>HTTP/1.1 200 OK</d:status>
+  </d:propstat>
+ </d:response>
+ <d:sync-token>http://sabre.io/ns/sync/{$token->id}</d:sync-token>
+</d:multistatus>");
     }
 }


### PR DESCRIPTION
This implements the [rfc6578](https://tools.ietf.org/html/rfc6578) as describe in [sabre documentation](http://sabre.io/dav/building-a-carddav-client/#speeding-up-sync-with-webdav-sync).

Limitation: this only handles the 'modified' and 'added' contact, but will not senf the 'deleted' ones as a change.