### PR TITLE
chore(deps): require ext-gd by composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "require": {
         "php": "^7.1.3",
         "ext-bcmath": "*",
+        "ext-gd": "*",
         "ext-intl": "*",
         "bacon/bacon-qr-code": "^1.0",
         "creativeorange/gravatar": "~1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -12562,6 +12562,7 @@
     "platform": {
         "php": "^7.1.3",
         "ext-bcmath": "*",
+        "ext-gd": "*",
         "ext-intl": "*"
     },
     "platform-dev": []


### PR DESCRIPTION
This PR resolves #2534 - `ext-gd` is required by some tests, but is not mentioned in `composer.json`

### Checklist

#### Before submitting the PR
- [x] Read the [CONTRIBUTING document](https://github.com/monicahq/monica/blob/master/CONTRIBUTING.md) before submitting your PR.
- [x] If the PR is related to an issue or fix one, don't forget to indicate it.

### General checks
- [x] Make sure that the change you propose is the smallest possible.
- [x] The name of the PR should follow the [conventional commits guideline](https://github.com/monicahq/monica/blob/master/docs/contribute/index.md#conventional-commits) that the project follows.
