### PR TITLE
fix: fix docker cron (legacy) on apache variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixes:
 
+* Fix docker cron (legacy) on apache variant
 * Fix login route already set by Laravel now
 * Fix setMe contact controller
 * Fix carddav sync-collection reporting wrong syncToken

--- a/scripts/docker/apache/Dockerfile
+++ b/scripts/docker/apache/Dockerfile
@@ -121,7 +121,7 @@ RUN set -ex && \
 	cd /etc/periodic/hourly/ && \
 	{ \
 		echo '#!/bin/sh'; \
-		echo '/usr/bin/php /usr/src/monica/artisan schedule:run -v > /proc/1/fd/1 2> /proc/1/fd/2'; \
+		echo '/usr/bin/php /var/www/monica/artisan schedule:run -v > /proc/1/fd/1 2> /proc/1/fd/2'; \
 	} | tee monica && \
 	chmod a+x monica
 


### PR DESCRIPTION
Fix #3668