### PR TITLE
fix: update adorable api to api.hello-avatar.com

### DIFF
--- a/app/Services/Contact/Avatar/GetAdorableAvatarURL.php
+++ b/app/Services/Contact/Avatar/GetAdorableAvatarURL.php
@@ -6,7 +6,7 @@ use App\Services\BaseService;
 
 class GetAdorableAvatarURL extends BaseService
 {
-    private const ADORABLE_API = 'https://api.adorable.io/avatars/';
+    private const ADORABLE_API = 'https://api.hello-avatar.com/adorables/';
 
     /**
      * Get the validation rules that apply to the service.

--- a/database/migrations/2021_01_10_235600_update_adorable_api.php
+++ b/database/migrations/2021_01_10_235600_update_adorable_api.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Models\Contact\Contact;
+use Illuminate\Database\Migrations\Migration;
+
+class UpdateAdorableAPI extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Contact::without(['account', 'avatarPhoto', 'gender'])
+            ->where('avatar_adorable_url', 'like', '%api.adorable.io%')
+            ->chunk(1000, function ($contacts) {
+                foreach ($contacts as $contact) {
+                    $contact->avatar_adorable_url = str_replace('api.adorable.io/avatars', 'api.hello-avatar.com/adorables', $contact->avatar_adorable_url)
+                    $contact->save
+                }
+            });
+    }
+}

--- a/database/migrations/2021_01_10_235600_update_adorable_api.php
+++ b/database/migrations/2021_01_10_235600_update_adorable_api.php
@@ -16,8 +16,8 @@ class UpdateAdorableAPI extends Migration
             ->where('avatar_adorable_url', 'like', '%api.adorable.io%')
             ->chunk(1000, function ($contacts) {
                 foreach ($contacts as $contact) {
-                    $contact->avatar_adorable_url = str_replace('api.adorable.io/avatars', 'api.hello-avatar.com/adorables', $contact->avatar_adorable_url)
-                    $contact->save
+                    $contact->avatar_adorable_url = str_replace('api.adorable.io/avatars', 'api.hello-avatar.com/adorables', $contact->avatar_adorable_url);
+                    $contact->save();
                 }
             });
     }

--- a/tests/Unit/Services/Contact/Avatar/GetAdorableAvatarTest.php
+++ b/tests/Unit/Services/Contact/Avatar/GetAdorableAvatarTest.php
@@ -22,7 +22,7 @@ class GetAdorableAvatarTest extends TestCase
         $url = app(GetAdorableAvatarURL::class)->execute($request);
 
         $this->assertEquals(
-            'https://api.adorable.io/avatars/400/matt@wordpress.com.png',
+            'https://api.hello-avatar.com/adorables/400/matt@wordpress.com.png',
             $url
         );
     }
@@ -38,7 +38,7 @@ class GetAdorableAvatarTest extends TestCase
 
         // should return an avatar of 200 px wide
         $this->assertEquals(
-            'https://api.adorable.io/avatars/200/matt@wordpress.com.png',
+            'https://api.hello-avatar.com/adorables/200/matt@wordpress.com.png',
             $url
         );
     }


### PR DESCRIPTION
Resolves https://github.com/monicahq/monica/issues/4777

The Adorable.io avatar API has been closed down: https://github.com/itsthatguy/avatars-api-middleware/issues/108#issuecomment-709611542

This PR switches the URL to https://api.hello-avatar.com/adorables/ to immediately get the avatars working again.
See: https://github.com/itsthatguy/avatars-api-middleware/issues/108#issuecomment-709593363