### PR TITLE
docs: Update heroku docs to use updated screenshot

### DIFF
--- a/docs/installation/heroku.md
+++ b/docs/installation/heroku.md
@@ -25,7 +25,7 @@ Monica doesn't require a lot of power - it will run perfectly fine on the free p
 
 After deployment, the configuration of your app should look like this:
 
-![Picture Of Configuration](https://user-images.githubusercontent.com/25419741/45253146-9f904800-b362-11e8-916b-8980fc2a83d8.png)
+![picture of configuration](https://raw.githubusercontent.com/monicahq/monica/master/docs/images/heroku_dashboard-resources.png)
 
 Note that when you deploy with the "Deploy to Heroku" purple button, only 1 dyno ("web") is activated while the "queue" one is not. That is OK - the "queue" dyno is only helpful if you set `QUEUE_CONNECTION=database` (default is 'sync').
 


### PR DESCRIPTION
Update heroku.md to use an updated second screenshot to reflect switch to JawsDB (from ClearDB) as Monica's default database provider in Heroku.