### PR TITLE
Adding libapache module to php install

### DIFF
--- a/docs/installation/ubuntu.md
+++ b/docs/installation/ubuntu.md
@@ -20,9 +20,7 @@ Monica depends on the following:
 ```sh
 sudo add-apt-repository ppa:ondrej/php
 sudo apt-get update
-sudo apt-get install php7.1 php7.1-cli php7.1-common php7.1-json php7.1-opcache \
-    php7.1-mysql php7.1-mbstring php7.1-mcrypt php7.1-zip php7.1-fpm php7.1-bcmath \
-    php7.1-intl php7.1-simplexml php7.1-dom php7.1-curl php7.1-gd
+sudo apt-get install php7.1 php7.1-cli php7.1-common php7.1-json libapache2-mod-php7.1 php7.1-opcache php7.1-mysql php7.1-mbstring php7.1-mcrypt php7.1-zip php7.1-fpm php7.1-bcmath php7.1-intl php7.1-simplexml php7.1-dom php7.1-curl php7.1-gd
 ```
 
 **Composer:** After you're done installing PHP, you'll need the Composer dependency manager.


### PR DESCRIPTION
I've updated the docs to include installing Apache (since it's not always installed - just spun up an Ubuntu 16.04 DigitalOcean instance and it wasn't there), and forgot to include libapache2 in the PHP installation.