### PR TITLE
fix: dashboard doesn't crash anymore, when trying to get property of non-object

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 UNRELEASED CHANGES:
+* Fix Dashboard doesn't crash anymore, when trying to get property 'contact' of non-object
 
 New features:
 

--- a/resources/views/dashboard/_monthReminder.blade.php
+++ b/resources/views/dashboard/_monthReminder.blade.php
@@ -3,6 +3,9 @@
     <ul class="mb4">
         @if(count($reminderOutboxes) > 0)
             @foreach($reminderOutboxes as $reminderOutbox)
+            @if (!is_object($reminderOutbox->reminder))
+                @continue;
+            @endif
             <li class="pb2">
                 <span class="ttu f6 mr2 black-60">{{ \App\Helpers\DateHelper::getShortDateWithoutYear($reminderOutbox->planned_date) }}</span>
                 <span>


### PR DESCRIPTION
Fixed that the dashboard could crash with "ErrorException: Trying to get property 'contact' of non-object"

See: https://github.com/monicahq/monica/issues/2388