### PR TITLE
fix: money format for non two minor unit currencies

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@ Fixes:
 * Fix import vCard with Cyrillic encoding
 * Fix import/export vcard with birthday with year unknown
 * Fix contact missing create form
+* Fix money format for non two "2" minor unit currencies
 
 
 RELEASED VERSIONS:

--- a/app/Helpers/MoneyHelper.php
+++ b/app/Helpers/MoneyHelper.php
@@ -39,8 +39,11 @@ class MoneyHelper
             return $numberFormatter->format($amount);
         }
 
-        $money = new Money($amount * 100, new MoneyCurrency($currency->iso));
+        $moneyCurrency = new MoneyCurrency($currency->iso);
         $currencies = new ISOCurrencies();
+        $minorUnitAdjustment = pow(10, $currencies->subunitFor($moneyCurrency));
+
+        $money = new Money($amount * $minorUnitAdjustment, $moneyCurrency);
 
         $numberFormatter = new \NumberFormatter(App::getLocale(), \NumberFormatter::CURRENCY);
         $moneyFormatter = new IntlMoneyFormatter($numberFormatter, $currencies);

--- a/tests/Unit/Helpers/MoneyHelperTest.php
+++ b/tests/Unit/Helpers/MoneyHelperTest.php
@@ -21,6 +21,15 @@ class MoneyHelperTest extends TestCase
         $this->assertEquals('€5,038.29', MoneyHelper::format(5038.29, $currency));
     }
 
+    public function testFormatReturnsAmountWithCurrencySymbolOfZeroMinorUnitCurrency()
+    {
+        $currency = new Currency();
+        $currency->iso = 'JPY'; // minorUnit value is zero "0"
+
+        $this->assertEquals('¥500', MoneyHelper::format(500, $currency));
+        $this->assertEquals('¥5,038', MoneyHelper::format(5038, $currency));
+    }
+
     public function testFormatUsesCurrencySettingIfDefined()
     {
         $currency = Currency::where('iso', 'GBP')->first();


### PR DESCRIPTION
This PR is related to #2540 

Bug:

`MoneyHelper::format` method is implemented only for two "2" minor unit currencies, and it causes display error for non two "2" minor unit currencies such as JPY, ISK, etc.

Fix:

This PR enables it to format correctly for all minor unit cases which is defined in moneyphp/money lib.

### Checklist

#### Before submitting the PR
- [x] Read the [CONTRIBUTING document](https://github.com/monicahq/monica/blob/master/CONTRIBUTING.md) before submitting your PR.
- [x] If the PR is related to an issue or fix one, don't forget to indicate it.
- [x] Indicate `[wip]` in the title of the PR it is is not final yet. Remove `[wip]` when ready. Otherwise the PR will be considered complete and rejected if it's not working.

### General checks
- [x] Make sure that the change you propose is the smallest possible.
- [x] The name of the PR should follow the [conventional commits guideline](https://github.com/monicahq/monica/blob/master/docs/contribute/index.md#conventional-commits) that the project follows.

### Front-end changes
- ~~[ ] If you change the UI, make sure to ask repositories administrators first about your changes by pinging @djaiss or @asbiin in this PR.~~
- ~~[ ] Screenshots are included if the PR changes the UI.~~
- ~~[ ] Front-end tests have been written with Cypress.~~

#### Backend/models changes
- ~~[ ] The API has been updated.~~
- ~~[ ] API's documentation has been added by submitting a pull request in the [marketing website repository](https://github.com/monicahq/marketing_site/pulls).~~
- [x] Tests have been added for the new code.
- ~~[ ] If you change a model, make sure the FakeContentTableSeeder is updated. We need seeders to develop locally and generate fake data.~~

#### If the code changes the SQL schema
- ~~[ ] Make sure exporting account data as SQL is still working.~~
- ~~[ ] Make sure your changes do not break importing data with `vCard` and `.csv` files.~~
- ~~[ ] Make sure account reset and deletion still work.~~

#### Other tasks
- ~~[ ] [CHANGELOG](https://github.com/monicahq/monica/blob/master/CHANGELOG) entry added, if necessary, under `UNRELEASED`.~~
- ~~[ ] [CONTRIBUTORS](https://github.com/monicahq/monica/blob/master/CONTRIBUTORS) entry added, if necessary.~~
- ~~[ ] If it's relevant and worth mentioning, create a changelog entry for this change. The changelog entry will appear inside the UI for all users to see. To know if your change is worth the creation of a changelog entry, [read the documentation](https://github.com/monicahq/monica/blob/master/docs/administrators/tips.md#when-is-it-relevant-to-create-a-changelog-entry).~~
- ~~[ ] Don't forget to [ask for a free account](mailto:regis@monicahq.com) on https://monicahq.com as anyone who contributes can request a free account.~~
