### PR TITLE
fix: remove monica:clean command confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 ### Fixes:
 
-*
+* Remove monica:clean command confirmation
+
 
 # RELEASED VERSIONS:
 

--- a/app/Console/Commands/Clean.php
+++ b/app/Console/Commands/Clean.php
@@ -7,19 +7,15 @@ use Illuminate\Console\Command;
 use App\Events\TokenDeleteEvent;
 use App\Services\Instance\TokenClean;
 use Illuminate\Support\Facades\Event;
-use Illuminate\Console\ConfirmableTrait;
 
 class Clean extends Command
 {
-    use ConfirmableTrait;
-
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
     protected $signature = 'monica:clean
-                            {--force : Force the operation to run when in production.}
                             {--dry-run : Do everything except actually clean monica instance.}';
 
     /**
@@ -40,11 +36,9 @@ class Clean extends Command
             $this->handleTokenDelete($event->token);
         });
 
-        if ($this->confirmToProceed()) {
-            app(TokenClean::class)->execute([
-                'dryrun' => (bool) $this->option('dry-run'),
-            ]);
-        }
+        app(TokenClean::class)->execute([
+            'dryrun' => (bool) $this->option('dry-run'),
+        ]);
     }
 
     /**


### PR DESCRIPTION
Remove confirmation trait to able the command to actually run on scheduling.