### PR TITLE
fix: fix scope search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Fixes:
 
+* Fix scope search
 * Reschedule missed stay-in-touch
 * Fix tasks 'mark as done' UX
 * Fix tattoo or piercing activity locale title

--- a/app/Traits/Searchable.php
+++ b/app/Traits/Searchable.php
@@ -27,7 +27,7 @@ trait Searchable
 
         $queryString = StringHelper::buildQuery($this->searchable_columns, $needle);
 
-        $builder->whereRaw('account_id = '.$accountId.' and ('.$queryString.') '.$whereCondition);
+        $builder->whereRaw("`{$this->getTable()}`.`account_id` = ".$accountId.' and ('.$queryString.') '.$whereCondition);
         $builder->orderByRaw($orderBy);
         if ($sortOrder) {
             $builder->sortedBy($sortOrder);


### PR DESCRIPTION
Fix this error:
```
SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'account_id' in where clause is ambiguous (SQL: select count(*) as aggregate from `contacts` left join `activity_contact` on `contacts`.`id` = `activity_contact`.`contact_id` left join `activities` on `activity_contact`.`activity_id` = `activities`.`id` where `contacts`.`account_id` = XXX and `contacts`.`account_id` is not null and `is_partial` = 0 and `is_active` = 1 and `is_dead` = 0 and account_id = XXX and (first_name LIKE '%%' or middle_name LIKE '%%' or last_name LIKE '%%' or nickname LIKE '%%' or description LIKE '%%' or job LIKE '%%')) ```