### PR TITLE
Fixed Issue 2279 Search doesn't match last name when searching both name

### DIFF
--- a/app/Helpers/StringHelper.php
+++ b/app/Helpers/StringHelper.php
@@ -16,15 +16,21 @@ class StringHelper
     {
         $first = true;
         $queryString = '';
-        $searchTerm = DB::connection()->getPdo()->quote('%'.$searchTerm.'%');
+        $searchTerms = explode(' ', $searchTerm);
 
-        foreach ($array as $column) {
-            if ($first) {
-                $first = false;
-            } else {
-                $queryString .= ' or ';
+        foreach($searchTerms as $searchTerm)
+        {
+            $searchTerm = DB::connection()->getPdo()->quote('%'.$searchTerm.'%');
+
+            foreach ($array as $column) {
+
+                if ($first) {
+                    $first = false;
+                } else {
+                    $queryString .= ' or ';
+                }
+                $queryString .= $column.' LIKE '.$searchTerm;
             }
-            $queryString .= $column.' LIKE '.$searchTerm;
         }
 
         return $queryString;


### PR DESCRIPTION
Search doesn't match last name when searching both first and last name
 ( https://github.com/monicahq/monica/issues/2279 )
- Corrected Query and consider all keywords ( accept space as well)
- Fixed Open Issue
