### PR TITLE
fix: Remove not matched ignored PHPStan errors

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,27 +9,13 @@ parameters:
     level: 5
     ignoreErrors:
         # Level 1
-        - '#Call to an undefined static method Vinkla\\Hashids\\Facades\\Hashids::encode\(\)\.#'
-        - '#Call to an undefined static method Vinkla\\Hashids\\Facades\\Hashids::decode\(\)\.#'
         - '#Call to an undefined static method PragmaRX\\CountriesLaravel\\Package\\Facade::[a-zA-Z0-9_]+\(\)\.#'
-        - '#Call to an undefined method \(Illuminate\\Database\\Eloquent\\Collection&iterable<[a-zA-Z0-9\\_]+>\)\|Illuminate\\Database\\Eloquent\\Model::[a-zA-Z0-9\\_]+\(\)\.#'
-        - '#Call to an undefined method App\\Http\\Resources\\[a-zA-Z0-9\\_]+::[a-zA-Z0-9_]+\(\)\.#'
         - '#Access to an undefined property App\\Interfaces\\LabelInterface::\$labels\.#'
         # Level 2
         - '#Access to an undefined property Illuminate\\Support\\Fluent::\$[a-zA-Z0-9_]+\.#'
         - '#Access to an undefined property Sabre\\VObject\\Component\\[a-zA-Z0-9\\_]+::\$[a-zA-Z0-9_]+\.#'
         - '#Access to an undefined property PragmaRX\\Countries\\Package\\Support\\Collection::\$[a-zA-Z0-9_]+\.#'
-        - '#Access to an undefined property Illuminate\\Database\\Eloquent\\Builder::\$id\.#'
         - '#Call to an undefined method Illuminate\\View\\View::with[a-zA-Z0-9\\_]+\(\)\.#'
-        - '#Call to an undefined method Illuminate\\Database\\Eloquent\\Model::[a-zA-Z0-9_]+\(\)\.#'
-        - '#Call to an undefined method Illuminate\\Database\\Eloquent\\Relations\\HasMany::active\(\)\.#'
-        - '#Call to an undefined method Illuminate\\Database\\Eloquent\\Relations\\HasMany::real\(\)\.#'
-        - '#Call to an undefined method Illuminate\\Database\\Eloquent\\Relations\\HasMany::offered\(\)\.#'
-        - '#Call to an undefined method Illuminate\\Database\\Eloquent\\Relations\\HasMany::isIdea\(\)\.#'
-        - '#Call to an undefined method Illuminate\\Database\\Eloquent\\Relations\\HasMany::inProgress\(\)\.#'
-        - '#Call to an undefined method Illuminate\\Database\\Eloquent\\Relations\\HasMany::completed\(\)\.#'
-        - '#Call to an undefined method Illuminate\\Database\\Eloquent\\Relations\\HasMany::email\(\)\.#'
-        - '#Call to an undefined method Illuminate\\Database\\Eloquent\\Relations\\HasMany::phone\(\)\.#'
         - '#Call to an undefined method Illuminate\\Database\\Eloquent\\Builder::sortedBy\(\)\.#'
         - '#Parameter \#2 \$configGroup of static method Creativeorange\\Gravatar\\Gravatar::get\(\) expects string, array<string, bool\|int\|string> given\.#'
         # Level 3


### PR DESCRIPTION
Hi,

By running PHPStan with `reportUnmatchedIgnoredErrors: true` added to the config file I discovered some ignored errors are not matched currently. It means it is fixed in the code or in the Larastan.

This PR removes those unmatched errors.