### PR TITLE
feat: add cache for S3 storage, and use new standard variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Enhancements:
 
+* Add cache for S3 storage, and use new standard variables
 * Add new command monica:passport to generate encryption if needed
 * Improve nginx config docker examples
 * Remove u2f support (replaced with WebAuthn)

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -56,12 +56,17 @@ return [
 
         's3' => [
             'driver' => 's3',
-            'key' => env('AWS_KEY'),
-            'secret' => env('AWS_SECRET'),
-            'region' => env('AWS_REGION'),
+            'key' => env('AWS_ACCESS_KEY_ID', env('AWS_KEY')),
+            'secret' => env('AWS_SECRET_ACCESS_KEY', env('AWS_SECRET')),
+            'region' => env('AWS_DEFAULT_REGION', env('AWS_REGION')),
             'bucket' => env('AWS_BUCKET'),
-            'endpoint' => env('AWS_SERVER', '') ? 'https://'.env('AWS_SERVER') : null,
             'url' => env('AWS_URL'),
+            'endpoint' => env('AWS_ENDPOINT', env('AWS_SERVER', '') ? 'https://'.env('AWS_SERVER') : null),
+            'cache' => [
+                'store' => env('S3_CACHE_STORE', env('CACHE_DRIVER', 'file')),
+                'expire' => env('S3_CACHE_EXPIRE', 600),
+                'prefix' => env('S3_CACHE_PREFIX', 's3'),
+            ],
         ],
 
     ],


### PR DESCRIPTION
Add [cache](https://laravel.com/docs/7.x/filesystem#caching) to S3 storage. This will improve metadata gets.

Also use [standard variables](https://github.com/laravel/laravel/blob/master/config/filesystems.php#L60):
- AWS_ACCESS_KEY_ID
- AWS_SECRET_ACCESS_KEY
- AWS_DEFAULT_REGION
- AWS_ENDPOINT

of course old environment variables are still working.