### PR TITLE
fix: fix subscriptions list display

### DIFF
--- a/app/Helpers/InstanceHelper.php
+++ b/app/Helpers/InstanceHelper.php
@@ -29,6 +29,8 @@ class InstanceHelper
      */
     public static function getPlanInformationFromConfig(string $timePeriod): ?array
     {
+        $timePeriod = strtolower($timePeriod);
+
         if ($timePeriod != 'monthly' && $timePeriod != 'annual') {
             return null;
         }

--- a/app/Http/Controllers/Settings/SubscriptionsController.php
+++ b/app/Http/Controllers/Settings/SubscriptionsController.php
@@ -41,7 +41,6 @@ class SubscriptionsController extends Controller
             ]);
         }
 
-        $planId = $account->getSubscribedPlanId();
         try {
             $nextBillingDate = $account->getNextBillingDate();
         } catch (StripeException $e) {
@@ -55,7 +54,7 @@ class SubscriptionsController extends Controller
         }
 
         return view('settings.subscriptions.account', [
-            'planInformation' => InstanceHelper::getPlanInformationFromConfig($planId),
+            'planInformation' => InstanceHelper::getPlanInformationFromConfig($subscription),
             'nextBillingDate' => $nextBillingDate,
             'subscription' => $subscription,
             'hasInvoices' => $hasInvoices,

--- a/app/Http/Controllers/Settings/SubscriptionsController.php
+++ b/app/Http/Controllers/Settings/SubscriptionsController.php
@@ -54,7 +54,7 @@ class SubscriptionsController extends Controller
         }
 
         return view('settings.subscriptions.account', [
-            'planInformation' => InstanceHelper::getPlanInformationFromConfig($subscription),
+            'planInformation' => InstanceHelper::getPlanInformationFromConfig($subscription->name),
             'nextBillingDate' => $nextBillingDate,
             'subscription' => $subscription,
             'hasInvoices' => $hasInvoices,


### PR DESCRIPTION
This fix #4951 

`InstanceHelper::getPlanInformationFromConfig` need the friendly name, and not the PlanId - to be fair, I don't know how it worked before ...