### PR TITLE
refactor: change minimum php version for 7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ There are multiple ways of getting started with Monica:
 
 If you want to host it yourself, you need
 
-- PHP 7.2+ or newer
+- PHP 7.4+ or newer
 - HTTP server with PHP support (eg: Apache, Nginx, Caddy)
 - Composer
 - MySQL

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "license": "AGPL",
     "require": {
-        "php": "^7.3",
+        "php": "^7.4",
         "ext-bcmath": "*",
         "ext-gd": "*",
         "ext-gmp": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c45c706db073937e89780bd3584e14ea",
+    "content-hash": "26e87cdd0a4f0003f2909bc8fc61f7e8",
     "packages": [
         {
             "name": "asbiin/laravel-webauthn",
@@ -17733,7 +17733,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3",
+        "php": "^7.4",
         "ext-bcmath": "*",
         "ext-gd": "*",
         "ext-gmp": "*",

--- a/docs/contribute/readme.md
+++ b/docs/contribute/readme.md
@@ -80,7 +80,7 @@ We've installed the development version with [Valet](https://laravel.com/docs/va
 **Prerequisites**:
 * Git
 * [Node](https://nodejs.org/en/)
-* PHP 7.2+
+* PHP 7.4+
 * [Composer](https://getcomposer.org/)
 * GNU Make
 

--- a/docs/installation/providers/cpanel.md
+++ b/docs/installation/providers/cpanel.md
@@ -14,14 +14,14 @@
 Monica can be configured in shared hosting environments with a little differences that we can remedy easily. In this scenerio, Monica depends on the following:
 
 -   A shared cPanel Server
--   PHP 7.2+
+-   PHP 7.4+
 -   [Composer](https://getcomposer.org/)
 -   [MySQL](https://www.mysql.com/)
 -   SSH Access for an accont on the cPanel server
 
 **Git:** Git should come pre-installed with your server. If it doesn't - use the installation instructions in the link.
 
-**PHP:** Install php7.2 minimum. Generally cPanel will have a PHP 7 version installed, verify unser the 'PHP Version' section from the cPanel section. Make sure these extensions are enabled:
+**PHP:** Install php7.4 minimum. Generally cPanel will have a PHP 7 version installed, verify unser the 'PHP Version' section from the cPanel section. Make sure these extensions are enabled:
 
 -   bcmath
 -   curl

--- a/docs/installation/providers/debian.md
+++ b/docs/installation/providers/debian.md
@@ -19,7 +19,7 @@ Monica depends on the following:
 
 -   A Web server, like [Apache httpd webserver](https://httpd.apache.org/)
 -   [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
--   PHP 7.2+
+-   PHP 7.4+
 -   [Composer](https://getcomposer.org/)
 -   MySQL / MariaDB
 

--- a/docs/installation/providers/debian.md
+++ b/docs/installation/providers/debian.md
@@ -4,14 +4,14 @@
 
 Monica can run on Debian Buster.
 
--   [Prerequisites](#prerequisites)
--   [Installation steps](#installation-steps)
-    -   [1. Clone the repository](#1-clone-the-repository)
-    -   [2. Setup the database](#2-setup-the-database)
-    -   [3. Configure Monica](#3-configure-monica)
-    -   [4. Configure cron job](#4-configure-cron-job)
-    -   [5. Configure Apache webserver](#5-configure-apache-webserver)
-    -   [Final step](#final-step)
+- [Prerequisites](#prerequisites)
+- [Installation steps](#installation-steps)
+  - [1. Clone the repository](#1-clone-the-repository)
+  - [2. Setup the database](#2-setup-the-database)
+  - [3. Configure Monica](#3-configure-monica)
+  - [4. Configure cron job](#4-configure-cron-job)
+  - [5. Configure Apache webserver](#5-configure-apache-webserver)
+  - [Final step](#final-step)
 
 ## Prerequisites
 
@@ -40,7 +40,7 @@ sudo apt install -y git
 
 **PHP:**
 
-Install PHP 7.3 with these extensions:
+Install PHP 7.4 with these extensions:
 
 ```sh
 sudo apt install -y php php-bcmath php-curl php-gd php-gmp php-imagick \

--- a/docs/installation/providers/generic.md
+++ b/docs/installation/providers/generic.md
@@ -20,14 +20,14 @@
 If you don't want to use Docker, the best way to setup the project is to use the same configuration that [Homestead](https://laravel.com/docs/homestead) uses. Basically, Monica depends on the following:
 
 -   [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
--   PHP 7.2+
+-   PHP 7.4+
 -   [Composer](https://getcomposer.org/)
 -   [MySQL](https://www.mysql.com/)
 -   Optional: Redis or Beanstalk
 
 **Git:** Git should come pre-installed with your server. If it doesn't - use the installation instructions in the link.
 
-**PHP:** Install php7.2 minimum, with these extensions:
+**PHP:** Install php7.4 minimum, with these extensions:
 
 -   bcmath
 -   curl

--- a/docs/installation/providers/ubuntu.md
+++ b/docs/installation/providers/ubuntu.md
@@ -20,7 +20,7 @@ Monica depends on the following:
 
 -   [Apache httpd webserver](https://httpd.apache.org/)
 -   [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
--   PHP 7.2+
+-   PHP 7.4+
 -   [Composer](https://getcomposer.org/)
 -   [MySQL](https://support.rackspace.com/how-to/installing-mysql-server-on-ubuntu/)
 

--- a/docs/installation/providers/ubuntu.md
+++ b/docs/installation/providers/ubuntu.md
@@ -40,7 +40,7 @@ sudo apt update
 sudo apt install -y apache2
 ```
 
-**PHP 7.3+:**
+**PHP 7.4+:**
 
 First add this PPA repository:
 
@@ -49,13 +49,13 @@ sudo apt-get install -y software-properties-common
 sudo add-apt-repository ppa:ondrej/php
 ```
 
-Then install php 7.3 with these extensions:
+Then install php 7.4 with these extensions:
 
 ```sh
 sudo apt update
-sudo apt install -y php7.3 php7.3-cli php7.3-common php7.3-fpm \
-    php7.3-json php7.3-opcache php7.3-mysql php7.3-mbstring php7.3-zip \
-    php7.3-bcmath php7.3-intl php7.3-xml php7.3-curl php7.3-gd php7.3-gmp php-imagick
+sudo apt install -y php7.4 php7.4-cli php7.4-common php7.4-fpm \
+    php7.4-json php7.4-opcache php7.4-mysql php7.4-mbstring php7.4-zip \
+    php7.4-bcmath php7.4-intl php7.4-xml php7.4-curl php7.4-gd php7.4-gmp php-imagick
 ```
 
 **Composer:** After you're done installing PHP, you'll need the [Composer](https://getcomposer.org/download/) dependency manager.
@@ -214,10 +214,10 @@ Then, in the `nano` text editor window you just opened, copy the following - swa
 sudo a2dissite 000-default.conf
 sudo a2ensite monica.conf
 
-# Enable php7.3 fpm, and restart apache
+# Enable php7.4 fpm, and restart apache
 sudo a2enmod proxy_fcgi setenvif
-sudo a2enconf php7.3-fpm
-sudo service php7.3-fpm restart
+sudo a2enconf php7.4-fpm
+sudo service php7.4-fpm restart
 sudo service apache2 restart
 ```
 

--- a/docs/installation/readme.md
+++ b/docs/installation/readme.md
@@ -14,7 +14,7 @@ Monica can be installed on a variety of platforms. The choice of the platform is
 If you don't want to use [Docker](/docs/installation/providers/docker.md), the best way to setup the project is to use the same configuration that [Homestead](https://laravel.com/docs/homestead) uses. Basically, Monica depends on the following:
 
 * [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-* PHP 7.2+
+* PHP 7.4+
 * [Composer](https://getcomposer.org/)
 * [MySQL](https://www.mysql.com/)
 * Optional: Redis or Beanstalk

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -5,7 +5,7 @@
 ### The standard monica image definition will be found here: https://github.com/monicahq/docker
 ###
 
-FROM php:7.3-apache
+FROM php:7.4-apache
 
 # opencontainers annotations https://github.com/opencontainers/image-spec/blob/master/annotations.md
 LABEL org.opencontainers.image.authors="Alexis Saettler <alexis@saettler.org>" \

--- a/scripts/vagrant/build/install-monica.sh
+++ b/scripts/vagrant/build/install-monica.sh
@@ -37,24 +37,24 @@ debconf-set-selections <<< "mysql-server mysql-server/root_password password $MY
 debconf-set-selections <<< "mysql-server mysql-server/root_password_again password $MYSQL_ROOT_PASSWORD"
 apt-get install -y mysql-server mysql-client >/dev/null
 
-echo -e "\n\033[4;32mInstalling PHP 7.2\033[0;40m"
+echo -e "\n\033[4;32mInstalling PHP 7.4\033[0;40m"
 apt install -y curl gnupg2 apt-transport-https apt-transport-https lsb-release ca-certificates
 curl -s https://packages.sury.org/php/apt.gpg -o /etc/apt/trusted.gpg.d/php.gpg
 echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/php.list
 apt-get update >/dev/null
-apt-get install -y php7.3 >/dev/null
+apt-get install -y php7.4 >/dev/null
 
 echo -e "\n\033[4;32mInstalling git\033[0;40m"
 apt-get install -y git >/dev/null
 
 echo -e "\n\033[4;32mInstalling composer\033[0;40m"
-apt-get install -y curl php7.3-cli >/dev/null
+apt-get install -y curl php7.4-cli >/dev/null
 curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 echo -e "\n\033[4;32mInstalling packages for Monica\033[0;40m"
-apt-get install -y php7.3-common php7.3-fpm \
-    php7.3-json php7.3-opcache php7.3-mysql php7.3-mbstring php7.3-zip \
-    php7.3-bcmath php7.3-intl php7.3-xml php7.3-curl php7.3-gd php7.3-gmp >/dev/null
+apt-get install -y php7.4-common php7.4-fpm \
+    php7.4-json php7.4-opcache php7.4-mysql php7.4-mbstring php7.4-zip \
+    php7.4-bcmath php7.4-intl php7.4-xml php7.4-curl php7.4-gd php7.4-gmp >/dev/null
 
 echo -e "\n\033[4;32mGetting database ready\033[0;40m"
 mysql -uroot -p$MYSQL_ROOT_PASSWORD -e "CREATE DATABASE $MYSQL_DB_DATABASE;


### PR DESCRIPTION
PHP 7.3 now accepts only security fixes, and PHP 7.4 is fully supported.
See https://www.php.net/supported-versions.php