### PR TITLE
docs: add Platform.sh quick-launch button.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -109,6 +109,14 @@ There are multiple ways of getting started with Monica.
 
 Note: while the .com version has a paid plan, there is no limitations on Monica if you install it on a server that you own.
 
+You can also deploy Monica on [Platform.sh](https://platform.sh.) using the button below.
+
+<p align="center">
+<a href="https://console.platform.sh/projects/create-project?template=https://github.com/monicahq/monica.git&utm_content=monica3&utm_source=github&utm_medium=button&utm_campaign=deploy_on_platform">
+    <img src="https://platform.sh/images/deploy/lg-blue.svg" alt="Deploy on Platform.sh" width="180px" />
+</a>
+</p>
+
 ### Requirements
 
 If you want to host it yourself, you need


### PR DESCRIPTION
Hi folks.  Since the project includes configuration files for Platform.sh already, that makes it compatible with quick-deployment.  This PR just adds a "Deploy on Platform.sh" button to the README to make it easier to install.

I put it at what seemed like the appropriate place in the flow of the document.  If there's a better place, let me know and I'll move it and/or you can update the PR yourself.  I'm flexible.

Cheers.