### PR TITLE
fix: api routes

### DIFF
--- a/app/Http/Controllers/Api/ApiController.php
+++ b/app/Http/Controllers/Api/ApiController.php
@@ -93,7 +93,6 @@ class ApiController extends Controller
                 'message' => 'Welcome to Monica',
             ],
             'links' => [
-                'activities_url' => route('api.activities'),
                 'addresses_url' => route('api.addresses'),
                 'calls_url' => route('api.calls'),
                 'contacts_url' => route('api.contacts'),

--- a/app/Http/Resources/Activity/Activity.php
+++ b/app/Http/Resources/Activity/Activity.php
@@ -29,7 +29,7 @@ class Activity extends Resource
                 'contacts' => $this->getContactsForAPI(),
             ],
             'emotions' => EmotionResource::collection($this->emotions),
-            'url' => route('api.activity', $this->id),
+            'url' => null,
             'account' => [
                 'id' => $this->account->id,
             ],

--- a/routes/api.php
+++ b/routes/api.php
@@ -82,11 +82,6 @@ Route::group(['middleware' => ['auth:api']], function () {
         Route::apiResource('conversations/{conversation}/messages', 'Contact\\ApiMessageController', ['except' => ['index', 'show']]);
         Route::get('/contacts/{contact}/conversations', 'Contact\\ApiConversationController@conversations');
 
-        // Activities
-        Route::apiResource('activities', 'ApiActivityController')
-            ->names(['index' => 'activities', 'show' => 'activity']);
-        Route::get('/contacts/{contact}/activities', 'ApiActivityController@activities');
-
         // Reminders
         Route::apiResource('reminders', 'ApiReminderController');
         Route::get('/contacts/{contact}/reminders', 'ApiReminderController@reminders');


### PR DESCRIPTION
It looks like something has been deleted but the routes for it were still there. I experienced it when I wanted to call `php artisan route:list`.