### PR TITLE
chore: reduce the numbers of hashing rounds in CI

### DIFF
--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Contracts\Console\Kernel;
 
 trait CreatesApplication
@@ -19,6 +20,10 @@ trait CreatesApplication
         $app->make(Kernel::class)->bootstrap();
 
         App::setLocale('en');
+
+        // set the bcrypt hashing rounds (the minimum allowed).
+        // this reduces the amount of cycles needed to manage users.
+        Hash::setRounds(4);
 
         return $app;
     }


### PR DESCRIPTION
This decreases the tests time by 31% on my machine. Thanks to [this tweet](https://twitter.com/taylorotwell/status/943135617466105856?ref_src=twsrc%5Etfw%7Ctwcamp%5Etweetembed%7Ctwterm%5E943135617466105856&ref_url=https%3A%2F%2Flaravel-news.com%2Ftips-to-speed-up-phpunit-tests).

cc @asbiin 