### PR TITLE
fix: Sort relationship by relationship types

### DIFF
--- a/resources/views/people/relationship/_relationship.blade.php
+++ b/resources/views/people/relationship/_relationship.blade.php
@@ -1,7 +1,10 @@
 @php
-    function my_cmpr($a, $b)
+    if(!function_exists('my_cmpr'))
     {
+      function my_cmpr($a, $b)
+      {
         return strcmp($a->relationshipType->getLocalizedName(null, false, $relationship->ofContact->gender ? $relationship->ofContact->gender->type : null), $b->relationshipType->getLocalizedName(null, false, $relationship->ofContact->gender ? $relationship->ofContact->gender->type : null));
+      }
     }
     usort($relationships, "my_cmpr");
     $curr_relationship = NULL;

--- a/resources/views/people/relationship/_relationship.blade.php
+++ b/resources/views/people/relationship/_relationship.blade.php
@@ -1,9 +1,9 @@
 @php
-    function cmp($a, $b)
+    function my_cmpr($a, $b)
     {
         return strcmp($a->relationshipType->getLocalizedName(null, false, $relationship->ofContact->gender ? $relationship->ofContact->gender->type : null), $b->relationshipType->getLocalizedName(null, false, $relationship->ofContact->gender ? $relationship->ofContact->gender->type : null));
     }
-    usort($relationships, "cmp");
+    usort($relationships, "my_cmpr");
     $curr_relationship = NULL;
 @endphp
 @foreach ($relationships as $relationship)

--- a/resources/views/people/relationship/_relationship.blade.php
+++ b/resources/views/people/relationship/_relationship.blade.php
@@ -1,12 +1,10 @@
 @php
-    if(!function_exists('my_cmpr'))
-    {
-      function my_cmpr($a, $b)
-      {
-        return strcmp($a->relationshipType->getLocalizedName(null, false, $relationship->ofContact->gender ? $relationship->ofContact->gender->type : null), $b->relationshipType->getLocalizedName(null, false, $relationship->ofContact->gender ? $relationship->ofContact->gender->type : null));
-      }
-    }
-    usort($relationships, "my_cmpr");
+    usort($relationships, function ($a, $b) { 
+      return strcmp(
+        $a->relationshipType->getLocalizedName(null, false, $relationship->ofContact->gender ? $relationship->ofContact->gender->type : null),
+        $b->relationshipType->getLocalizedName(null, false, $relationship->ofContact->gender ? $relationship->ofContact->gender->type : null)
+      ); 
+    });
     $curr_relationship = NULL;
 @endphp
 @foreach ($relationships as $relationship)
@@ -18,8 +16,8 @@
       $relationshipType = $relationship->relationshipType->getLocalizedName(null, false, $relationship->ofContact->gender ? $relationship->ofContact->gender->type : null);
       if( $curr_relationship !== $relationshipType )
       {
-        echo "<h3>" . relationshipType . "</h3>";
-        $curr_relationship = relationshipType;
+        echo "<h3>" . $relationshipType . "</h3>";
+        $curr_relationship = $relationshipType;
       }
     @endphp
 

--- a/resources/views/people/relationship/_relationship.blade.php
+++ b/resources/views/people/relationship/_relationship.blade.php
@@ -1,9 +1,24 @@
+@php
+    function cmp($a, $b)
+    {
+        return strcmp($a->relationshipType->getLocalizedName(null, false, $relationship->ofContact->gender ? $relationship->ofContact->gender->type : null), $b->relationshipType->getLocalizedName(null, false, $relationship->ofContact->gender ? $relationship->ofContact->gender->type : null));
+    }
+    usort($relationships, "cmp");
+    $curr_relationship = NULL;
+@endphp
 @foreach ($relationships as $relationship)
   @if (! $relationship->ofContact)
     @continue
   @endif
   <div class="sidebar-box-paragraph">
-    <span class="silver fw3 ba br2 ph1 {{ htmldir() == 'ltr' ? '' : 'fr' }}">{{ $relationship->relationshipType->getLocalizedName(null, false, $relationship->ofContact->gender ? $relationship->ofContact->gender->type : null) }}</span>
+    @php 
+      $relationshipType = $relationship->relationshipType->getLocalizedName(null, false, $relationship->ofContact->gender ? $relationship->ofContact->gender->type : null);
+      if( $curr_relationship !== $relationshipType )
+      {
+        echo "<h3>" . relationshipType . "</h3>";
+        $curr_relationship = relationshipType;
+      }
+    @endphp
 
     {{-- NAME --}}
     @if ($relationship->ofContact->is_partial)


### PR DESCRIPTION
FIX #2395 
Sort the  array by relationshipType
if relationshipType occours for first time, save it and display it
else continue displaying other details

when relationshipType changes, it won't be equal to curr_relationship and hence will display it

**UI CHANGES:** replace the silver badge with <h3> @djaiss 

NOTE: test are not written in cypress yet