### PR TITLE
fix: fix validation fails with Services

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ Enhancements:
 
 Fixes:
 
+* Fix validation fails with Services
 * Fix getting birthday reminders about related contacts
 * Fix default temperature scale setting
 * Fix API methods for Occupation object

--- a/app/Http/Controllers/Api/Account/ApiCompanyController.php
+++ b/app/Http/Controllers/Api/Account/ApiCompanyController.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Request;
 use App\Models\Account\Company;
 use Illuminate\Database\QueryException;
 use App\Http\Controllers\Api\ApiController;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Services\Account\Company\CreateCompany;
 use App\Services\Account\Company\UpdateCompany;
 use App\Services\Account\Company\DestroyCompany;
@@ -70,8 +70,8 @@ class ApiCompanyController extends ApiController
             );
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         } catch (QueryException $e) {
             return $this->respondInvalidQuery();
         }
@@ -99,8 +99,8 @@ class ApiCompanyController extends ApiController
             );
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         } catch (QueryException $e) {
             return $this->respondInvalidQuery();
         }
@@ -123,8 +123,8 @@ class ApiCompanyController extends ApiController
             ]);
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         } catch (QueryException $e) {
             return $this->respondInvalidQuery();
         }

--- a/app/Http/Controllers/Api/Account/ApiPlaceController.php
+++ b/app/Http/Controllers/Api/Account/ApiPlaceController.php
@@ -9,7 +9,7 @@ use App\Http\Controllers\Api\ApiController;
 use App\Services\Account\Place\CreatePlace;
 use App\Services\Account\Place\UpdatePlace;
 use App\Services\Account\Place\DestroyPlace;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Http\Resources\Place\Place as PlaceResource;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
@@ -70,8 +70,8 @@ class ApiPlaceController extends ApiController
             );
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         } catch (QueryException $e) {
             return $this->respondInvalidQuery();
         }
@@ -99,8 +99,8 @@ class ApiPlaceController extends ApiController
             );
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         } catch (QueryException $e) {
             return $this->respondInvalidQuery();
         }
@@ -123,8 +123,8 @@ class ApiPlaceController extends ApiController
             ]);
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         } catch (QueryException $e) {
             return $this->respondInvalidQuery();
         }

--- a/app/Http/Controllers/Api/ApiContactController.php
+++ b/app/Http/Controllers/Api/ApiContactController.php
@@ -7,7 +7,7 @@ use App\Helpers\SearchHelper;
 use App\Models\Contact\Contact;
 use Illuminate\Support\Collection;
 use Illuminate\Database\QueryException;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Services\Contact\Contact\CreateContact;
 use App\Services\Contact\Contact\UpdateContact;
 use App\Services\Contact\Contact\DestroyContact;
@@ -101,8 +101,8 @@ class ApiContactController extends ApiController
             );
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         } catch (QueryException $e) {
             return $this->respondInvalidQuery();
         }
@@ -128,8 +128,8 @@ class ApiContactController extends ApiController
             );
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         } catch (QueryException $e) {
             return $this->respondInvalidQuery();
         }

--- a/app/Http/Controllers/Api/ApiTagController.php
+++ b/app/Http/Controllers/Api/ApiTagController.php
@@ -8,7 +8,7 @@ use App\Services\Contact\Tag\CreateTag;
 use App\Services\Contact\Tag\UpdateTag;
 use Illuminate\Database\QueryException;
 use App\Services\Contact\Tag\DestroyTag;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Http\Resources\Tag\Tag as TagResource;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
@@ -69,8 +69,8 @@ class ApiTagController extends ApiController
             );
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         }
 
         return new TagResource($tag);
@@ -94,8 +94,8 @@ class ApiTagController extends ApiController
             );
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         }
 
         return new TagResource($tag);
@@ -115,8 +115,8 @@ class ApiTagController extends ApiController
             ]);
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         }
 
         return $this->respondObjectDeleted($id);

--- a/app/Http/Controllers/Api/ApiTagController.php
+++ b/app/Http/Controllers/Api/ApiTagController.php
@@ -8,8 +8,8 @@ use App\Services\Contact\Tag\CreateTag;
 use App\Services\Contact\Tag\UpdateTag;
 use Illuminate\Database\QueryException;
 use App\Services\Contact\Tag\DestroyTag;
-use Illuminate\Validation\ValidationException;
 use App\Http\Resources\Tag\Tag as TagResource;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 class ApiTagController extends ApiController

--- a/app/Http/Controllers/Api/ApiTaskController.php
+++ b/app/Http/Controllers/Api/ApiTaskController.php
@@ -9,7 +9,7 @@ use App\Services\Task\CreateTask;
 use App\Services\Task\UpdateTask;
 use App\Services\Task\DestroyTask;
 use Illuminate\Database\QueryException;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Http\Resources\Task\Task as TaskResource;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
@@ -67,8 +67,8 @@ class ApiTaskController extends ApiController
             ]);
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         }
 
         return new TaskResource($task);
@@ -93,8 +93,8 @@ class ApiTaskController extends ApiController
             );
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         }
 
         return new TaskResource($task);
@@ -114,8 +114,8 @@ class ApiTaskController extends ApiController
             ]);
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         }
 
         return $this->respondObjectDeleted($taskId);

--- a/app/Http/Controllers/Api/Contact/ApiAddressController.php
+++ b/app/Http/Controllers/Api/Contact/ApiAddressController.php
@@ -7,7 +7,7 @@ use App\Models\Contact\Address;
 use App\Models\Contact\Contact;
 use Illuminate\Database\QueryException;
 use App\Http\Controllers\Api\ApiController;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Services\Contact\Address\CreateAddress;
 use App\Services\Contact\Address\UpdateAddress;
 use App\Services\Contact\Address\DestroyAddress;
@@ -70,8 +70,8 @@ class ApiAddressController extends ApiController
             );
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         } catch (QueryException $e) {
             return $this->respondInvalidQuery();
         }
@@ -98,8 +98,8 @@ class ApiAddressController extends ApiController
             );
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         } catch (QueryException $e) {
             return $this->respondInvalidQuery();
         }
@@ -121,8 +121,8 @@ class ApiAddressController extends ApiController
             ]);
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         } catch (QueryException $e) {
             return $this->respondInvalidQuery();
         }

--- a/app/Http/Controllers/Api/Contact/ApiCallController.php
+++ b/app/Http/Controllers/Api/Contact/ApiCallController.php
@@ -10,7 +10,7 @@ use App\Services\Contact\Call\CreateCall;
 use App\Services\Contact\Call\UpdateCall;
 use App\Services\Contact\Call\DestroyCall;
 use App\Http\Controllers\Api\ApiController;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Http\Resources\Call\Call as CallResource;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
@@ -71,8 +71,8 @@ class ApiCallController extends ApiController
             );
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         } catch (QueryException $e) {
             return $this->respondInvalidQuery();
         }
@@ -100,8 +100,8 @@ class ApiCallController extends ApiController
             );
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         } catch (QueryException $e) {
             return $this->respondInvalidQuery();
         }
@@ -124,8 +124,8 @@ class ApiCallController extends ApiController
             ]);
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         } catch (QueryException $e) {
             return $this->respondInvalidQuery();
         }

--- a/app/Http/Controllers/Api/Contact/ApiConversationController.php
+++ b/app/Http/Controllers/Api/Contact/ApiConversationController.php
@@ -7,7 +7,7 @@ use App\Models\Contact\Contact;
 use App\Models\Contact\Conversation;
 use Illuminate\Database\QueryException;
 use App\Http\Controllers\Api\ApiController;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use App\Services\Contact\Conversation\CreateConversation;
 use App\Services\Contact\Conversation\UpdateConversation;
@@ -97,8 +97,8 @@ class ApiConversationController extends ApiController
             );
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         } catch (QueryException $e) {
             return $this->respondInvalidQuery();
         }
@@ -126,8 +126,8 @@ class ApiConversationController extends ApiController
             );
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         } catch (QueryException $e) {
             return $this->respondInvalidQuery();
         }
@@ -151,8 +151,8 @@ class ApiConversationController extends ApiController
             ]);
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         } catch (QueryException $e) {
             return $this->respondInvalidQuery();
         }

--- a/app/Http/Controllers/Api/Contact/ApiLifeEventController.php
+++ b/app/Http/Controllers/Api/Contact/ApiLifeEventController.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers\Api\Contact;
 use Illuminate\Http\Request;
 use App\Models\Contact\LifeEvent;
 use App\Http\Controllers\Api\ApiController;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Services\Contact\LifeEvent\CreateLifeEvent;
 use App\Services\Contact\LifeEvent\UpdateLifeEvent;
 use App\Services\Contact\LifeEvent\DestroyLifeEvent;
@@ -64,8 +64,8 @@ class ApiLifeEventController extends ApiController
             );
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         }
 
         return new LifeEventResource($lifeEvent);
@@ -91,8 +91,8 @@ class ApiLifeEventController extends ApiController
             );
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         }
 
         return new LifeEventResource($lifeEvent);

--- a/app/Http/Controllers/Api/Contact/ApiMessageController.php
+++ b/app/Http/Controllers/Api/Contact/ApiMessageController.php
@@ -7,7 +7,7 @@ use App\Models\Contact\Message;
 use App\Models\Contact\Conversation;
 use Illuminate\Database\QueryException;
 use App\Http\Controllers\Api\ApiController;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Services\Contact\Conversation\UpdateMessage;
 use App\Services\Contact\Conversation\DestroyMessage;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -42,8 +42,8 @@ class ApiMessageController extends ApiController
             );
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         } catch (QueryException $e) {
             return $this->respondInvalidQuery();
         }
@@ -81,8 +81,8 @@ class ApiMessageController extends ApiController
             );
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         } catch (QueryException $e) {
             return $this->respondInvalidQuery();
         }
@@ -115,8 +115,8 @@ class ApiMessageController extends ApiController
             ]);
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         } catch (QueryException $e) {
             return $this->respondInvalidQuery();
         }

--- a/app/Http/Controllers/Api/Contact/ApiOccupationController.php
+++ b/app/Http/Controllers/Api/Contact/ApiOccupationController.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Request;
 use App\Models\Contact\Occupation;
 use Illuminate\Database\QueryException;
 use App\Http\Controllers\Api\ApiController;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Services\Contact\Occupation\CreateOccupation;
 use App\Services\Contact\Occupation\UpdateOccupation;
 use App\Services\Contact\Occupation\DestroyOccupation;
@@ -70,8 +70,8 @@ class ApiOccupationController extends ApiController
             );
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         } catch (QueryException $e) {
             return $this->respondInvalidQuery();
         }
@@ -99,8 +99,8 @@ class ApiOccupationController extends ApiController
             );
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         } catch (QueryException $e) {
             return $this->respondInvalidQuery();
         }
@@ -123,8 +123,8 @@ class ApiOccupationController extends ApiController
             ]);
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
-        } catch (MissingParameterException $e) {
-            return $this->respondInvalidParameters($e->errors);
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         } catch (QueryException $e) {
             return $this->respondInvalidQuery();
         }

--- a/app/Http/Controllers/Contacts/AddressesController.php
+++ b/app/Http/Controllers/Contacts/AddressesController.php
@@ -66,20 +66,21 @@ class AddressesController extends Controller
      */
     public function store(Request $request, Contact $contact)
     {
-        $request = [
-            'account_id' => auth()->user()->account->id,
+        $datas = [
+            'account_id' => auth()->user()->account_id,
             'contact_id' => $contact->id,
-            'name' => $request->get('name'),
-            'country' => $request->get('country'),
-            'street' => $request->get('street'),
-            'city' => $request->get('city'),
-            'province' => $request->get('province'),
-            'postal_code' => $request->get('postal_code'),
-            'latitude' => $request->get('latitude'),
-            'longitude' => $request->get('longitude'),
-        ];
+        ] + $request->only([
+            'name',
+            'country',
+            'street',
+            'city',
+            'province',
+            'postal_code',
+            'latitude',
+            'longitude',
+        ]);
 
-        return (new CreateAddress)->execute($request);
+        return (new CreateAddress)->execute($datas);
     }
 
     /**
@@ -87,21 +88,22 @@ class AddressesController extends Controller
      */
     public function edit(Request $request, Contact $contact, Address $address)
     {
-        $request = [
-            'account_id' => auth()->user()->account->id,
+        $datas = [
+            'account_id' => auth()->user()->account_id,
             'contact_id' => $contact->id,
             'address_id' => $address->id,
-            'name' => $request->get('name'),
-            'country' => $request->get('country'),
-            'street' => $request->get('street'),
-            'city' => $request->get('city'),
-            'province' => $request->get('province'),
-            'postal_code' => $request->get('postal_code'),
-            'latitude' => $request->get('latitude'),
-            'longitude' => $request->get('longitude'),
-        ];
+        ] + $request->only([
+            'name',
+            'country',
+            'street',
+            'city',
+            'province',
+            'postal_code',
+            'latitude',
+            'longitude',
+        ]);
 
-        return (new UpdateAddress)->execute($request);
+        return (new UpdateAddress)->execute($datas);
     }
 
     /**
@@ -114,11 +116,11 @@ class AddressesController extends Controller
      */
     public function destroy(Request $request, Contact $contact, Address $address)
     {
-        $request = [
-            'account_id' => auth()->user()->account->id,
+        $datas = [
+            'account_id' => auth()->user()->account_id,
             'address_id' => $address->id,
         ];
 
-        (new DestroyAddress)->execute($request);
+        return (new DestroyAddress)->execute($datas);
     }
 }

--- a/app/Http/Controllers/ContactsController.php
+++ b/app/Http/Controllers/ContactsController.php
@@ -185,8 +185,8 @@ class ContactsController extends Controller
                 'is_deceased_date_known' => false,
             ]);
         } catch (ValidationException $e) {
-            return back()	
-                ->withInput()	
+            return back()
+                ->withInput()
                 ->withErrors($e->validator);
         }
 

--- a/app/Http/Controllers/ContactsController.php
+++ b/app/Http/Controllers/ContactsController.php
@@ -13,6 +13,7 @@ use App\Services\VCard\ExportVCard;
 use Illuminate\Support\Facades\Auth;
 use App\Models\Relationship\Relationship;
 use Barryvdh\Debugbar\Facade as Debugbar;
+use Illuminate\Validation\ValidationException;
 use App\Services\Contact\Contact\CreateContact;
 use App\Services\Contact\Contact\UpdateContact;
 use App\Services\Contact\Contact\DestroyContact;
@@ -172,16 +173,22 @@ class ContactsController extends Controller
      */
     public function store(Request $request)
     {
-        $contact = (new CreateContact)->execute([
-            'account_id' => auth()->user()->account->id,
-            'first_name' => $request->get('first_name'),
-            'last_name' => $request->input('last_name', null),
-            'nickname' => $request->input('nickname', null),
-            'gender_id' => $request->get('gender'),
-            'is_birthdate_known' => false,
-            'is_deceased' => false,
-            'is_deceased_date_known' => false,
-        ]);
+        try {
+            $contact = (new CreateContact)->execute([
+                'account_id' => auth()->user()->account->id,
+                'first_name' => $request->get('first_name'),
+                'last_name' => $request->input('last_name', null),
+                'nickname' => $request->input('nickname', null),
+                'gender_id' => $request->get('gender'),
+                'is_birthdate_known' => false,
+                'is_deceased' => false,
+                'is_deceased_date_known' => false,
+            ]);
+        } catch (ValidationException $e) {
+            return back()	
+                ->withInput()	
+                ->withErrors($e->validator);
+        }
 
         // Did the user press "Save" or "Submit and add another person"
         if (! is_null($request->get('save'))) {

--- a/app/Models/Account/ImportJob.php
+++ b/app/Models/Account/ImportJob.php
@@ -8,7 +8,7 @@ use Sabre\VObject\Component\VCard;
 use App\Services\VCard\ImportVCard;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Storage;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
@@ -211,7 +211,7 @@ class ImportJob extends Model
                 'entry' => $entry,
                 'behaviour' => $behaviour,
             ]);
-        } catch (MissingParameterException $e) {
+        } catch (ValidationException $e) {
             $this->fail((string) $e);
 
             return;

--- a/app/Services/BaseService.php
+++ b/app/Services/BaseService.php
@@ -4,7 +4,7 @@ namespace App\Services;
 
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Validator;
-use App\Exceptions\MissingParameterException;
+use App\Exceptions\ValidationFailedException;
 
 abstract class BaseService
 {
@@ -26,11 +26,8 @@ abstract class BaseService
      */
     public function validate(array $data) : bool
     {
-        $validator = Validator::make($data, $this->rules());
-
-        if ($validator->fails()) {
-            throw new MissingParameterException('Missing parameters', $validator->errors()->all());
-        }
+        Validator::make($data, $this->rules())
+            ->validate();
 
         return true;
     }

--- a/app/Services/BaseService.php
+++ b/app/Services/BaseService.php
@@ -4,7 +4,6 @@ namespace App\Services;
 
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Validator;
-use App\Exceptions\ValidationFailedException;
 
 abstract class BaseService
 {

--- a/app/Services/Instance/Weather/GetWeatherInformation.php
+++ b/app/Services/Instance/Weather/GetWeatherInformation.php
@@ -30,7 +30,7 @@ class GetWeatherInformation extends BaseService
      *
      * @param array $data
      * @return Weather|null
-     * @throws App\Exceptions\MissingParameterException if the array that is given in parameter is not valid
+     * @throws Illuminate\Validation\ValidationException if the array that is given in parameter is not valid
      * @throws App\Exceptions\MissingEnvVariableException if the weather services are not enabled
      * @throws Illuminate\Database\Eloquent\ModelNotFoundException if the Place object is not found
      * @throws GuzzleHttp\Exception\ClientException if the request to Darksky crashed

--- a/app/Traits/JsonRespondController.php
+++ b/app/Traits/JsonRespondController.php
@@ -137,7 +137,7 @@ trait JsonRespondController
      */
     public function respondInvalidParameters($message = null)
     {
-        return $this->setHTTPStatusCode(400)
+        return $this->setHTTPStatusCode(422)
                     ->setErrorCode(41)
                     ->respondWithError($message);
     }
@@ -150,7 +150,7 @@ trait JsonRespondController
      */
     public function respondValidatorFailed(Validator $validator)
     {
-        return $this->setHTTPStatusCode(400)
+        return $this->setHTTPStatusCode(422)
                     ->setErrorCode(32)
                     ->respondWithError($validator->errors()->all());
     }

--- a/tests/Unit/Services/Account/Company/CreateCompanyTest.php
+++ b/tests/Unit/Services/Account/Company/CreateCompanyTest.php
@@ -5,7 +5,7 @@ namespace Tests\Unit\Services\Account\Place;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Account\Company;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Services\Account\Company\CreateCompany;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
@@ -49,7 +49,7 @@ class CreateCompanyTest extends TestCase
             'street' => '199 Lafayette Street',
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
         (new CreateCompany)->execute($request);
     }
 }

--- a/tests/Unit/Services/Account/Company/DestroyCompanyTest.php
+++ b/tests/Unit/Services/Account/Company/DestroyCompanyTest.php
@@ -5,7 +5,7 @@ namespace Tests\Unit\Services\Account\Company;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Account\Company;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Services\Account\Company\DestroyCompany;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -52,7 +52,7 @@ class DestroyCompanyTest extends TestCase
             'company_id' => 11111111,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
         (new DestroyCompany)->execute($request);
     }
 }

--- a/tests/Unit/Services/Account/Company/UpdateCompanyTest.php
+++ b/tests/Unit/Services/Account/Company/UpdateCompanyTest.php
@@ -5,7 +5,7 @@ namespace Tests\Unit\Services\Account\Place;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Account\Company;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Services\Account\Company\UpdateCompany;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -51,7 +51,7 @@ class UpdateCompanyTest extends TestCase
             'name' => '199 Lafayette Street',
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
         (new UpdateCompany)->execute($request);
     }
 

--- a/tests/Unit/Services/Account/DestroyAllDocumentsTest.php
+++ b/tests/Unit/Services/Account/DestroyAllDocumentsTest.php
@@ -7,7 +7,7 @@ use App\Models\Contact\Contact;
 use App\Models\Contact\Document;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Services\Account\DestroyAllDocuments;
 use App\Services\Contact\Document\UploadDocument;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -43,7 +43,7 @@ class DestroyAllDocumentsTest extends TestCase
         $request = [
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $destroyAllDocumentsService = new DestroyAllDocuments;
         $result = $destroyAllDocumentsService->execute($request);

--- a/tests/Unit/Services/Account/DestroyAllDocumentsTest.php
+++ b/tests/Unit/Services/Account/DestroyAllDocumentsTest.php
@@ -7,8 +7,8 @@ use App\Models\Contact\Contact;
 use App\Models\Contact\Document;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Validation\ValidationException;
 use App\Services\Account\DestroyAllDocuments;
+use Illuminate\Validation\ValidationException;
 use App\Services\Contact\Document\UploadDocument;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 

--- a/tests/Unit/Services/Account/Photo/DestroyPhotoTest.php
+++ b/tests/Unit/Services/Account/Photo/DestroyPhotoTest.php
@@ -9,7 +9,7 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use App\Services\Account\Photo\UploadPhoto;
 use App\Services\Account\Photo\DestroyPhoto;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
@@ -47,7 +47,7 @@ class DestroyPhotoTest extends TestCase
             'photo_id' => 2,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $destroyPhotoService = new DestroyPhoto;
         $result = $destroyPhotoService->execute($request);

--- a/tests/Unit/Services/Account/Photo/UploadPhotoTest.php
+++ b/tests/Unit/Services/Account/Photo/UploadPhotoTest.php
@@ -9,7 +9,7 @@ use App\Models\Contact\Document;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use App\Services\Account\Photo\UploadPhoto;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class UploadPhotoTest extends TestCase
@@ -50,7 +50,7 @@ class UploadPhotoTest extends TestCase
             'account_id' => 1,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $uploadService = new UploadPhoto;
         $photo = $uploadService->execute($request);
@@ -65,7 +65,7 @@ class UploadPhotoTest extends TestCase
             'photo' => UploadedFile::fake()->image('document.pdf'),
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $uploadService = (new UploadPhoto)->execute($request);
     }

--- a/tests/Unit/Services/Account/Place/CreatePlaceTest.php
+++ b/tests/Unit/Services/Account/Place/CreatePlaceTest.php
@@ -6,7 +6,7 @@ use Tests\TestCase;
 use App\Models\Account\Place;
 use App\Models\Account\Account;
 use App\Services\Account\Place\CreatePlace;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class CreatePlaceTest extends TestCase
@@ -90,7 +90,7 @@ class CreatePlaceTest extends TestCase
             'street' => '199 Lafayette Street',
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
         (new CreatePlace)->execute($request);
     }
 }

--- a/tests/Unit/Services/Account/Place/DestroyPlaceTest.php
+++ b/tests/Unit/Services/Account/Place/DestroyPlaceTest.php
@@ -6,7 +6,7 @@ use Tests\TestCase;
 use App\Models\Account\Place;
 use App\Models\Account\Account;
 use App\Services\Account\Place\DestroyPlace;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
@@ -52,7 +52,7 @@ class DestroyPlaceTest extends TestCase
             'place_id' => 11111111,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
         (new DestroyPlace)->execute($request);
     }
 }

--- a/tests/Unit/Services/Account/Place/UpdatePlaceTest.php
+++ b/tests/Unit/Services/Account/Place/UpdatePlaceTest.php
@@ -6,7 +6,7 @@ use Tests\TestCase;
 use App\Models\Account\Place;
 use App\Models\Account\Account;
 use App\Services\Account\Place\UpdatePlace;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
@@ -93,7 +93,7 @@ class UpdatePlaceTest extends TestCase
             'street' => '199 Lafayette Street',
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
         (new UpdatePlace)->execute($request);
     }
 

--- a/tests/Unit/Services/Auth/PopulateContactFieldTypesTableTest.php
+++ b/tests/Unit/Services/Auth/PopulateContactFieldTypesTableTest.php
@@ -6,7 +6,7 @@ use Tests\TestCase;
 use App\Models\User\User;
 use App\Models\Account\Account;
 use Illuminate\Support\Facades\DB;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use App\Services\Auth\Population\PopulateContactFieldTypesTable;
 
@@ -27,7 +27,7 @@ class PopulateContactFieldTypesTableTest extends TestCase
             'migrate_existing_data' => false,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
         (new PopulateContactFieldTypesTable)->execute($request);
     }
 

--- a/tests/Unit/Services/Auth/PopulateLifeEventsTableTest.php
+++ b/tests/Unit/Services/Auth/PopulateLifeEventsTableTest.php
@@ -6,7 +6,7 @@ use Tests\TestCase;
 use App\Models\User\User;
 use App\Models\Account\Account;
 use Illuminate\Support\Facades\DB;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use App\Services\Auth\Population\PopulateLifeEventsTable;
 
@@ -29,7 +29,7 @@ class PopulateLifeEventsTableTest extends TestCase
             'migrate_existing_data' => false,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $populateLifeEventService = new PopulateLifeEventsTable;
         $populateLifeEventService->execute($request);

--- a/tests/Unit/Services/Auth/PopulateModulesTableTest.php
+++ b/tests/Unit/Services/Auth/PopulateModulesTableTest.php
@@ -6,7 +6,7 @@ use Tests\TestCase;
 use App\Models\User\User;
 use App\Models\Account\Account;
 use Illuminate\Support\Facades\DB;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Services\Auth\Population\PopulateModulesTable;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
@@ -29,7 +29,7 @@ class PopulateModulesTableTest extends TestCase
             'migrate_existing_data' => false,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $populateModulesService = new PopulateModulesTable;
         $populateModulesService->execute($request);

--- a/tests/Unit/Services/Contact/Address/CreateAddressTest.php
+++ b/tests/Unit/Services/Contact/Address/CreateAddressTest.php
@@ -6,7 +6,7 @@ use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Address;
 use App\Models\Contact\Contact;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Services\Contact\Address\CreateAddress;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -60,7 +60,7 @@ class CreateAddressTest extends TestCase
             'name' => '199 Lafayette Street',
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
         (new CreateAddress)->execute($request);
     }
 

--- a/tests/Unit/Services/Contact/Address/DestroyAddressTest.php
+++ b/tests/Unit/Services/Contact/Address/DestroyAddressTest.php
@@ -5,7 +5,7 @@ namespace Tests\Unit\Services\Contact\Address;
 use Tests\TestCase;
 use App\Models\Contact\Address;
 use App\Models\Contact\Contact;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Services\Contact\Address\DestroyAddress;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -51,7 +51,7 @@ class DestroyAddressTest extends TestCase
             'address_id' => 11111111,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
         (new DestroyAddress)->execute($request);
     }
 }

--- a/tests/Unit/Services/Contact/Address/UpdateAddressTest.php
+++ b/tests/Unit/Services/Contact/Address/UpdateAddressTest.php
@@ -6,7 +6,7 @@ use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Address;
 use App\Models\Contact\Contact;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Services\Contact\Address\UpdateAddress;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -61,7 +61,7 @@ class UpdateAddressTest extends TestCase
             'street' => '199 Lafayette Street',
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
         (new UpdateAddress)->execute($request);
     }
 

--- a/tests/Unit/Services/Contact/Call/CreateCallTest.php
+++ b/tests/Unit/Services/Contact/Call/CreateCallTest.php
@@ -9,7 +9,7 @@ use App\Models\Account\Account;
 use App\Models\Contact\Contact;
 use App\Models\Instance\Emotion\Emotion;
 use App\Services\Contact\Call\CreateCall;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
@@ -211,7 +211,7 @@ class CreateCallTest extends TestCase
             'called_at' => Carbon::now(),
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
         (new CreateCall)->execute($request);
     }
 

--- a/tests/Unit/Services/Contact/Call/UpdateCallTest.php
+++ b/tests/Unit/Services/Contact/Call/UpdateCallTest.php
@@ -10,7 +10,7 @@ use App\Models\Contact\Contact;
 use Illuminate\Support\Facades\DB;
 use App\Models\Instance\Emotion\Emotion;
 use App\Services\Contact\Call\UpdateCall;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
@@ -289,7 +289,7 @@ class UpdateCallTest extends TestCase
             'called_at' => Carbon::now(),
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $createConversation = new UpdateCall;
         $call = $createConversation->execute($request);

--- a/tests/Unit/Services/Contact/Contact/CreateContactTest.php
+++ b/tests/Unit/Services/Contact/Contact/CreateContactTest.php
@@ -6,7 +6,7 @@ use Tests\TestCase;
 use App\Models\Contact\Gender;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Services\Contact\Contact\CreateContact;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
@@ -68,7 +68,7 @@ class CreateContactTest extends TestCase
             'is_deceased_date_known' => false,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
         (new CreateContact)->execute($request);
     }
 
@@ -88,7 +88,7 @@ class CreateContactTest extends TestCase
             'is_deceased_date_known' => false,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         (new CreateContact)->execute($request);
     }

--- a/tests/Unit/Services/Contact/Contact/DestroyContactTest.php
+++ b/tests/Unit/Services/Contact/Contact/DestroyContactTest.php
@@ -5,7 +5,7 @@ namespace Tests\Unit\Services\Contact\Contact;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Services\Contact\Contact\DestroyContact;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -39,7 +39,7 @@ class DestroyContactTest extends TestCase
             'account_id' => $contact->account_id,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         (new DestroyContact)->execute($request);
     }

--- a/tests/Unit/Services/Contact/Contact/UpdateBirthdayInformationTest.php
+++ b/tests/Unit/Services/Contact/Contact/UpdateBirthdayInformationTest.php
@@ -5,7 +5,7 @@ namespace Tests\Unit\Services\Contact\Contact;
 use Tests\TestCase;
 use App\Models\Contact\Contact;
 use App\Models\Instance\SpecialDate;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use App\Services\Contact\Contact\UpdateBirthdayInformation;
 
@@ -167,7 +167,7 @@ class UpdateBirthdayInformationTest extends TestCase
             'add_reminder' => false,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $updateContact = new UpdateBirthdayInformation;
         $updateContact->execute($request);
@@ -188,7 +188,7 @@ class UpdateBirthdayInformationTest extends TestCase
             'add_reminder' => false,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         (new UpdateBirthdayInformation)->execute($request);
     }

--- a/tests/Unit/Services/Contact/Contact/UpdateContactTest.php
+++ b/tests/Unit/Services/Contact/Contact/UpdateContactTest.php
@@ -4,7 +4,7 @@ namespace Tests\Unit\Services\Contact\Contact;
 
 use Tests\TestCase;
 use App\Models\Contact\Contact;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Services\Contact\Contact\UpdateContact;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
@@ -82,7 +82,7 @@ class UpdateContactTest extends TestCase
             'deceased_date_add_reminder' => true,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
         (new UpdateContact)->execute($request);
     }
 
@@ -114,7 +114,7 @@ class UpdateContactTest extends TestCase
             'deceased_date_add_reminder' => true,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
         (new UpdateContact)->execute($request);
     }
 }

--- a/tests/Unit/Services/Contact/Contact/UpdateDeceasedInformationTest.php
+++ b/tests/Unit/Services/Contact/Contact/UpdateDeceasedInformationTest.php
@@ -5,7 +5,7 @@ namespace Tests\Unit\Services\Contact\Contact;
 use Tests\TestCase;
 use App\Models\Contact\Contact;
 use App\Models\Instance\SpecialDate;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use App\Services\Contact\Contact\UpdateDeceasedInformation;
 
@@ -161,7 +161,7 @@ class UpdateDeceasedInformationTest extends TestCase
             'add_reminder' => false,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $deceasedService = new UpdateDeceasedInformation;
         $contact = $deceasedService->execute($request);
@@ -182,7 +182,7 @@ class UpdateDeceasedInformationTest extends TestCase
             'add_reminder' => false,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         (new UpdateDeceasedInformation)->execute($request);
     }

--- a/tests/Unit/Services/Contact/Conversation/AddMessageToConversationTest.php
+++ b/tests/Unit/Services/Contact/Conversation/AddMessageToConversationTest.php
@@ -8,7 +8,7 @@ use App\Models\Account\Account;
 use App\Models\Contact\Contact;
 use App\Models\Contact\Message;
 use App\Models\Contact\Conversation;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use App\Services\Contact\Conversation\AddMessageToConversation;
@@ -24,7 +24,7 @@ class AddMessageToConversationTest extends TestCase
             'happened_at' => Carbon::now(),
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $addMessageToConversation = new AddMessageToConversation;
         $conversation = $addMessageToConversation->execute($request);

--- a/tests/Unit/Services/Contact/Conversation/CreateConversationTest.php
+++ b/tests/Unit/Services/Contact/Conversation/CreateConversationTest.php
@@ -8,7 +8,7 @@ use App\Models\Account\Account;
 use App\Models\Contact\Contact;
 use App\Models\Contact\Conversation;
 use App\Models\Contact\ContactFieldType;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use App\Services\Contact\Conversation\CreateConversation;
@@ -56,7 +56,7 @@ class CreateConversationTest extends TestCase
             'happened_at' => Carbon::now(),
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $createConversation = new CreateConversation;
         $conversation = $createConversation->execute($request);

--- a/tests/Unit/Services/Contact/Conversation/DestroyConversationTest.php
+++ b/tests/Unit/Services/Contact/Conversation/DestroyConversationTest.php
@@ -6,7 +6,7 @@ use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Message;
 use App\Models\Contact\Conversation;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use App\Services\Contact\Conversation\DestroyConversation;
@@ -79,7 +79,7 @@ class DestroyConversationTest extends TestCase
             'account_id' => $conversation->account->id,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $conversationService = (new DestroyConversation)->execute($request);
     }

--- a/tests/Unit/Services/Contact/Conversation/DestroyMessageTest.php
+++ b/tests/Unit/Services/Contact/Conversation/DestroyMessageTest.php
@@ -5,7 +5,7 @@ namespace Tests\Unit\Services\Contact\Conversation;
 use Tests\TestCase;
 use App\Models\Contact\Message;
 use App\Models\Contact\Conversation;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Services\Contact\Conversation\DestroyMessage;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -52,7 +52,7 @@ class DestroyMessageTest extends TestCase
             'message_id' => 3,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $destroyMessage = new DestroyMessage;
         $result = $destroyMessage->execute($request);

--- a/tests/Unit/Services/Contact/Conversation/UpdateConversationTest.php
+++ b/tests/Unit/Services/Contact/Conversation/UpdateConversationTest.php
@@ -8,7 +8,7 @@ use App\Models\Account\Account;
 use App\Models\Contact\Contact;
 use App\Models\Contact\Conversation;
 use App\Models\Contact\ContactFieldType;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use App\Services\Contact\Conversation\UpdateConversation;
@@ -57,7 +57,7 @@ class UpdateConversationTest extends TestCase
             'happened_at' => Carbon::now(),
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $updateConversation = new UpdateConversation;
         $conversation = $updateConversation->execute($request);

--- a/tests/Unit/Services/Contact/Conversation/UpdateMessageTest.php
+++ b/tests/Unit/Services/Contact/Conversation/UpdateMessageTest.php
@@ -7,7 +7,7 @@ use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Message;
 use App\Models\Contact\Conversation;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Services\Contact\Conversation\UpdateMessage;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -68,7 +68,7 @@ class UpdateMessageTest extends TestCase
             'content' => 'lorem',
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $updateMessage = (new UpdateMessage)->execute($request);
     }

--- a/tests/Unit/Services/Contact/Document/DestroyDocumentTest.php
+++ b/tests/Unit/Services/Contact/Document/DestroyDocumentTest.php
@@ -7,7 +7,7 @@ use App\Models\Contact\Contact;
 use App\Models\Contact\Document;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Services\Contact\Document\UploadDocument;
 use App\Services\Contact\Document\DestroyDocument;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -47,7 +47,7 @@ class DestroyDocumentTest extends TestCase
             'document_id' => 2,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $destroyDocumentService = new DestroyDocument;
         $result = $destroyDocumentService->execute($request);

--- a/tests/Unit/Services/Contact/Document/UploadDocumentTest.php
+++ b/tests/Unit/Services/Contact/Document/UploadDocumentTest.php
@@ -8,7 +8,7 @@ use App\Models\Contact\Contact;
 use App\Models\Contact\Document;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Services\Contact\Document\UploadDocument;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -54,7 +54,7 @@ class UploadDocumentTest extends TestCase
             'contact_id' => 2,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $uploadService = new UploadDocument;
         $document = $uploadService->execute($request);

--- a/tests/Unit/Services/Contact/LifeEvent/AddReminderToLifeEventTest.php
+++ b/tests/Unit/Services/Contact/LifeEvent/AddReminderToLifeEventTest.php
@@ -5,7 +5,7 @@ namespace Tests\Unit\Services\Contact\LifeEvent;
 use Tests\TestCase;
 use App\Models\Contact\Reminder;
 use App\Models\Contact\LifeEvent;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use App\Services\Contact\LifeEvent\AddReminderToLifeEvent;
@@ -51,7 +51,7 @@ class AddReminderToLifeEventTest extends TestCase
             'frequency_number' => 1,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $reminderService = new AddReminderToLifeEvent;
         $reminder = $reminderService->execute($request);

--- a/tests/Unit/Services/Contact/LifeEvent/CreateLifeEventTest.php
+++ b/tests/Unit/Services/Contact/LifeEvent/CreateLifeEventTest.php
@@ -8,7 +8,7 @@ use App\Models\Account\Account;
 use App\Models\Contact\Contact;
 use App\Models\Contact\LifeEvent;
 use App\Models\Contact\LifeEventType;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Services\Contact\LifeEvent\CreateLifeEvent;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -95,7 +95,7 @@ class CreateLifeEventTest extends TestCase
             'happened_at' => Carbon::now(),
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $createLifeEvent = new CreateLifeEvent;
         $lifeEvent = $createLifeEvent->execute($request);

--- a/tests/Unit/Services/Contact/LifeEvent/DestroyLifeEventTest.php
+++ b/tests/Unit/Services/Contact/LifeEvent/DestroyLifeEventTest.php
@@ -6,7 +6,7 @@ use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Reminder;
 use App\Models\Contact\LifeEvent;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Services\Contact\LifeEvent\DestroyLifeEvent;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -64,7 +64,7 @@ class DestroyLifeEventTest extends TestCase
             'account_id' => 1,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $destroyMessage = (new DestroyLifeEvent)->execute($request);
     }

--- a/tests/Unit/Services/Contact/LifeEvent/UpdateLifeEventTest.php
+++ b/tests/Unit/Services/Contact/LifeEvent/UpdateLifeEventTest.php
@@ -8,7 +8,7 @@ use App\Models\Account\Account;
 use App\Models\Contact\Contact;
 use App\Models\Contact\LifeEvent;
 use App\Models\Contact\LifeEventType;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Services\Contact\LifeEvent\UpdateLifeEvent;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -63,7 +63,7 @@ class UpdateLifeEventTest extends TestCase
             'happened_at' => Carbon::now(),
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $updateConversation = (new UpdateLifeEvent)->execute($request);
     }

--- a/tests/Unit/Services/Contact/Occupation/CreateOccupationTest.php
+++ b/tests/Unit/Services/Contact/Occupation/CreateOccupationTest.php
@@ -7,7 +7,7 @@ use App\Models\Account\Account;
 use App\Models\Account\Company;
 use App\Models\Contact\Contact;
 use App\Models\Contact\Occupation;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Services\Contact\Occupation\CreateOccupation;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
@@ -56,7 +56,7 @@ class CreateOccupationTest extends TestCase
             'street' => '199 Lafayette Street',
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
         (new CreateOccupation)->execute($request);
     }
 }

--- a/tests/Unit/Services/Contact/Occupation/UpdateOccupationTest.php
+++ b/tests/Unit/Services/Contact/Occupation/UpdateOccupationTest.php
@@ -5,7 +5,7 @@ namespace Tests\Unit\Services\Account\Place;
 use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Occupation;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Services\Contact\Occupation\UpdateOccupation;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -54,7 +54,7 @@ class UpdateOccupationTest extends TestCase
             'name' => '199 Lafayette Street',
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
         (new UpdateOccupation)->execute($request);
     }
 

--- a/tests/Unit/Services/Contact/Relationship/DestroyRelationshipTest.php
+++ b/tests/Unit/Services/Contact/Relationship/DestroyRelationshipTest.php
@@ -6,7 +6,7 @@ use Tests\TestCase;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
 use App\Models\Relationship\Relationship;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use App\Services\Contact\Relationship\DestroyRelationship;
@@ -49,7 +49,7 @@ class DestroyRelationshipTest extends TestCase
             'account_id' => $account->id,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         (new DestroyRelationship)->execute($request);
     }

--- a/tests/Unit/Services/Contact/Reminder/CreateReminderTest.php
+++ b/tests/Unit/Services/Contact/Reminder/CreateReminderTest.php
@@ -8,7 +8,7 @@ use App\Models\Account\Account;
 use App\Models\Contact\Contact;
 use App\Models\Contact\Reminder;
 use App\Models\Instance\SpecialDate;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Services\Contact\Reminder\CreateReminder;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -88,7 +88,7 @@ class CreateReminderTest extends TestCase
             'date' => Carbon::now(),
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $reminderService = (new CreateReminder)->execute($request);
     }
@@ -144,11 +144,11 @@ class CreateReminderTest extends TestCase
             'special_date_id' => null,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         try {
             $reminderService = (new CreateReminder)->execute($request);
-        } catch (MissingParameterException $e) {
+        } catch (ValidationException $e) {
             $this->assertEquals(['The selected frequency type is invalid.'], $e->errors);
             throw $e;
         }

--- a/tests/Unit/Services/Contact/Tag/AssociateTagTest.php
+++ b/tests/Unit/Services/Contact/Tag/AssociateTagTest.php
@@ -7,7 +7,7 @@ use App\Models\Contact\Tag;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
 use App\Services\Contact\Tag\AssociateTag;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
@@ -99,7 +99,7 @@ class AssociateTagTest extends TestCase
             'contact_id' => 2,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $associateTagService = new AssociateTag;
         $tag = $associateTagService->execute($request);

--- a/tests/Unit/Services/Contact/Tag/CreateTagTest.php
+++ b/tests/Unit/Services/Contact/Tag/CreateTagTest.php
@@ -5,7 +5,7 @@ namespace Tests\Unit\Services\Contact\Conversation;
 use Tests\TestCase;
 use App\Models\Contact\Tag;
 use App\Services\Contact\Tag\CreateTag;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class CreateTagTest extends TestCase
@@ -43,7 +43,7 @@ class CreateTagTest extends TestCase
             'tag_id' => 2,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $createTagService = new CreateTag;
         $tag = $createTagService->execute($request);

--- a/tests/Unit/Services/Contact/Tag/DestroyTagTest.php
+++ b/tests/Unit/Services/Contact/Tag/DestroyTagTest.php
@@ -7,7 +7,7 @@ use App\Models\Contact\Tag;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
 use App\Services\Contact\Tag\DestroyTag;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
@@ -61,7 +61,7 @@ class DestroyTagTest extends TestCase
             'account_id' => 1,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $destroyTagService = new DestroyTag;
         $tag = $destroyTagService->execute($request);

--- a/tests/Unit/Services/Contact/Tag/DetachTagTest.php
+++ b/tests/Unit/Services/Contact/Tag/DetachTagTest.php
@@ -7,7 +7,7 @@ use App\Models\Contact\Tag;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
 use App\Services\Contact\Tag\DetachTag;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
@@ -56,7 +56,7 @@ class DetachTagTest extends TestCase
             'account_id' => 1,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $detachTagService = new DetachTag;
         $detachTagService->execute($request);

--- a/tests/Unit/Services/Contact/Tag/UpdateTagTest.php
+++ b/tests/Unit/Services/Contact/Tag/UpdateTagTest.php
@@ -6,7 +6,7 @@ use Tests\TestCase;
 use App\Models\Contact\Tag;
 use App\Models\Account\Account;
 use App\Services\Contact\Tag\UpdateTag;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
@@ -46,7 +46,7 @@ class UpdateTagTest extends TestCase
             'tag_id' => 2,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $updateTagService = new UpdateTag;
         $tag = $updateTagService->execute($request);

--- a/tests/Unit/Services/Instance/Geolocalization/GetGPSCoordinateTest.php
+++ b/tests/Unit/Services/Instance/Geolocalization/GetGPSCoordinateTest.php
@@ -4,7 +4,7 @@ namespace Tests\Unit\Services\Instance\Geolocalization;
 
 use Tests\TestCase;
 use App\Models\Account\Place;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use App\Services\Instance\Geolocalization\GetGPSCoordinate;
 
@@ -99,7 +99,7 @@ class GetGPSCoordinateTest extends TestCase
             'account_id' => 111,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $geocodingService = new GetGPSCoordinate;
         $place = $geocodingService->execute($request);

--- a/tests/Unit/Services/Instance/Weather/GetWeatherInformationTest.php
+++ b/tests/Unit/Services/Instance/Weather/GetWeatherInformationTest.php
@@ -5,7 +5,7 @@ namespace Tests\Unit\Services\Instance\Weather;
 use Tests\TestCase;
 use App\Models\Account\Place;
 use App\Models\Account\Weather;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use App\Exceptions\MissingEnvVariableException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use App\Services\Instance\Weather\GetWeatherInformation;
@@ -112,7 +112,7 @@ class GetWeatherInformationTest extends TestCase
 
         $request = [];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
         (new GetWeatherInformation)->execute($request);
     }
 }

--- a/tests/Unit/Services/Task/CreateTaskTest.php
+++ b/tests/Unit/Services/Task/CreateTaskTest.php
@@ -7,7 +7,7 @@ use App\Models\Contact\Task;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
 use App\Services\Task\CreateTask;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
@@ -103,7 +103,7 @@ class CreateTaskTest extends TestCase
             'account_id' => $contact->account->id,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $createTask = new CreateTask;
         $task = $createTask->execute($request);

--- a/tests/Unit/Services/Task/DestroyTaskTest.php
+++ b/tests/Unit/Services/Task/DestroyTaskTest.php
@@ -6,7 +6,7 @@ use Tests\TestCase;
 use App\Models\Contact\Task;
 use App\Models\Account\Account;
 use App\Services\Task\DestroyTask;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
@@ -41,7 +41,7 @@ class DestroyTaskTest extends TestCase
             'task_id' => 2,
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $destroyTaskService = new DestroyTask;
         $result = $destroyTaskService->execute($request);

--- a/tests/Unit/Services/Task/UpdateTaskTest.php
+++ b/tests/Unit/Services/Task/UpdateTaskTest.php
@@ -7,7 +7,7 @@ use App\Models\Contact\Task;
 use App\Models\Account\Account;
 use App\Models\Contact\Contact;
 use App\Services\Task\UpdateTask;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 
@@ -87,7 +87,7 @@ class UpdateTaskTest extends TestCase
             'description' => 'description',
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $updateTask = new UpdateTask;
         $task = $updateTask->execute($request);

--- a/tests/Unit/Services/User/EmailChangeTest.php
+++ b/tests/Unit/Services/User/EmailChangeTest.php
@@ -7,7 +7,7 @@ use App\Models\User\User;
 use App\Models\Account\Account;
 use App\Services\User\EmailChange;
 use App\Notifications\ConfirmEmail;
-use App\Exceptions\MissingParameterException;
+use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Facades\Notification as NotificationFacade;
@@ -55,7 +55,7 @@ class EmailChangeTest extends TestCase
             'email' => 'email@email.com',
         ];
 
-        $this->expectException(MissingParameterException::class);
+        $this->expectException(ValidationException::class);
 
         $emailChangeService = new EmailChange;
         $user = $emailChangeService->execute($request);


### PR DESCRIPTION
This fix a lot of sentry errors.
Services used to throw a `MissingParameterException` when a validation failed. But we can use the Laravel's `ValidationException` instead, which is easier (and already not reported).