### PR TITLE
feat: remove authentication with login + password for carddav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Enhancements:
 
+* Remove authentication with login+password for carddav
 * Add new command monica:passport to generate encryption if needed
 * Improve nginx config docker examples
 * Remove u2f support (replaced with WebAuthn)
@@ -14,6 +15,7 @@
 
 ### Fixes:
 
+* Fix authentication with token on basic auth
 * Fix editing multiple notes at the same time only edits one note
 * Fix countries in fake contact seeder
 * Fix docker rsync exclude rules

--- a/app/Http/Middleware/AuthenticateWithTokenOnBasicAuth.php
+++ b/app/Http/Middleware/AuthenticateWithTokenOnBasicAuth.php
@@ -68,11 +68,11 @@ class AuthenticateWithTokenOnBasicAuth
     }
 
     /**
-     * Try Bearer authentication, with token in 'password' field on basic auth
+     * Try Bearer authentication, with token in 'password' field on basic auth.
      *
      * @param  \Illuminate\Http\Request  $request
      */
-    private function tryBearer(Request  $request)
+    private function tryBearer(Request $request)
     {
         // Try Bearer authentication, with token in 'password' field on basic auth
         if (! $request->bearerToken()) {


### PR DESCRIPTION
This authentication is not 100% secure, and it can bypass 2fa.
From now, authentication for carddav must use API Token.

Use login + Token, or just the token on your carddav app.

Fix  #3829