### PR TITLE
fix: fix broken age calculation for deceased contacts

### DIFF
--- a/app/Models/Contact/Contact.php
+++ b/app/Models/Contact/Contact.php
@@ -1342,7 +1342,7 @@ class Contact extends Model
             return;
         }
 
-        if ($this->deceasedDate->is_year_unkown == 1) {
+        if ($this->deceasedDate->is_year_unknown == 1) {
             return;
         }
 

--- a/resources/views/people/_header.blade.php
+++ b/resources/views/people/_header.blade.php
@@ -59,7 +59,7 @@
           @elseif ($contact->is_dead)
               @if (! is_null($contact->deceasedDate))
                 {{ trans('people.deceased_label_with_date', ['date' => $contact->deceasedDate->toShortString()]) }}
-                @if ($contact->deceasedDate->is_year_unknown == 0)
+                @if ($contact->deceasedDate->is_year_unknown == 0 && $contact->getBirthdayState() !== 'almost')
                   <span>({{ trans('people.deceased_age') }} {{ $contact->getAgeAtDeath() }})</span>
                 @endif
               @else


### PR DESCRIPTION
This commit fixes the Contact Profile page for deceased contacts as noted in #2951. 

Additionally, I fixed a typo in the method that calculates `Age at Death`