### PR TITLE
docs: update ubuntu.md to add php-imagick dependency

### DIFF
--- a/docs/installation/providers/ubuntu.md
+++ b/docs/installation/providers/ubuntu.md
@@ -55,7 +55,7 @@ Then install php 7.3 with these extensions:
 sudo apt update
 sudo apt install -y php7.3 php7.3-cli php7.3-common php7.3-fpm \
     php7.3-json php7.3-opcache php7.3-mysql php7.3-mbstring php7.3-zip \
-    php7.3-bcmath php7.3-intl php7.3-xml php7.3-curl php7.3-gd php7.3-gmp
+    php7.3-bcmath php7.3-intl php7.3-xml php7.3-curl php7.3-gd php7.3-gmp php-imagick
 ```
 
 **Composer:** After you're done installing PHP, you'll need the [Composer](https://getcomposer.org/download/) dependency manager.


### PR DESCRIPTION
default install with dashboard doesn't run without php-imagick and shows an error. Solves #4644 
