### PR TITLE
feat: services to set and clear personal description

### DIFF
--- a/app/Services/Contact/Description/ClearPersonalDescription.php
+++ b/app/Services/Contact/Description/ClearPersonalDescription.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Services\Contact\Description;
+
+use App\Models\Contact\Contact;
+use Carbon\Carbon;
+use App\Services\BaseService;
+
+class ClearPersonalDescription extends BaseService
+{
+    /**
+     * Get the validation rules that apply to the service.
+     *
+     * @return array
+     */
+    public function rules(): array
+    {
+        return [
+            'account_id' => 'required|integer|exists:accounts,id',
+            'contact_id' => 'required|integer|exists:contacts,id',
+            'author_id' => 'required|integer|exists:users,id',
+        ];
+    }
+
+    /**
+     * Clear a contact's description.
+     *
+     * @param array $data
+     * @return Contact
+     */
+    public function execute(array $data): Contact
+    {
+        $this->validate($data);
+
+        $contact = Contact::where('account_id', $data['account_id'])
+            ->findOrFail($data['contact_id']);
+
+        $contact->description = null;
+        $contact->save();
+
+        return $contact;
+    }
+}

--- a/app/Services/Contact/Description/ClearPersonalDescription.php
+++ b/app/Services/Contact/Description/ClearPersonalDescription.php
@@ -2,9 +2,8 @@
 
 namespace App\Services\Contact\Description;
 
-use App\Models\Contact\Contact;
-use Carbon\Carbon;
 use App\Services\BaseService;
+use App\Models\Contact\Contact;
 
 class ClearPersonalDescription extends BaseService
 {

--- a/app/Services/Contact/Description/SetPersonalDescription.php
+++ b/app/Services/Contact/Description/SetPersonalDescription.php
@@ -2,9 +2,8 @@
 
 namespace App\Services\Contact\Description;
 
-use App\Models\Contact\Contact;
-use Carbon\Carbon;
 use App\Services\BaseService;
+use App\Models\Contact\Contact;
 
 class SetPersonalDescription extends BaseService
 {

--- a/app/Services/Contact/Description/SetPersonalDescription.php
+++ b/app/Services/Contact/Description/SetPersonalDescription.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Services\Contact\Description;
+
+use App\Models\Contact\Contact;
+use Carbon\Carbon;
+use App\Services\BaseService;
+
+class SetPersonalDescription extends BaseService
+{
+    /**
+     * Get the validation rules that apply to the service.
+     *
+     * @return array
+     */
+    public function rules(): array
+    {
+        return [
+            'account_id' => 'required|integer|exists:accounts,id',
+            'contact_id' => 'required|integer|exists:contacts,id',
+            'author_id' => 'required|integer|exists:users,id',
+            'description' => 'required|string|max:255',
+        ];
+    }
+
+    /**
+     * Set a contact's description.
+     * The description should be saved as unparsed markdown content, and fetched
+     * as unparsed markdown content. The UI is responsible for parsing and
+     * displaying the proper content.
+     *
+     * @param array $data
+     * @return Contact
+     */
+    public function execute(array $data): Contact
+    {
+        $this->validate($data);
+
+        $contact = Contact::where('account_id', $data['account_id'])
+            ->findOrFail($data['contact_id']);
+
+        $contact->description = $data['description'];
+        $contact->save();
+
+        return $contact;
+    }
+}

--- a/tests/Unit/Services/Contact/Description/ClearPersonalDescriptionTest.php
+++ b/tests/Unit/Services/Contact/Description/ClearPersonalDescriptionTest.php
@@ -3,15 +3,12 @@
 namespace Tests\Unit\Services\Contact\Description;
 
 use Tests\TestCase;
-use App\Jobs\LogAccountAudit;
-use App\Jobs\LogEmployeeAudit;
-use App\Models\Company\Employee;
-use App\Models\Contact\Contact;
 use App\Models\User\User;
-use App\Services\Contact\Description\ClearPersonalDescription;
+use App\Models\Contact\Contact;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use App\Services\Contact\Description\ClearPersonalDescription;
 
 class ClearPersonalDescriptionTest extends TestCase
 {

--- a/tests/Unit/Services/Contact/Description/ClearPersonalDescriptionTest.php
+++ b/tests/Unit/Services/Contact/Description/ClearPersonalDescriptionTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Unit\Services\Contact\Description;
+
+use Tests\TestCase;
+use App\Jobs\LogAccountAudit;
+use App\Jobs\LogEmployeeAudit;
+use App\Models\Company\Employee;
+use App\Models\Contact\Contact;
+use App\Models\User\User;
+use App\Services\Contact\Description\ClearPersonalDescription;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Validation\ValidationException;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class ClearPersonalDescriptionTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function it_clears_a_personal_description(): void
+    {
+        Queue::fake();
+
+        $contact = factory(Contact::class)->create([]);
+        $user = factory(User::class)->create([
+            'account_id' => $contact->account_id,
+        ]);
+
+        $request = [
+            'account_id' => $contact->account_id,
+            'author_id' => $user->id,
+            'contact_id' => $contact->id,
+        ];
+
+        $michael = (new ClearPersonalDescription)->execute($request);
+
+        $this->assertDatabaseHas('contacts', [
+            'account_id' => $contact->account_id,
+            'id' => $contact->id,
+            'description' => null,
+        ]);
+
+        $this->assertInstanceOf(
+            Contact::class,
+            $contact
+        );
+    }
+
+    /** @test */
+    public function it_fails_if_wrong_parameters_are_given(): void
+    {
+        $request = [
+            'first_name' => 'Dwight',
+        ];
+
+        $this->expectException(ValidationException::class);
+        (new ClearPersonalDescription)->execute($request);
+    }
+}

--- a/tests/Unit/Services/Contact/Description/SetPersonalDescriptionTest.php
+++ b/tests/Unit/Services/Contact/Description/SetPersonalDescriptionTest.php
@@ -3,15 +3,12 @@
 namespace Tests\Unit\Services\Contact\Description;
 
 use Tests\TestCase;
-use App\Jobs\LogAccountAudit;
-use App\Jobs\LogEmployeeAudit;
-use App\Models\Company\Employee;
-use App\Models\Contact\Contact;
 use App\Models\User\User;
-use App\Services\Contact\Description\SetPersonalDescription;
+use App\Models\Contact\Contact;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use App\Services\Contact\Description\SetPersonalDescription;
 
 class SetPersonalDescriptionTest extends TestCase
 {

--- a/tests/Unit/Services/Contact/Description/SetPersonalDescriptionTest.php
+++ b/tests/Unit/Services/Contact/Description/SetPersonalDescriptionTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Unit\Services\Contact\Description;
+
+use Tests\TestCase;
+use App\Jobs\LogAccountAudit;
+use App\Jobs\LogEmployeeAudit;
+use App\Models\Company\Employee;
+use App\Models\Contact\Contact;
+use App\Models\User\User;
+use App\Services\Contact\Description\SetPersonalDescription;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Validation\ValidationException;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class SetPersonalDescriptionTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function it_sets_a_personal_description(): void
+    {
+        Queue::fake();
+
+        $contact = factory(Contact::class)->create([]);
+        $user = factory(User::class)->create([
+            'account_id' => $contact->account_id,
+        ]);
+
+        $request = [
+            'account_id' => $contact->account_id,
+            'author_id' => $user->id,
+            'contact_id' => $contact->id,
+            'description' => 'This is just great',
+        ];
+
+        $contact = (new SetPersonalDescription)->execute($request);
+
+        $this->assertDatabaseHas('contacts', [
+            'account_id' => $contact->account_id,
+            'id' => $contact->id,
+            'description' => 'This is just great',
+        ]);
+
+        $this->assertInstanceOf(
+            Contact::class,
+            $contact
+        );
+    }
+
+    /** @test */
+    public function it_fails_if_wrong_parameters_are_given(): void
+    {
+        $request = [
+            'first_name' => 'Dwight',
+        ];
+
+        $this->expectException(ValidationException::class);
+        (new SetPersonalDescription)->execute($request);
+    }
+}


### PR DESCRIPTION
This PR adds two new services:
* one to set the contact's personal description
* the other one to clear the personal description.

Both services will be needed for the new UI.