### PR TITLE
feat: redirect to real contact when it's a partial one

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@ New features:
 
 Enhancements:
 
+* Redirect to the related real contact when trying to display a partial contact
 * Use iterator reader for vcard imports
 * Accept last name when using contact search field
 * Register all app services as singleton

--- a/app/Http/Controllers/ContactsController.php
+++ b/app/Http/Controllers/ContactsController.php
@@ -210,7 +210,7 @@ class ContactsController extends Controller
         // make sure we don't display a significant other if it's not set as a
         // real contact
         if ($contact->is_partial) {
-            return redirect()->route('people.index');
+            return redirect()->route('people.show', $contact->getRelatedRealContact());
         }
         $contact->load(['notes' => function ($query) {
             $query->orderBy('updated_at', 'desc');

--- a/app/Models/Contact/Contact.php
+++ b/app/Models/Contact/Contact.php
@@ -1442,7 +1442,7 @@ class Contact extends Model
     /**
      * Gets the first contact related to this contact if the current contact is
      * partial.
-     * 
+     *
      * @return self
      */
     public function getRelatedRealContact()

--- a/app/Models/Contact/Contact.php
+++ b/app/Models/Contact/Contact.php
@@ -1442,6 +1442,8 @@ class Contact extends Model
     /**
      * Gets the first contact related to this contact if the current contact is
      * partial.
+     * 
+     * @return self
      */
     public function getRelatedRealContact()
     {
@@ -1457,6 +1459,15 @@ class Contact extends Model
                         ]);
             })
             ->first();
+    }
+
+    /**
+     * Get the link to this contact, or the related real contact.
+     * @return string
+     */
+    public function getLink()
+    {
+        return route('people.show', $this->is_partial ? $this->getRelatedRealContact() : $this);
     }
 
     /**

--- a/app/Notifications/StayInTouchEmail.php
+++ b/app/Notifications/StayInTouchEmail.php
@@ -59,7 +59,7 @@ class StayInTouchEmail extends LaravelNotification implements ShouldQueue
                 'name' => $this->contact->name,
                 'frequency' => $this->contact->stay_in_touch_frequency,
             ]))
-            ->action(trans('mail.footer_contact_info2', ['name' => $this->contact->name]), route('people.show', $this->contact));
+            ->action(trans('mail.footer_contact_info2', ['name' => $this->contact->name]), $this->contact->getLink());
     }
 
     /**

--- a/app/Notifications/UserNotified.php
+++ b/app/Notifications/UserNotified.php
@@ -66,7 +66,7 @@ class UserNotified extends LaravelNotification implements ShouldQueue
             ]))
             ->line($this->reminderOutbox->reminder->title)
             ->line(trans('mail.for', ['name' => $contact->name]))
-            ->action(trans('mail.footer_contact_info2', ['name' => $contact->name]), route('people.show', $contact));
+            ->action(trans('mail.footer_contact_info2', ['name' => $contact->name]), $contact->getLink());
 
         if (! is_null($this->reminderOutbox->reminder->description)) {
             $message = $message

--- a/app/Notifications/UserReminded.php
+++ b/app/Notifications/UserReminded.php
@@ -61,7 +61,7 @@ class UserReminded extends LaravelNotification implements ShouldQueue
             ->greeting(trans('mail.greetings', ['username' => $user->first_name]))
             ->line(trans('mail.want_reminded_of', ['reason' => $this->reminderOutbox->reminder->title]))
             ->line(trans('mail.for', ['name' => $contact->name]))
-            ->action(trans('mail.footer_contact_info2', ['name' => $contact->name]), route('people.show', $contact));
+            ->action(trans('mail.footer_contact_info2', ['name' => $contact->name]), $contact->getLink());
 
         if (! is_null($this->reminderOutbox->reminder->description)) {
             $message = $message

--- a/app/Services/VCalendar/ExportTask.php
+++ b/app/Services/VCalendar/ExportTask.php
@@ -93,7 +93,7 @@ class ExportTask extends BaseService
             $vtodo->DESCRIPTION = $task->description;
         }
         if ($contact) {
-            $vtodo->ATTACH = route('people.show', $contact);
+            $vtodo->ATTACH = $contact->getLink();
         }
         if ($task->completed) {
             $vtodo->STATUS = 'COMPLETED';

--- a/app/Services/VCalendar/ExportVCalendar.php
+++ b/app/Services/VCalendar/ExportVCalendar.php
@@ -98,10 +98,10 @@ class ExportVCalendar extends BaseService
         if ($contact) {
             $name = $contact->name;
             $vevent->SUMMARY = trans('people.reminders_birthday', ['name' => $name]);
-            $vevent->ATTACH = route('people.show', $contact);
+            $vevent->ATTACH = $contact->getLink();
             $vevent->DESCRIPTION = trans('mail.footer_contact_info2_link', [
                 'name' => $name,
-                'url' => route('people.show', $contact),
+                'url' => $contact->getLink(),
             ]);
         }
     }

--- a/app/Services/VCard/ExportVCard.php
+++ b/app/Services/VCard/ExportVCard.php
@@ -60,7 +60,7 @@ class ExportVCard extends BaseService
         // Basic information
         $vcard = new VCard([
             'UID' => $contact->uuid,
-            'SOURCE' => route('people.show', $contact),
+            'SOURCE' => $contact->getLink(),
             'VERSION' => '4.0',
         ]);
 


### PR DESCRIPTION
- add a function `Contact::getLink` to get the 'people.show' route from either the contact, or the related real contact if the current contact is a partial one.
- use this function in mail templates, DAV export, 
- change of the behavior of `ContactsController::show` in case it's a partial contact, redirect to the related real contact, and not to the 'people.index' route.

This will fix #2232
