### PR TITLE
fix: update .platform.app.yaml - add app/temp to writable mounts

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -45,6 +45,9 @@ mounts:
   "storage/app/public":
       source: local
       source_path: "public"
+  "storage/app/temp":
+      source: local
+      source_path: "temp"
   "storage/framework/views":
       source: local
       source_path: "views"


### PR DESCRIPTION
Updates .platform.app.yaml - adding app/temp as writable directory under `mounts`.