### PR TITLE
chore: last consulted at field update is now in a job

### DIFF
--- a/app/Http/Controllers/Api/ApiContactController.php
+++ b/app/Http/Controllers/Api/ApiContactController.php
@@ -20,6 +20,7 @@ use App\Http\Resources\Contact\Contact as ContactResource;
 use App\Services\Contact\Contact\UpdateContactIntroduction;
 use App\Services\Contact\Contact\UpdateContactFoodPreferences;
 use App\Http\Resources\Contact\ContactWithContactFields as ContactWithContactFieldsResource;
+use App\Jobs\UpdateLastConsultedDate;
 
 class ApiContactController extends ApiController
 {
@@ -96,7 +97,7 @@ class ApiContactController extends ApiController
             return $this->respondNotFound();
         }
 
-        $contact->updateConsulted();
+        UpdateLastConsultedDate::dispatch($contact);
 
         if ($this->getWithParameter() == 'contactfields') {
             return new ContactWithContactFieldsResource($contact);

--- a/app/Http/Controllers/Api/ApiContactController.php
+++ b/app/Http/Controllers/Api/ApiContactController.php
@@ -7,6 +7,7 @@ use App\Helpers\SearchHelper;
 use App\Models\Contact\Contact;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Collection;
+use App\Jobs\UpdateLastConsultedDate;
 use Illuminate\Database\QueryException;
 use App\Services\Contact\Contact\SetMeContact;
 use Illuminate\Validation\ValidationException;
@@ -20,7 +21,6 @@ use App\Http\Resources\Contact\Contact as ContactResource;
 use App\Services\Contact\Contact\UpdateContactIntroduction;
 use App\Services\Contact\Contact\UpdateContactFoodPreferences;
 use App\Http\Resources\Contact\ContactWithContactFields as ContactWithContactFieldsResource;
-use App\Jobs\UpdateLastConsultedDate;
 
 class ApiContactController extends ApiController
 {

--- a/app/Http/Controllers/ContactsController.php
+++ b/app/Http/Controllers/ContactsController.php
@@ -18,6 +18,7 @@ use App\Models\Contact\Contact;
 use App\Services\VCard\ExportVCard;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Auth;
+use App\Jobs\UpdateLastConsultedDate;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Contracts\View\Factory;
 use App\Models\Relationship\Relationship;
@@ -30,7 +31,6 @@ use App\Services\Contact\Contact\DestroyContact;
 use App\Services\Contact\Contact\UpdateContactWork;
 use App\Services\Contact\Contact\UpdateContactFoodPreferences;
 use App\Http\Resources\Contact\ContactSearch as ContactResource;
-use App\Jobs\UpdateLastConsultedDate;
 
 class ContactsController extends Controller
 {

--- a/app/Http/Controllers/ContactsController.php
+++ b/app/Http/Controllers/ContactsController.php
@@ -30,6 +30,7 @@ use App\Services\Contact\Contact\DestroyContact;
 use App\Services\Contact\Contact\UpdateContactWork;
 use App\Services\Contact\Contact\UpdateContactFoodPreferences;
 use App\Http\Resources\Contact\ContactSearch as ContactResource;
+use App\Jobs\UpdateLastConsultedDate;
 
 class ContactsController extends Controller
 {
@@ -244,7 +245,7 @@ class ContactsController extends Controller
             $query->orderBy('updated_at', 'desc');
         }]);
 
-        $contact->updateConsulted();
+        UpdateLastConsultedDate::dispatch($contact);
 
         $relationships = $contact->relationships;
         // get love relationship type

--- a/app/Jobs/UpdateLastConsultedDate.php
+++ b/app/Jobs/UpdateLastConsultedDate.php
@@ -4,13 +4,10 @@ namespace App\Jobs;
 
 use Illuminate\Bus\Queueable;
 use App\Models\Contact\Contact;
-use Intervention\Image\Facades\Image;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
-use Illuminate\Contracts\Filesystem\FileNotFoundException;
 
 class UpdateLastConsultedDate implements ShouldQueue
 {

--- a/app/Jobs/UpdateLastConsultedDate.php
+++ b/app/Jobs/UpdateLastConsultedDate.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use App\Models\Contact\Contact;
+use Intervention\Image\Facades\Image;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Contracts\Filesystem\FileNotFoundException;
+
+class UpdateLastConsultedDate implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    protected $contact;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(Contact $contact)
+    {
+        $this->contact = $contact;
+    }
+
+    /**
+     * Update the Last Consulted At field for the given contact.
+     *
+     * @return void
+     */
+    public function handle(): void
+    {
+        $timestamps = $this->contact->timestamps;
+        $this->contact->timestamps = false;
+
+        $this->contact->last_consulted_at = now();
+        $this->contact->number_of_views = $this->contact->number_of_views + 1;
+
+        $this->contact->save();
+
+        $this->contact->timestamps = $timestamps;
+    }
+}

--- a/tests/Unit/Jobs/UpdateLastConsultedDateTest.php
+++ b/tests/Unit/Jobs/UpdateLastConsultedDateTest.php
@@ -4,14 +4,9 @@ namespace Tests\Unit\Jobs;
 
 use Carbon\Carbon;
 use Tests\TestCase;
-use App\Models\User\User;
-use App\Models\Account\Account;
 use App\Models\Contact\Contact;
-use App\Notifications\StayInTouchEmail;
-use App\Jobs\StayInTouch\ScheduleStayInTouch;
 use App\Jobs\UpdateLastConsultedDate;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
-use Illuminate\Support\Facades\Notification as NotificationFacade;
 
 class UpdateLastConsultedDateTest extends TestCase
 {

--- a/tests/Unit/Jobs/UpdateLastConsultedDateTest.php
+++ b/tests/Unit/Jobs/UpdateLastConsultedDateTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Unit\Jobs;
+
+use Carbon\Carbon;
+use Tests\TestCase;
+use App\Models\User\User;
+use App\Models\Account\Account;
+use App\Models\Contact\Contact;
+use App\Notifications\StayInTouchEmail;
+use App\Jobs\StayInTouch\ScheduleStayInTouch;
+use App\Jobs\UpdateLastConsultedDate;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Notification as NotificationFacade;
+
+class UpdateLastConsultedDateTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function it_updates_the_last_consulted_at_field_for_the_given_contact()
+    {
+        Carbon::setTestNow(Carbon::create(2017, 1, 1, 7, 0, 0, 'America/New_York'));
+
+        $contact = factory(Contact::class)->create([
+            'number_of_views' => 1,
+        ]);
+
+        dispatch(new UpdateLastConsultedDate($contact));
+
+        $this->assertDatabaseHas('contacts', [
+            'id' => $contact->id,
+            'last_consulted_at' => '2017-01-01 07:00:00',
+            'number_of_views' => 2,
+        ]);
+    }
+}


### PR DESCRIPTION
The `contact->updateConsulted()` method is now done in a job, instead of being a method called on the Contact object.

First of all, it’s better to put this kind of operations in a job (instead of blocking the main thread for this), and also, I’ll need this in a job for the new UI 😀

cc @asbiin 