### PR TITLE
chore: ignore cypress on crowdin branch

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,6 +1,9 @@
 name: Chrome headless
 
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - 'l10n_master*'
 
 jobs:
   cypress-run:


### PR DESCRIPTION
Do not run github action on crowdin branch