### PR TITLE
feat: add age of death to relationship sidebar if the person is dead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### New features:
 
+* Display age of death to relationship sidebar if the person is dead
+* Fix age of deceased person in relationship sidebar
 * Crop contact photos on upload
 * Add Traditional Chinese language
 * Add console command to test email delivery
@@ -23,7 +25,6 @@
 
 ### Fixes:
 
-* Fix age of deceased person in relationship sidebar
 * Fix google2fa column size
 * Fix errors display for api
 * Fix currency in double

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### Fixes:
 
+* Fix age of deceased person in relationship sidebar
 * Fix google2fa column size
 * Fix errors display for api
 * Fix currency in double

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### New features:
 
 * Display age of death to relationship sidebar if the person is dead
-* Fix age of deceased person in relationship sidebar
 * Crop contact photos on upload
 * Add Traditional Chinese language
 * Add console command to test email delivery

--- a/resources/views/people/relationship/_relationship.blade.php
+++ b/resources/views/people/relationship/_relationship.blade.php
@@ -13,7 +13,11 @@
     @endif
 
     {{-- AGE --}}
-    @if ($relationship->ofContact->birthday_special_date_id)
+    @if ($relationship->ofContact->is_dead)
+      @if ($relationship->ofContact->deceasedDate)
+        <span class="{{ htmldir() == 'ltr' ? '' : 'fr' }}">({{ $relationship->ofContact->getAgeAtDeath() }})</span>
+      @endif
+    @elseif ($relationship->ofContact->birthday_special_date_id)
       @if ($relationship->ofContact->birthdate->getAge())
         <span class="{{ htmldir() == 'ltr' ? '' : 'fr' }}">({{ $relationship->ofContact->birthdate->getAge() }})</span>
       @endif


### PR DESCRIPTION
Fix #3989
added age of death to relationships sidebar for all relationships that are marked as deceased.
if not marked as deceased, it will proceed as normal to calculate the age of the person.