### PR TITLE
docs: Revised minimum hardware requirements due to build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ If you want to host Monica yourself, you will need a server with:
 - Composer
 - MySQL
 
-Monica has been successfully self-hosted on a VPS with a single CPU core and 256&thinsp;MB of RAM. Monica was fully functional on this server, although suffered occasional slowdowns due to constrained resources. A machine with more RAM and CPU cores will give faster performance.
+To successfully build and host Monica, we recommend a system with at least 1.5&thinsp;GB for RAM.  Monica can run on systems with significantly less memory, but due to the high memory requirements of the build process during updates, you may encounter issues and failed builds.
 
 ### Update your instance
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ If you want to host Monica yourself, you will need a server with:
 - Composer
 - MySQL
 
+Monica has been successfully self-hosted on a VPS with a single CPU core and 256&thinsp;MB of RAM. Monica was fully functional on this server, although suffered occasional slowdowns due to constrained resources. A machine with more RAM and CPU cores will give faster performance.
+
 ### Update your instance
 
 Once the software is installed, you’ll need to update it from time to time to have access to the latest features. [Read this document](/docs/installation/update.md) to learn how to do it.

--- a/README.md
+++ b/README.md
@@ -134,8 +134,6 @@ If you want to host Monica yourself, you will need a server with:
 - Composer
 - MySQL
 
-Monica has been successfully self-hosted on a VPS with a single CPU core and 256&thinsp;MB of RAM. Monica was fully functional on this server, although suffered occasional slowdowns due to constrained resources. A machine with more RAM and CPU cores will give faster performance.
-
 ### Update your instance
 
 Once the software is installed, you’ll need to update it from time to time to have access to the latest features. [Read this document](/docs/installation/update.md) to learn how to do it.


### PR DESCRIPTION
Prior versions worked because yarn assets were pre-built and included.  With the removal of these, I don't think Monica can be successfully updated on a machine with 768MB or less of RAM.  I *think* yarn's memory requirements are too high.

Monica had been working fine on a Debian VPS with 256MB RAM.  It was a little slow but fully functional.  While trying to upgrade to 3.0, I could not successfully run the `yarn run production` command.  Despite being left for 6+ hours on several attempts, it simply freezes and does not go any further during the "fetching packages" stage.

I tried to build 3.0 on another Debian VPS with 768MB of RAM.  It got further in the process but repeatedly failed with this error:

    error Command failed with exit code 134

Which, as far as I can tell from Google, is because it runs out of memory.

Given that, I'm no longer comfortable recommending Monica run on such a constrained machine.