### PR TITLE
chore: add notes in contact api call

### DIFF
--- a/app/Http/Resources/Contact/ContactWithContactFields.php
+++ b/app/Http/Resources/Contact/ContactWithContactFields.php
@@ -3,8 +3,8 @@
 namespace App\Http\Resources\Contact;
 
 use App\Helpers\DateHelper;
-use App\Http\Resources\Contact\ContactShort as ContactShortResource;
 use App\Http\Resources\Note\Note as NoteResource;
+use App\Http\Resources\Contact\ContactShort as ContactShortResource;
 
 class ContactWithContactFields extends Contact
 {

--- a/app/Http/Resources/Contact/ContactWithContactFields.php
+++ b/app/Http/Resources/Contact/ContactWithContactFields.php
@@ -4,6 +4,7 @@ namespace App\Http\Resources\Contact;
 
 use App\Helpers\DateHelper;
 use App\Http\Resources\Contact\ContactShort as ContactShortResource;
+use App\Http\Resources\Note\Note as NoteResource;
 
 class ContactWithContactFields extends Contact
 {
@@ -96,6 +97,7 @@ class ContactWithContactFields extends Contact
                 'number_of_debts' => $this->debts->count(),
             ]),
             'contactFields' => $this->when(! $this->is_partial, $this->getContactFieldsForAPI()),
+            'notes' => $this->when(! $this->is_partial, NoteResource::collection($this->notes()->latest()->limit(3)->get())),
             'url' => $this->when(! $this->is_partial, route('api.contact', $this->id)),
             'account' => [
                 'id' => $this->account->id,


### PR DESCRIPTION
This PR adds the latest 3 notes that the user has written about a contact in the `/contact/{id}?with=contactfields` API method.

The reason I had this info only in this call is that this call will be used in the mobile app to reduce the number of queries we have to do to display a contact.