### PR TITLE
docs: add APP_URL to Heroku template

### DIFF
--- a/app.json
+++ b/app.json
@@ -26,6 +26,10 @@
       "description": "Please change this to a 32-character string. For example run `pwgen -s 32 1` and copy/paste the value.",
       "value": "change-me-to-a-random-string----"
     },
+    "APP_URL": {
+      "description": "Please change this to your Heroku app's domain.",
+      "value": "https://XXX.herokuapp.com"
+    },
     "APP_ENV": {
       "description": "Use monica in 'production' mode, or set it to 'local' if you want to install Monica as a development version.",
       "value": "production"

--- a/docs/installation/providers/heroku.md
+++ b/docs/installation/providers/heroku.md
@@ -15,7 +15,7 @@ Monica can be deployed on Heroku using the button below:
 
 Before deployment, Heroku will ask you to define a few variables.
 - Please ensure to enter a custom `APP_KEY` when asked (if, for example, you have the `pwgen` utility installed, you could copy and paste the output of `pwgen -s 32 1`).
-- In addition, you can edit the email address Monica will send emails to (`MAIL_FROM_ADDRESS`), the name of the sender (`MAIL_FROM_NAME`) and some other important variables on that screen.
+- In addition, you can edit the email address Monica will send emails to (`MAIL_FROM_ADDRESS`), the name of the sender (`MAIL_FROM_NAME`), where emails should link to (`APP_URL`) and some other important variables on that screen.
 
 After deployment, click on ![Manage App](../../images/heroku_manage_app.png) to open the dashboard of your new application:
 ![Heroku Dashbord](../../images/heroku_dashboard.png)


### PR DESCRIPTION
This should make it easier for people using Heroku for their emails to link to their app instead of the default URL ([http://localhost](https://github.com/monicahq/monica/blob/10f7f197309112836f39279de27e82ae5270ed4f/config/app.php#L66)).
