### PR TITLE
chore: add foreign keys to multiple tables

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ New features:
 
 Enhancements:
 
+* Add foreign keys to reminders, reminder rules, contacts and life events tables
 * Add number of life events on the contact profile page
 
 Fixes:

--- a/database/migrations/2019_01_05_202557_add_foreign_keys_to_reminder.php
+++ b/database/migrations/2019_01_05_202557_add_foreign_keys_to_reminder.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Models\Contact\Contact;
+use App\Models\Contact\Reminder;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+class AddForeignKeysToReminder extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // we need to parse the reminders table to make sure that we don't have
+        // "ghost" reminders that are not associated with any contact (as it's
+        // the case in production)
+        Reminder::chunk(200, function ($reminders) {
+            foreach ($reminders as $reminder) {
+                try {
+                    Contact::findOrFail($reminder->contact_id);
+                } catch (ModelNotFoundException $e) {
+                    $reminder->delete();
+                    continue;
+                }
+            }
+        });
+
+        Schema::table('reminders', function (Blueprint $table) {
+            $table->unsignedInteger('account_id')->change();
+            $table->unsignedInteger('contact_id')->change();
+            $table->foreign('account_id')->references('id')->on('accounts')->onDelete('cascade');
+            $table->foreign('contact_id')->references('id')->on('contacts')->onDelete('cascade');
+        });
+    }
+}

--- a/database/migrations/2019_01_05_202748_add_foreign_key_to_reminder_rule.php
+++ b/database/migrations/2019_01_05_202748_add_foreign_key_to_reminder_rule.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Models\Account\Account;
+use App\Models\Contact\ReminderRule;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+class AddForeignKeyToReminderRule extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // we need to parse the reminder rules table to make sure that we don't
+        // have "ghost" reminder rules that are not associated with any contact
+        // (as it's the case in production)
+        ReminderRule::chunk(200, function ($reminderRules) {
+            foreach ($reminderRules as $reminderRule) {
+                try {
+                    Account::findOrFail($reminderRule->account_id);
+                } catch (ModelNotFoundException $e) {
+                    $reminderRule->delete();
+                    continue;
+                }
+            }
+        });
+
+        Schema::table('reminder_rules', function (Blueprint $table) {
+            $table->unsignedInteger('account_id')->change();
+            $table->foreign('account_id')->references('id')->on('accounts')->onDelete('cascade');
+        });
+    }
+}

--- a/database/migrations/2019_01_05_202938_add_foreign_key_to_contacts.php
+++ b/database/migrations/2019_01_05_202938_add_foreign_key_to_contacts.php
@@ -1,0 +1,73 @@
+<?php
+
+use App\Models\Contact\Contact;
+use App\Models\Instance\SpecialDate;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+class AddForeignKeyToContacts extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // we need to parse the special date table to make sure that we don't have
+        // "ghost" special date that are not associated with any contact (as it's
+        // the case in production)
+        $contacts = Contact::select('birthday_special_date_id')
+            ->whereNotNull('birthday_special_date_id')
+            ->chunk(50, function ($contacts) {
+                foreach ($contacts as $contact) {
+                    try {
+                        SpecialDate::findOrFail($contact->birthday_special_date_id);
+                    } catch (ModelNotFoundException $e) {
+                        $contact->birthday_special_date_id = null;
+                        $contact->save();
+                        continue;
+                    }
+                }
+            });
+
+        $contacts = Contact::select('first_met_special_date_id')
+            ->whereNotNull('first_met_special_date_id')
+            ->chunk(50, function ($contacts) {
+                foreach ($contacts as $contact) {
+                    try {
+                        SpecialDate::findOrFail($contact->first_met_special_date_id);
+                    } catch (ModelNotFoundException $e) {
+                        $contact->first_met_special_date_id = null;
+                        $contact->save();
+                        continue;
+                    }
+                }
+            });
+
+        $contacts = Contact::select('deceased_special_date_id')
+            ->whereNotNull('deceased_special_date_id')
+            ->chunk(50, function ($contacts) {
+                foreach ($contacts as $contact) {
+                    try {
+                        SpecialDate::findOrFail($contact->deceased_special_date_id);
+                    } catch (ModelNotFoundException $e) {
+                        $contact->deceased_special_date_id = null;
+                        $contact->save();
+                        continue;
+                    }
+                }
+            });
+
+        Schema::table('contacts', function (Blueprint $table) {
+            $table->unsignedInteger('birthday_special_date_id')->change();
+            $table->unsignedInteger('first_met_special_date_id')->change();
+            $table->unsignedInteger('deceased_special_date_id')->change();
+            $table->foreign('birthday_special_date_id')->references('id')->on('special_dates')->onDelete('set null');
+            $table->foreign('first_met_special_date_id')->references('id')->on('special_dates')->onDelete('set null');
+            $table->foreign('deceased_special_date_id')->references('id')->on('special_dates')->onDelete('set null');
+        });
+    }
+}

--- a/database/migrations/2019_01_05_203201_add_foreign_key_for_reminder_in_life-events_table.php
+++ b/database/migrations/2019_01_05_203201_add_foreign_key_for_reminder_in_life-events_table.php
@@ -1,0 +1,41 @@
+<?php
+
+
+use App\Models\Contact\Reminder;
+use App\Models\Contact\LifeEvent;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+class AddForeignKeyForReminderInLifeEventsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        LifeEvent::select('reminder_id')
+            ->whereNotNull('reminder_id')
+            ->chunk(50, function ($lifeEvents) {
+                foreach ($lifeEvents as $lifeEvent) {
+                    try {
+                        Reminder::findOrFail($lifeEvent->reminder_id);
+                    } catch (ModelNotFoundException $e) {
+                        $lifeEvent->reminder_id = null;
+                        $lifeEvent->save();
+                        continue;
+                    }
+                }
+            });
+
+        Schema::disableForeignKeyConstraints();
+        Schema::table('life_events', function (Blueprint $table) {
+            $table->unsignedInteger('reminder_id')->change();
+            $table->foreign('reminder_id')->references('id')->on('reminders')->onDelete('set null');
+        });
+        Schema::enableForeignKeyConstraints();
+    }
+}

--- a/tests/Unit/Models/ReminderRuleTest.php
+++ b/tests/Unit/Models/ReminderRuleTest.php
@@ -42,7 +42,7 @@ class ReminderRuleTest extends TestCase
 
     public function test_it_toggles_the_status()
     {
-        $reminderRule = new ReminderRule;
+        $reminderRule = factory(ReminderRule::class)->create();
         $reminderRule->active = true;
         $reminderRule->save();
 


### PR DESCRIPTION
This is part of a bigger move to add foreign keys everywhere, in order to ensure database consistency.