### PR TITLE
fix: fix _header blade include

### DIFF
--- a/app/Http/Controllers/Contacts/DebtController.php
+++ b/app/Http/Controllers/Contacts/DebtController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Contacts;
 
 use App\Models\Contact\Debt;
+use App\Helpers\AccountHelper;
 use App\Models\Contact\Contact;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\People\DebtRequest;
@@ -31,8 +32,11 @@ class DebtController extends Controller
      */
     public function create(Contact $contact)
     {
+        $accountHasLimitations = AccountHelper::hasLimitations(auth()->user()->account);
+
         return view('people.debt.add')
             ->withContact($contact)
+            ->withAccountHasLimitations($accountHasLimitations)
             ->withDebt(new Debt);
     }
 
@@ -85,8 +89,11 @@ class DebtController extends Controller
      */
     public function edit(Contact $contact, Debt $debt)
     {
+        $accountHasLimitations = AccountHelper::hasLimitations(auth()->user()->account);
+
         return view('people.debt.edit')
             ->withContact($contact)
+            ->withAccountHasLimitations($accountHasLimitations)
             ->withDebt($debt);
     }
 

--- a/app/Http/Controllers/Contacts/DebtController.php
+++ b/app/Http/Controllers/Contacts/DebtController.php
@@ -32,11 +32,9 @@ class DebtController extends Controller
      */
     public function create(Contact $contact)
     {
-        $accountHasLimitations = AccountHelper::hasLimitations(auth()->user()->account);
-
         return view('people.debt.add')
             ->withContact($contact)
-            ->withAccountHasLimitations($accountHasLimitations)
+            ->withAccountHasLimitations(AccountHelper::hasLimitations(auth()->user()->account))
             ->withDebt(new Debt);
     }
 
@@ -89,11 +87,9 @@ class DebtController extends Controller
      */
     public function edit(Contact $contact, Debt $debt)
     {
-        $accountHasLimitations = AccountHelper::hasLimitations(auth()->user()->account);
-
         return view('people.debt.edit')
             ->withContact($contact)
-            ->withAccountHasLimitations($accountHasLimitations)
+            ->withAccountHasLimitations(AccountHelper::hasLimitations(auth()->user()->account))
             ->withDebt($debt);
     }
 

--- a/app/Http/Controllers/Contacts/RemindersController.php
+++ b/app/Http/Controllers/Contacts/RemindersController.php
@@ -22,11 +22,9 @@ class RemindersController extends Controller
      */
     public function create(Contact $contact)
     {
-        $accountHasLimitations = AccountHelper::hasLimitations(auth()->user()->account);
-
         return view('people.reminders.add')
             ->withContact($contact)
-            ->withAccountHasLimitations($accountHasLimitations)
+            ->withAccountHasLimitations(AccountHelper::hasLimitations(auth()->user()->account))
             ->withReminder(new Reminder);
     }
 
@@ -66,11 +64,9 @@ class RemindersController extends Controller
      */
     public function edit(Contact $contact, Reminder $reminder)
     {
-        $accountHasLimitations = AccountHelper::hasLimitations(auth()->user()->account);
-
         return view('people.reminders.edit')
             ->withContact($contact)
-            ->withAccountHasLimitations($accountHasLimitations)
+            ->withAccountHasLimitations(AccountHelper::hasLimitations(auth()->user()->account))
             ->withReminder($reminder);
     }
 

--- a/app/Http/Controllers/Contacts/RemindersController.php
+++ b/app/Http/Controllers/Contacts/RemindersController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Contacts;
 
 use Illuminate\Http\Request;
+use App\Helpers\AccountHelper;
 use App\Models\Contact\Contact;
 use App\Models\Contact\Reminder;
 use App\Http\Controllers\Controller;
@@ -21,8 +22,11 @@ class RemindersController extends Controller
      */
     public function create(Contact $contact)
     {
+        $accountHasLimitations = AccountHelper::hasLimitations(auth()->user()->account);
+
         return view('people.reminders.add')
             ->withContact($contact)
+            ->withAccountHasLimitations($accountHasLimitations)
             ->withReminder(new Reminder);
     }
 
@@ -62,8 +66,11 @@ class RemindersController extends Controller
      */
     public function edit(Contact $contact, Reminder $reminder)
     {
+        $accountHasLimitations = AccountHelper::hasLimitations(auth()->user()->account);
+
         return view('people.reminders.edit')
             ->withContact($contact)
+            ->withAccountHasLimitations($accountHasLimitations)
             ->withReminder($reminder);
     }
 

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -157,7 +157,7 @@ class SettingsController
     public function export()
     {
         return view('settings.export')
-            ->with('accountHasLimitations', AccountHelper::hasLimitations(auth()->user()->account));
+            ->withAccountHasLimitations(AccountHelper::hasLimitations(auth()->user()->account));
     }
 
     /**
@@ -360,7 +360,7 @@ class SettingsController
     public function tags()
     {
         return view('settings.tags')
-            ->with('accountHasLimitations', AccountHelper::hasLimitations(auth()->user()->account));
+            ->withAccountHasLimitations(AccountHelper::hasLimitations(auth()->user()->account));
     }
 
     /**
@@ -384,7 +384,7 @@ class SettingsController
     public function api()
     {
         return view('settings.api.index')
-            ->with('accountHasLimitations', AccountHelper::hasLimitations(auth()->user()->account));
+            ->withAccountHasLimitations(AccountHelper::hasLimitations(auth()->user()->account));
     }
 
     public function dav()
@@ -397,7 +397,7 @@ class SettingsController
                 ->withCardDavRoute("{$davroute}/addressbooks/{$email}/contacts")
                 ->withCalDavBirthdaysRoute("{$davroute}/calendars/{$email}/birthdays")
                 ->withCalDavTasksRoute("{$davroute}/calendars/{$email}/tasks")
-                ->with('accountHasLimitations', AccountHelper::hasLimitations(auth()->user()->account));
+                ->withAccountHasLimitations(AccountHelper::hasLimitations(auth()->user()->account));
     }
 
     public function security()
@@ -411,7 +411,7 @@ class SettingsController
             ->with('is2FAActivated', Google2FA::isActivated())
             ->with('currentkeys', U2fKeyResource::collection($u2fKeys))
             ->withWebauthnKeys(WebauthnKeyResource::collection($webauthnKeys))
-            ->with('accountHasLimitations', AccountHelper::hasLimitations(auth()->user()->account));
+            ->withAccountHasLimitations(AccountHelper::hasLimitations(auth()->user()->account));
     }
 
     /**


### PR DESCRIPTION
Fix error related to #3570

[`_header`](https://github.com/monicahq/monica/pull/3570/files#diff-345a977fab59890c36e33431012dafae) template requires a `$accountHasLimitations` variable, but this template is included in other blade templates.