### PR TITLE
feat: add job information next to the contact name on profile page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@
 
 ### Enhancements:
 
+* Add job information next to the contact name on profile page
 * Use supervisor in docker images
 * Use JawsDB by default on heroku instances
 * Add pluralization forms for non-english-like-plural languages, for vue.js translations
 
 ### Fixes:
 
+* Fix contact export
 * Fix currencies seeder by accounting for defaults
 * Fix search when prefix table is used
 * Fix storage page not being displayed if a contact does not exist anymore

--- a/resources/views/people/_header.blade.php
+++ b/resources/views/people/_header.blade.php
@@ -39,6 +39,13 @@
       <h1 class="tc mb2 mt4">
         <span class="{{ htmldir() == 'ltr' ? 'mr1' : 'ml1' }}">{{ $contact->name }}</span>
         <contact-favorite hash="{{ $contact->hashID() }}" :starred="{{ \Safe\json_encode($contact->is_starred) }}"></contact-favorite>
+        @if ($contact->job)
+        <span class="db f5 normal">{{ $contact->job }}
+          @if ($contact->company)
+            ({{ $contact->company }})
+          @endif
+        </span>
+        @endif
       </h1>
 
       <ul class="tc-ns mb3 {{ htmldir() == 'ltr' ? 'tl' : 'tr' }}">


### PR DESCRIPTION
This adds the job information next to the contact name if it’s defined on the profile page.
If you care enough to fill this information on a contact, it means it’s important to you when you take a look at the contact. Therefore, it makes sense to display it on the profile page.

Close #3143 