### PR TITLE
fix: reschedule missed stay-in-touch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Fixes:
 
+* Reschedule missed stay-in-touch
 * Fix tasks 'mark as done' UX
 * Fix tattoo or piercing activity locale title
 * Fix getting infos about country without providing ip

--- a/app/Console/Commands/SendStayInTouch.php
+++ b/app/Console/Commands/SendStayInTouch.php
@@ -31,6 +31,7 @@ class SendStayInTouch extends Command
     {
         // we add two days to make sure we cover all timezones
         Contact::where('stay_in_touch_trigger_date', '<', now()->addDays(2))
+                ->whereNotNull('stay_in_touch_frequency')
                 ->orderBy('stay_in_touch_trigger_date', 'asc')
                 ->chunk(500, function ($contacts) {
                     $this->schedule($contacts);

--- a/app/Jobs/StayInTouch/ScheduleStayInTouch.php
+++ b/app/Jobs/StayInTouch/ScheduleStayInTouch.php
@@ -47,6 +47,7 @@ class ScheduleStayInTouch implements ShouldQueue
         if (count($users) > 0) {
             NotificationFacade::send($users, new StayInTouchEmail($this->contact));
             $this->contact->setStayInTouchTriggerDate($this->contact->stay_in_touch_frequency);
+
             return;
         }
 

--- a/app/Jobs/StayInTouch/ScheduleStayInTouch.php
+++ b/app/Jobs/StayInTouch/ScheduleStayInTouch.php
@@ -47,6 +47,13 @@ class ScheduleStayInTouch implements ShouldQueue
         if (count($users) > 0) {
             NotificationFacade::send($users, new StayInTouchEmail($this->contact));
             $this->contact->setStayInTouchTriggerDate($this->contact->stay_in_touch_frequency);
+            return;
+        }
+
+        $now = now();
+        while ($this->contact->stay_in_touch_trigger_date < $now) {
+            // If stay in touch was missed, we reschedule it.
+            $this->contact->setStayInTouchTriggerDate($this->contact->stay_in_touch_frequency, $this->contact->stay_in_touch_trigger_date);
         }
     }
 }

--- a/app/Models/Contact/Contact.php
+++ b/app/Models/Contact/Contact.php
@@ -132,6 +132,7 @@ class Contact extends Model
         'has_avatar' => 'boolean',
         'is_starred' => 'boolean',
         'is_active' => 'boolean',
+        'stay_in_touch_frequency' => 'integer',
     ];
 
     /**

--- a/app/Models/Contact/Contact.php
+++ b/app/Models/Contact/Contact.php
@@ -2,6 +2,7 @@
 
 namespace App\Models\Contact;
 
+use Carbon\Carbon;
 use App\Helpers\DBHelper;
 use App\Models\User\User;
 use App\Traits\Searchable;
@@ -1397,7 +1398,7 @@ class Contact extends Model
      * Update the date the notification about staying in touch should be sent.
      *
      * @param int $frequency
-     * @param \DateTime|null $triggerDate
+     * @param Carbon|null $triggerDate
      */
     public function setStayInTouchTriggerDate($frequency, $triggerDate = null)
     {

--- a/app/Models/Contact/Contact.php
+++ b/app/Models/Contact/Contact.php
@@ -1396,8 +1396,9 @@ class Contact extends Model
      * Update the date the notification about staying in touch should be sent.
      *
      * @param int $frequency
+     * @param \DateTime|null $triggerDate
      */
-    public function setStayInTouchTriggerDate($frequency)
+    public function setStayInTouchTriggerDate($frequency, $triggerDate = null)
     {
         // prevent timestamp update
         $timestamps = $this->timestamps;
@@ -1406,8 +1407,8 @@ class Contact extends Model
         if ($frequency == 0) {
             $this->stay_in_touch_trigger_date = null;
         } else {
-            $now = now();
-            $newTriggerDate = $now->addDays($frequency);
+            $triggerDate = $triggerDate ?? now();
+            $newTriggerDate = $triggerDate->addDays($frequency);
             $this->stay_in_touch_trigger_date = $newTriggerDate;
         }
 

--- a/tests/Commands/SendStayInTouchTest.php
+++ b/tests/Commands/SendStayInTouchTest.php
@@ -25,6 +25,7 @@ class SendStayInTouchTest extends TestCase
         $contact = factory(Contact::class)->create([
             'account_id' => $account->id,
             'stay_in_touch_trigger_date' => '2017-01-01 07:00:00',
+            'stay_in_touch_frequency' => 30,
         ]);
 
         $exitCode = Artisan::call('send:stay_in_touch', []);
@@ -42,6 +43,7 @@ class SendStayInTouchTest extends TestCase
         $contact = factory(Contact::class)->create([
             'account_id' => $account->id,
             'stay_in_touch_trigger_date' => '2017-03-01 07:00:00',
+            'stay_in_touch_frequency' => 30,
         ]);
 
         $exitCode = Artisan::call('send:stay_in_touch', []);

--- a/tests/Unit/Jobs/ScheduleStayInTouchTest.php
+++ b/tests/Unit/Jobs/ScheduleStayInTouchTest.php
@@ -88,4 +88,35 @@ class ScheduleStayInTouchTest extends TestCase
             'stay_in_touch_trigger_date' => '2017-01-01 07:00:00',
         ]);
     }
+
+    public function test_it_reschedule_missed_stayintouch()
+    {
+        NotificationFacade::fake();
+
+        Carbon::setTestNow(Carbon::create(2019, 1, 1, 7, 0, 0, 'America/New_York'));
+
+        $account = factory(Account::class)->create([
+            'default_time_reminder_is_sent' => '07:00',
+            'has_access_to_paid_version_for_free' => 0,
+        ]);
+        $contact = factory(Contact::class)->create([
+            'account_id' => $account->id,
+            'stay_in_touch_trigger_date' => '2018-01-01 07:00:00',
+            'stay_in_touch_frequency' => 30,
+        ]);
+        $user = factory(User::class)->create([
+            'account_id' => $account->id,
+            'email' => 'john@doe.com',
+            'timezone' => 'America/New_York',
+        ]);
+
+        dispatch(new ScheduleStayInTouch($contact));
+
+        NotificationFacade::assertNotSentTo($user, StayInTouchEmail::class);
+        NotificationFacade::assertNothingSent();
+
+        $this->assertDatabaseHas('contacts', [
+            'stay_in_touch_trigger_date' => '2019-01-26 07:00:00',
+        ]);
+    }
 }

--- a/tests/Unit/Models/ContactTest.php
+++ b/tests/Unit/Models/ContactTest.php
@@ -961,7 +961,7 @@ class ContactTest extends FeatureTestCase
 
         $this->assertNull($contact->stay_in_touch_trigger_date);
 
-        $contact->setStayInTouchTriggerDate(3, 'UTC');
+        $contact->setStayInTouchTriggerDate(3);
 
         $this->assertNotNull($contact->stay_in_touch_trigger_date);
 


### PR DESCRIPTION
Some times the StayInTouch trigger is missed.
This fix the problem in rescheduling the StayInTouch as it was not previously missed.