### PR TITLE
fix: fix middleware priority order to always set locale after authenticate

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -27,6 +27,7 @@ Enhancements:
 
 Fixes:
 
+* Fix middleware priority order to always set locale after authenticate
 * Accept lastname_firstname name order for VCard imports (FN field)
 * Fix vue.js DateTime picker to type a date in other format than en-us one
 * Fix DateTime parse when compact format is used

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -84,8 +84,10 @@ class Kernel extends HttpKernel
         \Illuminate\Session\Middleware\StartSession::class,
         \Illuminate\View\Middleware\ShareErrorsFromSession::class,
         \App\Http\Middleware\Authenticate::class,
+        \App\Http\Middleware\AuthenticateWithTokenOnBasicAuth::class,
         \Illuminate\Session\Middleware\AuthenticateSession::class,
         \Illuminate\Routing\Middleware\SubstituteBindings::class,
         \Illuminate\Auth\Middleware\Authorize::class,
+        \App\Http\Middleware\CheckLocale::class,
     ];
 }


### PR DESCRIPTION
When using api and dav, locale is not set right, because call to the middleware happens too soon.
Changing the middleware priority fix this.