### PR TITLE
fixes #2917 - unset GOOGLE_SAFETYNET_API_KEY causes 500 errors adding webauthn device

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -178,3 +178,6 @@ ENABLE_WEATHER=false
 # Darksky provides an api with 1000 free API calls per day
 # You need to enable the weather above if you provide an API key here.
 DARKSKY_API_KEY=
+
+# Used by vendor/asbiin/laravel-webauthn
+GOOGLE_SAFETYNET_API_KEY=


### PR DESCRIPTION
fixes #2917

adds declaration for GOOGLE_SAFETYNET_API_KEY; resolves 500 errors due to NULL value when following instructions from docs

### Checklist

#### Before submitting the PR
- [x] Read the [CONTRIBUTING document](https://github.com/monicahq/monica/blob/master/CONTRIBUTING.md) before submitting your PR.
- [x] If the PR is related to an issue or fix one, don't forget to indicate it.
- [x] Indicate `[wip]` in the title of the PR it is is not final yet. Remove `[wip]` when ready. Otherwise the PR will be considered complete and rejected if it's not working.

### General checks
- [x] Make sure that the change you propose is the smallest possible.
- [ ] The name of the PR should follow the [conventional commits guideline](https://github.com/monicahq/monica/blob/master/docs/contribute/index.md#conventional-commits) that the project follows.

#### Other tasks
- [ ] [CHANGELOG](https://github.com/monicahq/monica/blob/master/CHANGELOG.md) entry added, if necessary, under `UNRELEASED`.
- [ ] [CONTRIBUTORS](https://github.com/monicahq/monica/blob/master/CONTRIBUTORS) entry added, if necessary.
- [ ] If it's relevant and worth mentioning, create a changelog entry for this change. The changelog entry will appear inside the UI for all users to see. To know if your change is worth the creation of a changelog entry, [read the documentation](https://github.com/monicahq/monica/blob/master/docs/administrators/tips.md#when-is-it-relevant-to-create-a-changelog-entry).
- [ ] Don't forget to [ask for a free account](mailto:regis@monicahq.com) on https://monicahq.com as anyone who contributes can request a free account.
