### PR TITLE
feat: use JawsDB by default on heroku instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Enhancements:
 
+* Use JawsDB by default on heroku instances
 * Add pluralization forms for non-english-like-plural languages, for vue.js translations
 
 ### Fixes:

--- a/app.json
+++ b/app.json
@@ -12,7 +12,7 @@
   ],
   "addons": [
     {
-      "plan": "cleardb:ignite"
+      "plan": "jawsdb:kitefin"
     },
     {
       "plan": "scheduler:standard"

--- a/config/database.php
+++ b/config/database.php
@@ -174,7 +174,7 @@ $db = [
  * This is done below, added to the $db variable and then returned.
  */
 if (env('HEROKU')) {
-    $url = parse_url(env('CLEARDB_DATABASE_URL'));
+    $url = parse_url(env('JAWSDB_URL', env('CLEARDB_DATABASE_URL')));
 
     $db['connections']['heroku'] = [
         'driver' => 'mysql',


### PR DESCRIPTION
Change the default mysql instance type on heroku, to create a mysql 5.7 instance (ClearDB uses mysql 5.6 by default).

This will let users create an instance with the right mysql version on heroku.

See #2926 or #2761 too.