### PR TITLE
refactor: distinguish passport password client and personal access token client configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -134,8 +134,8 @@ MFA_ENABLED=true
 DAV_ENABLED=true
 
 # CLIENT ID and SECRET used for OAuth authentication
-PASSPORT_PERSONAL_ACCESS_CLIENT_ID=
-PASSPORT_PERSONAL_ACCESS_CLIENT_SECRET=
+PASSPORT_PASSWORD_CLIENT_ID=
+PASSPORT_PASSWORD_CLIENT_SECRET=
 
 # Allow to access general statistics about your instance through a public API
 # call

--- a/.env.example
+++ b/.env.example
@@ -134,8 +134,8 @@ MFA_ENABLED=true
 DAV_ENABLED=true
 
 # CLIENT ID and SECRET used for OAuth authentication
-PASSPORT_PASSWORD_CLIENT_ID=
-PASSPORT_PASSWORD_CLIENT_SECRET=
+PASSPORT_PASSWORD_GRANT_CLIENT_ID=
+PASSPORT_PASSWORD_GRANT_CLIENT_SECRET=
 
 # Allow to access general statistics about your instance through a public API
 # call

--- a/app/Http/Controllers/Api/Auth/OAuthController.php
+++ b/app/Http/Controllers/Api/Auth/OAuthController.php
@@ -194,8 +194,8 @@ class OAuthController extends Controller
         /** @var \Illuminate\Http\Response */
         $response = app(Kernel::class)->handle(Request::create($url, 'POST', [
             'grant_type' => $data['grantType'],
-            'client_id' => config('passport.personal_access_client.id'),
-            'client_secret' => config('passport.personal_access_client.secret'),
+            'client_id' => config('passport.password_client.id'),
+            'client_secret' => config('passport.password_client.secret'),
             'username' => $data['username'],
             'password' => $data['password'],
             'scope' => '',

--- a/app/Http/Controllers/Api/Auth/OAuthController.php
+++ b/app/Http/Controllers/Api/Auth/OAuthController.php
@@ -194,8 +194,8 @@ class OAuthController extends Controller
         /** @var \Illuminate\Http\Response */
         $response = app(Kernel::class)->handle(Request::create($url, 'POST', [
             'grant_type' => $data['grantType'],
-            'client_id' => config('passport.password_client.id'),
-            'client_secret' => config('passport.password_client.secret'),
+            'client_id' => config('passport.password_grant_client.id'),
+            'client_secret' => config('passport.password_grant_client.secret'),
             'username' => $data['username'],
             'password' => $data['password'],
             'scope' => '',

--- a/config/passport.php
+++ b/config/passport.php
@@ -50,16 +50,16 @@ $passports = [
 
     /*
     |--------------------------------------------------------------------------
-    | Password Client
+    | Password Grant Client
     |--------------------------------------------------------------------------
     |
-    | Password client used for oauth login.
+    | Password grant client used for oauth login, and mobile application.
     |
     */
 
-    'password_client' => [
-        'id' => env('PASSPORT_PASSWORD_CLIENT_ID', env('MOBILE_CLIENT_ID')),
-        'secret' => env('PASSPORT_PASSWORD_CLIENT_SECRET', env('MOBILE_CLIENT_SECRET')),
+    'password_grant_client' => [
+        'id' => env('PASSPORT_PASSWORD_GRANT_CLIENT_ID', env('MOBILE_CLIENT_ID')),
+        'secret' => env('PASSPORT_PASSWORD_GRANT_CLIENT_SECRET', env('MOBILE_CLIENT_SECRET')),
     ],
 
     /*

--- a/config/passport.php
+++ b/config/passport.php
@@ -44,8 +44,22 @@ $passports = [
     */
 
     'personal_access_client' => [
-        'id' => env('PASSPORT_PERSONAL_ACCESS_CLIENT_ID', env('MOBILE_CLIENT_ID')),
-        'secret' => env('PASSPORT_PERSONAL_ACCESS_CLIENT_SECRET', env('MOBILE_CLIENT_SECRET')),
+        'id' => env('PASSPORT_PERSONAL_ACCESS_CLIENT_ID'),
+        'secret' => env('PASSPORT_PERSONAL_ACCESS_CLIENT_SECRET'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Password Client
+    |--------------------------------------------------------------------------
+    |
+    | Password client used for oauth login.
+    |
+    */
+
+    'password_client' => [
+        'id' => env('PASSPORT_PASSWORD_CLIENT_ID', env('MOBILE_CLIENT_ID')),
+        'secret' => env('PASSPORT_PASSWORD_CLIENT_SECRET', env('MOBILE_CLIENT_SECRET')),
     ],
 
     /*

--- a/docs/installation/providers/generic.md
+++ b/docs/installation/providers/generic.md
@@ -300,8 +300,8 @@ Client secret: zsfOHGnEbadlBP8kLsjOV8hMpHAxb0oAhenfmSqq
 
 -   Copy the two values into two new environment variables of your `.env` file:
 
-    -   The value of `Client ID` in a `PASSPORT_PERSONAL_ACCESS_CLIENT_ID` variable
-    -   The value of `Client secret` in a `PASSPORT_PERSONAL_ACCESS_CLIENT_SECRET` variable
+    -   The value of `Client ID` in a `PASSPORT_PASSWORD_CLIENT_ID` variable
+    -   The value of `Client secret` in a `PASSPORT_PASSWORD_CLIENT_SECRET` variable
 
 -   OAuth login can be access on `http://localhost/oauth/login`.
 

--- a/docs/installation/providers/generic.md
+++ b/docs/installation/providers/generic.md
@@ -300,8 +300,8 @@ Client secret: zsfOHGnEbadlBP8kLsjOV8hMpHAxb0oAhenfmSqq
 
 -   Copy the two values into two new environment variables of your `.env` file:
 
-    -   The value of `Client ID` in a `PASSPORT_PASSWORD_CLIENT_ID` variable
-    -   The value of `Client secret` in a `PASSPORT_PASSWORD_CLIENT_SECRET` variable
+    -   The value of `Client ID` in a `PASSPORT_PASSWORD_GRANT_CLIENT_ID` variable
+    -   The value of `Client secret` in a `PASSPORT_PASSWORD_GRANT_CLIENT_SECRET` variable
 
 -   OAuth login can be access on `http://localhost/oauth/login`.
 

--- a/docs/installation/providers/heroku.md
+++ b/docs/installation/providers/heroku.md
@@ -97,8 +97,8 @@ Client secret: zsfOHGnEbadlBP8kLsjOV8hMpHAxb0oAhenfmSqq
 ```
 
 * Copy the two values into two new environment variable of your `.env` file:
-   - The value of client ID in a `PASSPORT_PERSONAL_ACCESS_CLIENT_ID` variable
-   - The value of client secret in a `PASSPORT_PERSONAL_ACCESS_CLIENT_SECRET` variable
+   - The value of client ID in a `PASSPORT_PASSWORD_CLIENT_ID` variable
+   - The value of client secret in a `PASSPORT_PASSWORD_CLIENT_SECRET` variable
 
 ## Limitations
 

--- a/docs/installation/providers/heroku.md
+++ b/docs/installation/providers/heroku.md
@@ -97,8 +97,8 @@ Client secret: zsfOHGnEbadlBP8kLsjOV8hMpHAxb0oAhenfmSqq
 ```
 
 * Copy the two values into two new environment variable of your `.env` file:
-   - The value of client ID in a `PASSPORT_PASSWORD_CLIENT_ID` variable
-   - The value of client secret in a `PASSPORT_PASSWORD_CLIENT_SECRET` variable
+   - The value of client ID in a `PASSPORT_PASSWORD_GRANT_CLIENT_ID` variable
+   - The value of client secret in a `PASSPORT_PASSWORD_GRANT_CLIENT_SECRET` variable
 
 ## Limitations
 

--- a/tests/Browser/Auth/AuthControllerTest.php
+++ b/tests/Browser/Auth/AuthControllerTest.php
@@ -42,8 +42,8 @@ class AuthControllerTest extends TestCase
             );
 
             $this->setEnvironmentValue([
-                'PASSPORT_PERSONAL_ACCESS_CLIENT_ID' => $client->id,
-                'PASSPORT_PERSONAL_ACCESS_CLIENT_SECRET' => $client->secret,
+                'PASSPORT_PASSWORD_CLIENT_ID' => $client->id,
+                'PASSPORT_PASSWORD_CLIENT_SECRET' => $client->secret,
             ]);
 
             $userPassword = 'password';
@@ -79,8 +79,8 @@ class AuthControllerTest extends TestCase
             );
 
             $this->setEnvironmentValue([
-                'PASSPORT_PERSONAL_ACCESS_CLIENT_ID' => $client->id,
-                'PASSPORT_PERSONAL_ACCESS_CLIENT_SECRET' => $client->secret,
+                'PASSPORT_PASSWORD_CLIENT_ID' => $client->id,
+                'PASSPORT_PASSWORD_CLIENT_SECRET' => $client->secret,
             ]);
 
             $userPassword = 'password';
@@ -135,8 +135,8 @@ class AuthControllerTest extends TestCase
             );
 
             $this->setEnvironmentValue([
-                'PASSPORT_PERSONAL_ACCESS_CLIENT_ID' => $client->id,
-                'PASSPORT_PERSONAL_ACCESS_CLIENT_SECRET' => $client->secret,
+                'PASSPORT_PASSWORD_CLIENT_ID' => $client->id,
+                'PASSPORT_PASSWORD_CLIENT_SECRET' => $client->secret,
             ]);
 
             $userPassword = 'password';

--- a/tests/Browser/Auth/AuthControllerTest.php
+++ b/tests/Browser/Auth/AuthControllerTest.php
@@ -42,8 +42,8 @@ class AuthControllerTest extends TestCase
             );
 
             $this->setEnvironmentValue([
-                'PASSPORT_PASSWORD_CLIENT_ID' => $client->id,
-                'PASSPORT_PASSWORD_CLIENT_SECRET' => $client->secret,
+                'PASSPORT_PASSWORD_GRANT_CLIENT_ID' => $client->id,
+                'PASSPORT_PASSWORD_GRANT_CLIENT_SECRET' => $client->secret,
             ]);
 
             $userPassword = 'password';
@@ -79,8 +79,8 @@ class AuthControllerTest extends TestCase
             );
 
             $this->setEnvironmentValue([
-                'PASSPORT_PASSWORD_CLIENT_ID' => $client->id,
-                'PASSPORT_PASSWORD_CLIENT_SECRET' => $client->secret,
+                'PASSPORT_PASSWORD_GRANT_CLIENT_ID' => $client->id,
+                'PASSPORT_PASSWORD_GRANT_CLIENT_SECRET' => $client->secret,
             ]);
 
             $userPassword = 'password';
@@ -135,8 +135,8 @@ class AuthControllerTest extends TestCase
             );
 
             $this->setEnvironmentValue([
-                'PASSPORT_PASSWORD_CLIENT_ID' => $client->id,
-                'PASSPORT_PASSWORD_CLIENT_SECRET' => $client->secret,
+                'PASSPORT_PASSWORD_GRANT_CLIENT_ID' => $client->id,
+                'PASSPORT_PASSWORD_GRANT_CLIENT_SECRET' => $client->secret,
             ]);
 
             $userPassword = 'password';


### PR DESCRIPTION
There was a mistake between 
- [Personal access token](https://laravel.com/docs/8.x/passport#personal-access-tokens), used to provide personal access token
- [Password grant token](https://laravel.com/docs/8.x/passport#password-grant-tokens), used to register an oauth application

A confusion has been made in the passport config between these 2.

The `PASSPORT_PERSONAL_ACCESS_CLIENT_ID` and `PASSPORT_PERSONAL_ACCESS_CLIENT_SECRET` environment variable are optional to set.
`PASSPORT_PASSWORD_GRANT_CLIENT_ID` and `PASSPORT_PASSWORD_GRANT_CLIENT_SECRET` are only useful if you want to activate oauth client login.


This fix it.