### PR TITLE
docs: update ubuntu.md

### DIFF
--- a/docs/installation/providers/ubuntu.md
+++ b/docs/installation/providers/ubuntu.md
@@ -33,6 +33,13 @@ sudo apt update
 sudo apt install -y git
 ```
 
+**Apache:** Apache should come pre-installed with your server. If it's not, install it with:
+
+```sh
+sudo apt update
+sudo apt install -y apache2
+```
+
 **PHP 7.3+:**
 
 First add this PPA repository:


### PR DESCRIPTION
I had to install `apache2` first on Ubuntu 18.0.4. Without doing so, the directory `/var/www` did not exist and I could not follow the installation steps.
