### PR TITLE
fix: fix addresses and contact fields imports on VCard import

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -28,6 +28,7 @@ Enhancements:
 
 Fixes:
 
+* Fix addresses and contact fields imports on VCard import
 * Remove users without an existing account in the accounts table
 * Fix case when schedule date is null
 * Add phpstan analyser, and fix a lot of issues

--- a/app/Helpers/LocaleHelper.php
+++ b/app/Helpers/LocaleHelper.php
@@ -3,8 +3,10 @@
 namespace App\Helpers;
 
 use Matriphe\ISO639\ISO639;
+use libphonenumber\PhoneNumberUtil;
 use Illuminate\Support\Facades\Auth;
 use libphonenumber\PhoneNumberFormat;
+use libphonenumber\NumberParseException;
 
 class LocaleHelper
 {
@@ -174,12 +176,12 @@ class LocaleHelper
         }
 
         try {
-            $phoneUtil = \libphonenumber\PhoneNumberUtil::getInstance();
+            $phoneUtil = PhoneNumberUtil::getInstance();
 
-            $phoneInstance = $phoneUtil->parse($tel, strtoupper($iso));
+            $phoneInstance = $phoneUtil->parse($tel, mb_strtoupper($iso));
 
             $tel = $phoneUtil->format($phoneInstance, $format);
-        } catch (\libphonenumber\NumberParseException $e) {
+        } catch (NumberParseException $e) {
             // Do nothing if the number cannot be parsed successfully
         }
 

--- a/app/Helpers/VCardHelper.php
+++ b/app/Helpers/VCardHelper.php
@@ -9,19 +9,20 @@ class VCardHelper
     /**
      * Get country model object from given VCard file.
      *
-     * @param VCard $VCard
+     * @param VCard $vcard
      * @return string|null
      */
-    public static function getCountryISOFromSabreVCard(VCard $VCard)
+    public static function getCountryISOFromSabreVCard(VCard $vCard)
     {
-        $VCardAddress = $VCard->ADR;
+        $vCardAddress = $vCard->ADR;
 
-        if (empty($VCardAddress)) {
+        if (empty($vCardAddress)) {
             return;
         }
 
-        if (count($VCardAddress->getParts()) >= 7) {
-            return CountriesHelper::find($VCardAddress->getParts()[6]);
+        $country = array_get($vCardAddress->getParts(), 6);
+        if (!empty($country)) {
+            return CountriesHelper::find($country);
         }
     }
 }

--- a/app/Helpers/VCardHelper.php
+++ b/app/Helpers/VCardHelper.php
@@ -9,7 +9,7 @@ class VCardHelper
     /**
      * Get country model object from given VCard file.
      *
-     * @param VCard $vcard
+     * @param VCard $vCard
      * @return string|null
      */
     public static function getCountryISOFromSabreVCard(VCard $vCard)
@@ -20,7 +20,7 @@ class VCardHelper
             return;
         }
 
-        $country = array_get($vCardAddress->getParts(), 6);
+        $country = array_get($vCardAddress->getParts(), '6');
         if (! empty($country)) {
             return CountriesHelper::find($country);
         }

--- a/app/Helpers/VCardHelper.php
+++ b/app/Helpers/VCardHelper.php
@@ -21,7 +21,7 @@ class VCardHelper
         }
 
         $country = array_get($vCardAddress->getParts(), 6);
-        if (!empty($country)) {
+        if (! empty($country)) {
             return CountriesHelper::find($country);
         }
     }

--- a/app/Models/Contact/Address.php
+++ b/app/Models/Contact/Address.php
@@ -43,7 +43,7 @@ class Address extends Model
     }
 
     /**
-     * Get the contact record associated with the address.
+     * Get the place record associated with the address.
      *
      * @return BelongsTo
      */

--- a/app/Models/Contact/Contact.php
+++ b/app/Models/Contact/Contact.php
@@ -19,7 +19,6 @@ use App\Models\Instance\SpecialDate;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Storage;
-use App\Models\Contact\ContactFieldType;
 use App\Models\Account\ActivityStatistic;
 use App\Models\Relationship\Relationship;
 use Illuminate\Database\Eloquent\Builder;

--- a/app/Models/Contact/Contact.php
+++ b/app/Models/Contact/Contact.php
@@ -19,6 +19,7 @@ use App\Models\Instance\SpecialDate;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Storage;
+use App\Models\Contact\ContactFieldType;
 use App\Models\Account\ActivityStatistic;
 use App\Models\Relationship\Relationship;
 use Illuminate\Database\Eloquent\Builder;
@@ -1102,11 +1103,7 @@ class Contact extends Model
      */
     public function getGravatar($size)
     {
-        $emails = $this->contactFields()
-            ->whereHas('contactFieldType', function ($query) {
-                $query->where('type', '=', 'email');
-            })
-            ->get();
+        $emails = $this->contactFields()->email()->get();
 
         foreach ($emails as $email) {
             if (empty($email) || empty($email->data)) {

--- a/app/Models/Contact/ContactField.php
+++ b/app/Models/Contact/ContactField.php
@@ -54,4 +54,30 @@ class ContactField extends Model
     {
         return $value;
     }
+
+    /**
+     * Scope a query to only include contact field of email type.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeEmail($query)
+    {
+        return $query->whereHas('contactFieldType', function ($query) {
+            $query->where('type', '=', ContactFieldType::EMAIL);
+        });
+    }
+
+    /**
+     * Scope a query to only include contact field of phone type.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopePhone($query)
+    {
+        return $query->whereHas('contactFieldType', function ($query) {
+            $query->where('type', '=', ContactFieldType::PHONE);
+        });
+    }
 }

--- a/app/Models/Contact/ContactFieldType.php
+++ b/app/Models/Contact/ContactFieldType.php
@@ -19,6 +19,20 @@ class ContactFieldType extends Model
     protected $table = 'contact_field_types';
 
     /**
+     * Email type contact field.
+     * 
+     * @var string
+     */
+    public const EMAIL = 'email';
+
+    /**
+     * Phone type contact field.
+     * 
+     * @var string
+     */
+    public const PHONE = 'phone';
+
+    /**
      * Get the account record associated with the contact field type.
      *
      * @return BelongsTo

--- a/app/Models/Contact/ContactFieldType.php
+++ b/app/Models/Contact/ContactFieldType.php
@@ -20,14 +20,14 @@ class ContactFieldType extends Model
 
     /**
      * Email type contact field.
-     * 
+     *
      * @var string
      */
     public const EMAIL = 'email';
 
     /**
      * Phone type contact field.
-     * 
+     *
      * @var string
      */
     public const PHONE = 'phone';

--- a/app/Services/VCard/ExportVCard.php
+++ b/app/Services/VCard/ExportVCard.php
@@ -7,6 +7,7 @@ use App\Services\BaseService;
 use App\Models\Contact\Gender;
 use App\Models\Contact\Contact;
 use Sabre\VObject\Component\VCard;
+use App\Models\Contact\ContactFieldType;
 
 class ExportVCard extends BaseService
 {
@@ -181,10 +182,10 @@ class ExportVCard extends BaseService
     {
         foreach ($contact->contactFields as $contactField) {
             switch ($contactField->contactFieldType->type) {
-                case 'phone':
+                case ContactFieldType::PHONE:
                     $vcard->add('TEL', $this->escape($contactField->data));
                     break;
-                case 'email':
+                case ContactFieldType::EMAIL:
                     $vcard->add('EMAIL', $this->escape($contactField->data));
                     break;
                 default:

--- a/app/Services/VCard/ImportVCard.php
+++ b/app/Services/VCard/ImportVCard.php
@@ -659,7 +659,6 @@ class ImportVCard extends BaseService
                                 ->sortBy('id');
 
         foreach ($entry->ADR as $adr) {
-
             $parts = $adr->getParts();
             $addressContent = [
                 'street' => $this->formatValue(array_get($parts, 2)),
@@ -677,7 +676,7 @@ class ImportVCard extends BaseService
                 app(CreateAddress::class)->execute([
                     'account_id' => $contact->account_id,
                     'contact_id' => $contact->id,
-                ] + 
+                ] +
                     $addressContent
                 );
             } else {
@@ -687,7 +686,7 @@ class ImportVCard extends BaseService
                     'contact_id' => $contact->id,
                     'address_id' => $address->id,
                     'name' => $address->name,
-                ] + 
+                ] +
                     $addressContent
                 );
             }

--- a/app/Services/VCard/ImportVCard.php
+++ b/app/Services/VCard/ImportVCard.php
@@ -20,6 +20,8 @@ use Sabre\VObject\Component\VCard;
 use App\Models\Contact\ContactField;
 use App\Models\Contact\ContactFieldType;
 use App\Services\Contact\Address\CreateAddress;
+use App\Services\Contact\Address\UpdateAddress;
+use App\Services\Contact\Address\DestroyAddress;
 use App\Services\Contact\Contact\UpdateBirthdayInformation;
 
 class ImportVCard extends BaseService
@@ -297,7 +299,7 @@ class ImportVCard extends BaseService
      */
     private function hasFirstnameInN(VCard $entry) : bool
     {
-        return $entry->N !== null && ! empty($entry->N->getParts()[1]);
+        return $entry->N !== null && ! empty(array_get($entry->N->getParts(), 1));
     }
 
     /**
@@ -370,7 +372,7 @@ class ImportVCard extends BaseService
         if ($this->isValidEmail((string) $entry->EMAIL)) {
             $contactField = ContactField::where([
                 'account_id' => $this->accountId,
-                'contact_field_type_id' => $this->getContactFieldTypeId('email'),
+                'contact_field_type_id' => $this->getContactFieldTypeId(ContactFieldType::EMAIL),
             ])->whereIn('data', iterator_to_array($entry->EMAIL))->first();
 
             if ($contactField) {
@@ -463,15 +465,15 @@ class ImportVCard extends BaseService
     {
         if ($this->hasFirstnameInN($entry)) {
             $parts = $entry->N->getParts();
-            $count = count($parts);
+
             $name = '';
-            if ($count >= 2) {
+            if (! empty(array_get($parts, 1))) {
                 $name .= $this->formatValue($parts[1]);
             }
-            if ($count >= 3 && ! empty($parts[2])) {
+            if (! empty(array_get($parts, 2))) {
                 $name .= ' '.$this->formatValue($parts[2]);
             }
-            if ($count >= 1 && ! empty($parts[0])) {
+            if (! empty(array_get($parts, 0))) {
                 $name .= ' '.$this->formatValue($parts[0]);
             }
             $name .= ' '.$this->formatValue($entry->EMAIL);
@@ -496,17 +498,9 @@ class ImportVCard extends BaseService
     private function importFromN(Contact $contact, VCard $entry): void
     {
         $parts = $entry->N->getParts();
-        $count = count($parts);
-
-        if ($count >= 1) {
-            $contact->last_name = $this->formatValue($parts[0]);
-        }
-        if ($count >= 2) {
-            $contact->first_name = $this->formatValue($parts[1]);
-        }
-        if ($count >= 3) {
-            $contact->middle_name = $this->formatValue($parts[2]);
-        }
+        $contact->last_name = $this->formatValue(array_get($parts, 0));
+        $contact->first_name = $this->formatValue(array_get($parts, 1));
+        $contact->middle_name = $this->formatValue(array_get($parts, 2));
         // prefix [3]
         // suffix [4]
 
@@ -660,16 +654,51 @@ class ImportVCard extends BaseService
             return;
         }
 
+        $addresses = $contact->addresses()
+                                ->get()
+                                ->sortBy('id');
+
         foreach ($entry->ADR as $adr) {
-            app(CreateAddress::class)->execute([
+
+            $parts = $adr->getParts();
+            $addressContent = [
+                'street' => $this->formatValue(array_get($parts, 2)),
+                'city' => $this->formatValue(array_get($parts, 3)),
+                'province' => $this->formatValue(array_get($parts, 4)),
+                'postal_code' => $this->formatValue(array_get($parts, 5)),
+                'country' => CountriesHelper::find(array_get($parts, 6)),
+            ];
+
+            // We assume addresses are in the same order
+            $address = $addresses->shift();
+
+            if (is_null($address)) {
+                // Address does not exist
+                app(CreateAddress::class)->execute([
+                    'account_id' => $contact->account_id,
+                    'contact_id' => $contact->id,
+                ] + 
+                    $addressContent
+                );
+            } else {
+                // Address has to be updated
+                app(UpdateAddress::class)->execute([
+                    'account_id' => $contact->account_id,
+                    'contact_id' => $contact->id,
+                    'address_id' => $address->id,
+                    'name' => $address->name,
+                ] + 
+                    $addressContent
+                );
+            }
+        }
+
+        foreach ($addresses as $address) {
+            // Remaining addresses have to be removed
+            app(DestroyAddress::class)->execute([
                 'account_id' => $contact->account_id,
-                'contact_id' => $contact->id,
-                'street' => $this->formatValue($adr->getParts()[2]),
-                'city' => $this->formatValue($adr->getParts()[3]),
-                'province' => $this->formatValue($adr->getParts()[4]),
-                'postal_code' => $this->formatValue($adr->getParts()[5]),
-                'country' => CountriesHelper::find($adr->getParts()[6]),
-            ]);
+                'address_id' => $address->id,
+                ]);
         }
     }
 
@@ -684,21 +713,40 @@ class ImportVCard extends BaseService
             return;
         }
 
-        $contactFieldTypeId = $this->getContactFieldTypeId('email');
+        $contactFieldTypeId = $this->getContactFieldTypeId(ContactFieldType::EMAIL);
         if (! $contactFieldTypeId) {
             // Case of contact field type email does not exist
             return;
         }
 
+        $emails = $contact->contactFields()
+                            ->email()
+                            ->get()
+                            ->sortBy('id');
+
         foreach ($entry->EMAIL as $email) {
-            if ($this->isValidEmail($email)) {
-                ContactField::firstOrCreate([
+            // We assume contact fields are in the same order
+            $email1 = $emails->shift();
+
+            if (is_null($email1)) {
+                // Contact field does not exist
+                ContactField::create([
                     'account_id' => $contact->account_id,
                     'contact_id' => $contact->id,
                     'data' => $this->formatValue($email),
                     'contact_field_type_id' => $contactFieldTypeId,
                 ]);
+            } else {
+                // Contact field has to be updated
+                $email1->update([
+                    'data' => $this->formatValue($email),
+                ]);
             }
+        }
+
+        foreach ($emails as $email) {
+            // Remaining contact fields have to be removed
+            $email->delete();
         }
     }
 
@@ -713,25 +761,45 @@ class ImportVCard extends BaseService
             return;
         }
 
-        $contactFieldTypeId = $this->getContactFieldTypeId('phone');
+        $contactFieldTypeId = $this->getContactFieldTypeId(ContactFieldType::PHONE);
         if (! $contactFieldTypeId) {
             // Case of contact field type phone does not exist
             return;
         }
 
+        $phones = $contact->contactFields()
+                            ->phone()
+                            ->get()
+                            ->sortBy('id');
+
+        $countryISO = VCardHelper::getCountryISOFromSabreVCard($entry);
+
         foreach ($entry->TEL as $tel) {
-            $tel = (string) $entry->TEL;
+            // We assume contact fields are in the same order
+            $phone = $phones->shift();
 
-            $countryISO = VCardHelper::getCountryISOFromSabreVCard($entry);
+            $tel = (string) $tel;
+            $tel = LocaleHelper::formatTelephoneNumberByISO($tel, $countryISO, starts_with($tel, '+') ? \libphonenumber\PhoneNumberFormat::INTERNATIONAL : \libphonenumber\PhoneNumberFormat::NATIONAL);
 
-            $tel = LocaleHelper::formatTelephoneNumberByISO($tel, $countryISO);
+            if (is_null($phone)) {
+                // Contact field does not exist
+                ContactField::create([
+                    'account_id' => $contact->account_id,
+                    'contact_id' => $contact->id,
+                    'data' => $this->formatValue($tel),
+                    'contact_field_type_id' => $contactFieldTypeId,
+                ]);
+            } else {
+                // Contact field has to be updated
+                $phone->update([
+                    'data' => $this->formatValue($tel),
+                ]);
+            }
+        }
 
-            ContactField::firstOrCreate([
-                'account_id' => $contact->account_id,
-                'contact_id' => $contact->id,
-                'data' => $this->formatValue($tel),
-                'contact_field_type_id' => $contactFieldTypeId,
-            ]);
+        foreach ($phones as $phone) {
+            // Remaining contact fields have to be removed
+            $phone->delete();
         }
     }
 

--- a/app/Services/VCard/ImportVCard.php
+++ b/app/Services/VCard/ImportVCard.php
@@ -299,7 +299,7 @@ class ImportVCard extends BaseService
      */
     private function hasFirstnameInN(VCard $entry) : bool
     {
-        return $entry->N !== null && ! empty(array_get($entry->N->getParts(), 1));
+        return $entry->N !== null && ! empty(array_get($entry->N->getParts(), '1'));
     }
 
     /**
@@ -467,13 +467,13 @@ class ImportVCard extends BaseService
             $parts = $entry->N->getParts();
 
             $name = '';
-            if (! empty(array_get($parts, 1))) {
+            if (! empty(array_get($parts, '1'))) {
                 $name .= $this->formatValue($parts[1]);
             }
-            if (! empty(array_get($parts, 2))) {
+            if (! empty(array_get($parts, '2'))) {
                 $name .= ' '.$this->formatValue($parts[2]);
             }
-            if (! empty(array_get($parts, 0))) {
+            if (! empty(array_get($parts, '0'))) {
                 $name .= ' '.$this->formatValue($parts[0]);
             }
             $name .= ' '.$this->formatValue($entry->EMAIL);
@@ -498,9 +498,9 @@ class ImportVCard extends BaseService
     private function importFromN(Contact $contact, VCard $entry): void
     {
         $parts = $entry->N->getParts();
-        $contact->last_name = $this->formatValue(array_get($parts, 0));
-        $contact->first_name = $this->formatValue(array_get($parts, 1));
-        $contact->middle_name = $this->formatValue(array_get($parts, 2));
+        $contact->last_name = $this->formatValue(array_get($parts, '0'));
+        $contact->first_name = $this->formatValue(array_get($parts, '1'));
+        $contact->middle_name = $this->formatValue(array_get($parts, '2'));
         // prefix [3]
         // suffix [4]
 
@@ -661,11 +661,11 @@ class ImportVCard extends BaseService
         foreach ($entry->ADR as $adr) {
             $parts = $adr->getParts();
             $addressContent = [
-                'street' => $this->formatValue(array_get($parts, 2)),
-                'city' => $this->formatValue(array_get($parts, 3)),
-                'province' => $this->formatValue(array_get($parts, 4)),
-                'postal_code' => $this->formatValue(array_get($parts, 5)),
-                'country' => CountriesHelper::find(array_get($parts, 6)),
+                'street' => $this->formatValue(array_get($parts, '2')),
+                'city' => $this->formatValue(array_get($parts, '3')),
+                'province' => $this->formatValue(array_get($parts, '4')),
+                'postal_code' => $this->formatValue(array_get($parts, '5')),
+                'country' => CountriesHelper::find(array_get($parts, '6')),
             ];
 
             // We assume addresses are in the same order

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -21,6 +21,8 @@ parameters:
         - '#Call to an undefined method Illuminate\\Database\\Eloquent\\Relations\\HasMany::isIdea\(\)\.#'
         - '#Call to an undefined method Illuminate\\Database\\Eloquent\\Relations\\HasMany::inProgress\(\)\.#'
         - '#Call to an undefined method Illuminate\\Database\\Eloquent\\Relations\\HasMany::completed\(\)\.#'
+        - '#Call to an undefined method Illuminate\\Database\\Eloquent\\Relations\\HasMany::email\(\)\.#'
+        - '#Call to an undefined method Illuminate\\Database\\Eloquent\\Relations\\HasMany::phone\(\)\.#'
         # Level 3
         - '#Method [a-zA-Z0-9\\_:]+\(\) should return [a-zA-Z0-9\\_\|]+ but empty return statement found\.#'
         - '#Method [a-zA-Z0-9\\_:]+\(\) should return Illuminate\\Http\\Response but returns [a-zA-Z0-9\\_]+\.#'

--- a/tests/Api/DAV/CardEtag.php
+++ b/tests/Api/DAV/CardEtag.php
@@ -5,6 +5,7 @@ namespace Tests\Api\DAV;
 use App\Models\Contact\Task;
 use App\Models\Contact\Contact;
 use App\Models\Instance\SpecialDate;
+use App\Models\Contact\ContactFieldType;
 
 trait CardEtag
 {
@@ -48,10 +49,10 @@ GENDER:O;
         }
         foreach ($contact->contactFields as $contactField) {
             switch ($contactField->contactFieldType->type) {
-                case 'phone':
+                case ContactFieldType::PHONE:
                     $data .= "TEL:{$contactField->data}\n";
                     break;
-                case 'email':
+                case ContactFieldType::EMAIL:
                     $data .= "EMAIL:{$contactField->data}\n";
                     break;
                 default:

--- a/tests/Unit/Services/VCard/ImportVCardTest.php
+++ b/tests/Unit/Services/VCard/ImportVCardTest.php
@@ -796,7 +796,7 @@ class ImportVCardTest extends TestCase
         ]);
     }
 
-    public function test_it_imports_phone_by_international_format()
+    public function test_it_imports_phone_by_national_format()
     {
         $account = factory(Account::class)->create([]);
         $importVCard = new ImportVCard;
@@ -804,6 +804,33 @@ class ImportVCardTest extends TestCase
 
         $vcard = new VCard([
             'TEL' => '202-555-0191',
+            'ADR' => ['', '', '17 Shakespeare Ave.', 'Southampton', '', 'SO17 2HB', 'United Kingdom'],
+        ]);
+
+        $contact = factory(Contact::class)->create([
+            'account_id' => $account->id,
+        ]);
+        $contactFieldType = factory(ContactFieldType::class)->create([
+            'account_id' => $account->id,
+            'type' => 'phone',
+        ]);
+        $this->invokePrivateMethod($importVCard, 'importTel', [$contact, $vcard]);
+
+        $this->assertDatabaseHas('contact_fields', [
+            'account_id' => $account->id,
+            'contact_id' => $contact->id,
+            'data' => '020 2555 0191',
+        ]);
+    }
+
+    public function test_it_imports_phone_by_international_format()
+    {
+        $account = factory(Account::class)->create([]);
+        $importVCard = new ImportVCard;
+        $importVCard->accountId = $account->id;
+
+        $vcard = new VCard([
+            'TEL' => '+44(0)202-555-0191',
             'ADR' => ['', '', '17 Shakespeare Ave.', 'Southampton', '', 'SO17 2HB', 'United Kingdom'],
         ]);
 

--- a/tests/Unit/Services/VCard/ImportVCardTest.php
+++ b/tests/Unit/Services/VCard/ImportVCardTest.php
@@ -546,7 +546,7 @@ class ImportVCardTest extends TestCase
             'ADR' => [
                 '',
                 '',
-                'street'
+                'street',
             ],
         ]);
 
@@ -712,7 +712,7 @@ class ImportVCardTest extends TestCase
             'account_id' => $account->id,
             'contact_id' => $contact->id,
         ]);
-        
+
         $importVCard = new ImportVCard;
         $importVCard->accountId = $account->id;
 
@@ -744,9 +744,9 @@ class ImportVCardTest extends TestCase
         $email2 = factory(ContactField::class)->create([
             'account_id' => $account->id,
             'contact_id' => $contact->id,
-            'data' => 'xxx@mail.com'
+            'data' => 'xxx@mail.com',
         ]);
-        
+
         $importVCard = new ImportVCard;
         $importVCard->accountId = $account->id;
 

--- a/tests/Unit/Services/VCard/ImportVCardTest.php
+++ b/tests/Unit/Services/VCard/ImportVCardTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Services\VCard;
 use Tests\TestCase;
 use App\Models\User\User;
 use App\Models\Account\Account;
+use App\Models\Contact\Address;
 use App\Models\Contact\Contact;
 use Sabre\VObject\Component\VCard;
 use App\Services\VCard\ImportVCard;
@@ -500,13 +501,21 @@ class ImportVCardTest extends TestCase
         $this->assertNotNull($contact->birthday_reminder_id);
     }
 
-    public function test_it_imports_address()
+    public function test_import_vcard_imports_address()
     {
         $account = factory(Account::class)->create([]);
         $importVCard = new ImportVCard;
 
         $vcard = new VCard([
-            'ADR' => ['data', 'data', 'data', 'data', 'data', 'data', 'us'],
+            'ADR' => [
+                '',
+                '',
+                'street',
+                'CITY',
+                'province',
+                '10000',
+                'us',
+            ],
         ]);
 
         $contact = factory(Contact::class)->create([
@@ -518,9 +527,156 @@ class ImportVCardTest extends TestCase
             'account_id' => $account->id,
             'contact_id' => $contact->id,
         ]);
+        $this->assertDatabaseHas('places', [
+            'account_id' => $account->id,
+            'street' => 'street',
+            'city' => 'CITY',
+            'province' => 'province',
+            'postal_code' => '10000',
+            'country' => 'US',
+        ]);
     }
 
-    public function test_it_imports_email()
+    public function test_import_vcard_imports_partial_address()
+    {
+        $account = factory(Account::class)->create([]);
+        $importVCard = new ImportVCard;
+
+        $vcard = new VCard([
+            'ADR' => [
+                '',
+                '',
+                'street'
+            ],
+        ]);
+
+        $contact = factory(Contact::class)->create([
+            'account_id' => $account->id,
+        ]);
+        $this->invokePrivateMethod($importVCard, 'importAddress', [$contact, $vcard]);
+
+        $this->assertDatabaseHas('addresses', [
+            'account_id' => $account->id,
+            'contact_id' => $contact->id,
+        ]);
+        $this->assertDatabaseHas('places', [
+            'account_id' => $account->id,
+            'street' => 'street',
+            'city' => null,
+            'province' => null,
+            'postal_code' => null,
+            'country' => null,
+        ]);
+    }
+
+    public function test_import_vcard_updates_address()
+    {
+        $account = factory(Account::class)->create([]);
+        $contact = factory(Contact::class)->create([
+            'account_id' => $account->id,
+        ]);
+        $address = factory(Address::class)->create([
+            'account_id' => $account->id,
+            'contact_id' => $contact->id,
+        ]);
+
+        $importVCard = new ImportVCard;
+
+        $vcard = new VCard([
+            'ADR' => [
+                '',
+                '',
+                'street',
+                'CITY',
+                'province',
+                '10000',
+                'us',
+            ],
+        ]);
+
+        $this->invokePrivateMethod($importVCard, 'importAddress', [$contact, $vcard]);
+
+        $this->assertDatabaseHas('addresses', [
+            'account_id' => $account->id,
+            'contact_id' => $contact->id,
+            'id' => $address->id,
+        ]);
+        $this->assertDatabaseHas('places', [
+            'account_id' => $account->id,
+            'street' => 'street',
+            'city' => 'CITY',
+            'province' => 'province',
+            'postal_code' => '10000',
+            'country' => 'US',
+        ]);
+        $address->refresh();
+        $place = $address->place()->first();
+        $this->assertEquals($place->street, 'street');
+        $this->assertEquals($place->city, 'CITY');
+        $this->assertEquals($place->province, 'province');
+        $this->assertEquals($place->postal_code, '10000');
+        $this->assertEquals($place->country, 'US');
+    }
+
+    public function test_import_vcard_updates_and_destroy_address()
+    {
+        $account = factory(Account::class)->create([]);
+        $contact = factory(Contact::class)->create([
+            'account_id' => $account->id,
+        ]);
+        $address1 = factory(Address::class)->create([
+            'account_id' => $account->id,
+            'contact_id' => $contact->id,
+        ]);
+        $address2 = factory(Address::class)->create([
+            'account_id' => $account->id,
+            'contact_id' => $contact->id,
+        ]);
+
+        $importVCard = new ImportVCard;
+
+        $vcard = new VCard([
+            'ADR' => [
+                '',
+                '',
+                'street',
+                'CITY',
+                'province',
+                '10000',
+                'us',
+            ],
+        ]);
+
+        $this->invokePrivateMethod($importVCard, 'importAddress', [$contact, $vcard]);
+
+        $this->assertDatabaseHas('addresses', [
+            'account_id' => $account->id,
+            'contact_id' => $contact->id,
+            'id' => $address1->id,
+        ]);
+        $this->assertDatabaseMissing('addresses', [
+            'account_id' => $account->id,
+            'contact_id' => $contact->id,
+            'id' => $address2->id,
+        ]);
+        $this->assertDatabaseHas('places', [
+            'account_id' => $account->id,
+            'street' => 'street',
+            'city' => 'CITY',
+            'province' => 'province',
+            'postal_code' => '10000',
+            'country' => 'US',
+        ]);
+        $address1->refresh();
+        $place = $address1->place()->first();
+        $this->assertEquals($place->street, 'street');
+        $this->assertEquals($place->city, 'CITY');
+        $this->assertEquals($place->province, 'province');
+        $this->assertEquals($place->postal_code, '10000');
+        $this->assertEquals($place->country, 'US');
+    }
+
+    public function test_import_vcard_imports_email()
     {
         $account = factory(Account::class)->create([]);
         $importVCard = new ImportVCard;
@@ -544,6 +700,74 @@ class ImportVCardTest extends TestCase
             'contact_id' => $contact->id,
             'data' => 'john@doe.com',
         ]);
+    }
+
+    public function test_import_vcard_updates_email()
+    {
+        $account = factory(Account::class)->create([]);
+        $contact = factory(Contact::class)->create([
+            'account_id' => $account->id,
+        ]);
+        $email = factory(ContactField::class)->create([
+            'account_id' => $account->id,
+            'contact_id' => $contact->id,
+        ]);
+        
+        $importVCard = new ImportVCard;
+        $importVCard->accountId = $account->id;
+
+        $vcard = new VCard([
+            'EMAIL' => 'other@doe.com',
+        ]);
+
+        $this->invokePrivateMethod($importVCard, 'importEmail', [$contact, $vcard]);
+
+        $this->assertDatabaseHas('contact_fields', [
+            'account_id' => $account->id,
+            'contact_id' => $contact->id,
+            'data' => 'other@doe.com',
+        ]);
+        $email->refresh();
+        $this->assertEquals($email->data, 'other@doe.com');
+    }
+
+    public function test_import_vcard_updates_and_detroy_email()
+    {
+        $account = factory(Account::class)->create([]);
+        $contact = factory(Contact::class)->create([
+            'account_id' => $account->id,
+        ]);
+        $email1 = factory(ContactField::class)->create([
+            'account_id' => $account->id,
+            'contact_id' => $contact->id,
+        ]);
+        $email2 = factory(ContactField::class)->create([
+            'account_id' => $account->id,
+            'contact_id' => $contact->id,
+            'data' => 'xxx@mail.com'
+        ]);
+        
+        $importVCard = new ImportVCard;
+        $importVCard->accountId = $account->id;
+
+        $vcard = new VCard([
+            'EMAIL' => 'other@doe.com',
+        ]);
+
+        $this->invokePrivateMethod($importVCard, 'importEmail', [$contact, $vcard]);
+
+        $this->assertDatabaseHas('contact_fields', [
+            'account_id' => $account->id,
+            'contact_id' => $contact->id,
+            'data' => 'other@doe.com',
+        ]);
+        $this->assertDatabaseMissing('contact_fields', [
+            'account_id' => $account->id,
+            'contact_id' => $contact->id,
+            'data' => 'xxx@mail.com',
+        ]);
+        $email1->refresh();
+        $this->assertEquals($email1->data, 'other@doe.com');
     }
 
     public function test_it_imports_phone()


### PR DESCRIPTION
VCard import now parses addresses and contact fields (email and phone) in the same order as on the database, to update, create, and destroy them.