### PR TITLE
Fixing local docker development

### DIFF
--- a/docs/contribute/docker.md
+++ b/docs/contribute/docker.md
@@ -21,21 +21,28 @@ docker-compose up
 Use this process if you're a developer and want complete control over
 your Monica container.
 
-Edit `.env` again to set the `DB_*` variables to match your database. Then run:
+If you aren't using docker-compose, edit `.env` again to set the `DB_*` variables to match your database. Then run:
 
 ```sh
-docker build -t monicahq/monicahq .
+# assets are copied from the host machine, make sure they are built
+npm install --production && npm run preproduction && npm run production
+
+docker build -t monicahq/monicahq -f scripts/docker/Dockerfile .
+
 docker run --env-file .env -p 80:80 monicahq/monicahq  # to run MonicaHQ
+
 # ...or...
 docker run --env-file .env -it monicahq/monicahq sh    # to get a prompt
 ```
+
+There's a bunch of [docker-compose examples here.](https://github.com/monicahq/docker/tree/master/.examples)
 
 Note that uploaded files, like avatars, will disappear when you
 restart the container. Map a volume to
 `/var/www/monica/storage/app/public` if you want that data to persist
 between runs. See `docker-compose.yml` for examples.
 
-## Other documents to read	
+## Other documents to read
 
 [Connecting to MySQL inside of a Docker container](/docs/installation/docker-mysql.md)
 [Use mobile app with standalone server](/docs/installation/mobile.md)

--- a/docs/contribute/docker.md
+++ b/docs/contribute/docker.md
@@ -25,7 +25,7 @@ If you aren't using docker-compose, edit `.env` again to set the `DB_*` variable
 
 ```sh
 # assets are copied from the host machine, make sure they are built
-npm install --production && npm run preproduction && npm run production
+yarn install && yarn run production
 
 docker build -t monicahq/monicahq -f scripts/docker/Dockerfile .
 

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -3,9 +3,10 @@
 ###
 ### This file is used for dev purpose.
 ### The standard monica image definition will be found here: https://github.com/monicahq/docker
+### This file is based off of the `apache` variant in the above mentioned repo
 ###
 
-FROM php:7.4-apache
+FROM php:8.0-apache
 
 # opencontainers annotations https://github.com/opencontainers/image-spec/blob/master/annotations.md
 LABEL org.opencontainers.image.authors="Alexis Saettler <alexis@saettler.org>" \
@@ -138,23 +139,7 @@ WORKDIR /var/www/html
 # Copy the local (outside Docker) source into the working directory,
 # copy system files into their proper homes, and set file ownership
 # correctly
-COPY --chown=www-data:www-data \
-    README.md \
-    CONTRIBUTING.md \
-    CHANGELOG.md \
-    CONTRIBUTORS \
-    LICENSE \
-    artisan \
-    composer.json \
-    composer.lock \
-    ./
-COPY --chown=www-data:www-data app ./app
-COPY --chown=www-data:www-data bootstrap ./bootstrap
-COPY --chown=www-data:www-data config ./config
-COPY --chown=www-data:www-data database ./database
-COPY --chown=www-data:www-data public ./public
-COPY --chown=www-data:www-data resources ./resources
-COPY --chown=www-data:www-data routes ./routes
+COPY --chown=www-data:www-data . ./
 
 RUN set -ex; \
     \


### PR DESCRIPTION
The individual copy commands missed some key files that are required to build the image. I don't see any downside to copying the entire source over. 