### PR TITLE
feat: add a rate limiter for locationiq queries

### DIFF
--- a/app/Console/Commands/ImportVCards.php
+++ b/app/Console/Commands/ImportVCards.php
@@ -92,7 +92,7 @@ class ImportVCards extends Command
             'filename' => $pathName,
         ]);
 
-        dispatch_now(new AddContactFromVCard($importJob));
+        AddContactFromVCard::dispatchSync($importJob);
 
         return $importJob;
     }

--- a/app/Http/Controllers/Auth/InvitationController.php
+++ b/app/Http/Controllers/Auth/InvitationController.php
@@ -129,7 +129,7 @@ class InvitationController extends Controller
         $user->save();
 
         // send me an alert
-        dispatch(new SendNewUserAlert($user));
+        SendNewUserAlert::dispatch($user);
 
         return $user;
     }

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -107,7 +107,7 @@ class RegisterController extends Controller
 
             if (! $first) {
                 // send me an alert
-                dispatch(new SendNewUserAlert($user));
+                SendNewUserAlert::dispatch($user);
             }
 
             return $user;

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -199,7 +199,7 @@ class SettingsController extends Controller
      */
     public function exportToSql()
     {
-        $path = dispatch_now(new ExportAccountAsSQL());
+        $path = ExportAccountAsSQL::dispatchSync();
 
         $adapter = disk_adapter(ExportAccountAsSQL::STORAGE);
 
@@ -250,7 +250,7 @@ class SettingsController extends Controller
             'filename' => $filename,
         ]);
 
-        dispatch(new AddContactFromVCard($importJob, $request->input('behaviour')));
+        AddContactFromVCard::dispatch($importJob, $request->input('behaviour'));
 
         return redirect()->route('settings.import');
     }

--- a/app/Jobs/GetGPSCoordinate.php
+++ b/app/Jobs/GetGPSCoordinate.php
@@ -4,7 +4,6 @@ namespace App\Jobs;
 
 use Illuminate\Bus\Queueable;
 use App\Models\Account\Place;
-use GuzzleHttp\Client as GuzzleClient;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -21,11 +20,6 @@ class GetGPSCoordinate implements ShouldQueue
      * @var Place
      */
     protected $place;
-
-    /**
-     * @var GuzzleClient
-     */
-    protected $client;
 
     /**
      * The number of times the job may be attempted.
@@ -46,10 +40,9 @@ class GetGPSCoordinate implements ShouldQueue
      *
      * @return void
      */
-    public function __construct(Place $place, GuzzleClient $client = null)
+    public function __construct(Place $place)
     {
         $this->place = $place->withoutRelations();
-        $this->client = $client;
     }
 
     /**
@@ -75,6 +68,6 @@ class GetGPSCoordinate implements ShouldQueue
         app(GetGPSCoordinateService::class)->execute([
             'account_id' => $this->place->account_id,
             'place_id' => $this->place->id,
-        ], $this->client);
+        ]);
     }
 }

--- a/app/Jobs/GetGPSCoordinate.php
+++ b/app/Jobs/GetGPSCoordinate.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use App\Models\Account\Place;
+use GuzzleHttp\Client as GuzzleClient;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\Middleware\RateLimited;
+use App\Services\Instance\Geolocalization\GetGPSCoordinate as GetGPSCoordinateService;
+
+
+class GetGPSCoordinate implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * @var Place
+     */
+    protected $place;
+
+    /**
+     * @var GuzzleClient
+     */
+    protected $client;
+
+    /**
+     * The number of times the job may be attempted.
+     *
+     * @var int
+     */
+    public $tries = 10;
+
+    /**
+     * The maximum number of unhandled exceptions to allow before failing.
+     *
+     * @var int
+     */
+    public $maxExceptions = 1;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(Place $place, GuzzleClient $client = null)
+    {
+        $this->place = $place->withoutRelations();
+        $this->client = $client;
+    }
+
+    /**
+     * Get the middleware the job should pass through.
+     *
+     * @return array
+     */
+    public function middleware()
+    {
+        return [
+            new RateLimited('GPSCoordinatePerMinute'),
+            new RateLimited('GPSCoordinatePerDay'),
+        ];
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        app(GetGPSCoordinateService::class)->execute([
+            'account_id' => $this->place->account_id,
+            'place_id' => $this->place->id,
+        ], $this->client);
+    }
+}

--- a/app/Jobs/SendNewUserAlert.php
+++ b/app/Jobs/SendNewUserAlert.php
@@ -7,12 +7,13 @@ use Illuminate\Bus\Queueable;
 use App\Notifications\NewUserAlert;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Facades\Notification;
 
 class SendNewUserAlert implements ShouldQueue
 {
-    use InteractsWithQueue, Queueable, SerializesModels;
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
     protected $user;
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -12,6 +12,8 @@ use Illuminate\Support\Facades\View;
 use App\Notifications\EmailMessaging;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Auth\Notifications\VerifyEmail;
 use Illuminate\Auth\Notifications\ResetPassword;
 
@@ -65,6 +67,13 @@ class AppServiceProvider extends ServiceProvider
         });
 
         Paginator::defaultView('vendor.pagination.default');
+
+        RateLimiter::for('GPSCoordinatePerMinute', function () {
+            return Limit::perMinute(60);
+        });
+        RateLimiter::for('GPSCoordinatePerDay', function () {
+            return Limit::perDay(5000);
+        });
     }
 
     /**

--- a/app/Services/Account/Place/CreatePlace.php
+++ b/app/Services/Account/Place/CreatePlace.php
@@ -5,7 +5,6 @@ namespace App\Services\Account\Place;
 use App\Models\Account\Place;
 use App\Services\BaseService;
 use App\Jobs\GetGPSCoordinate;
-use GuzzleHttp\Client as GuzzleClient;
 
 class CreatePlace extends BaseService
 {
@@ -32,10 +31,9 @@ class CreatePlace extends BaseService
      * Create a place.
      *
      * @param array $data
-     * @param GuzzleClient $client the Guzzle client, only needed when unit testing
      * @return Place
      */
-    public function execute(array $data, GuzzleClient $client = null): Place
+    public function execute(array $data): Place
     {
         $this->validate($data);
 
@@ -51,7 +49,7 @@ class CreatePlace extends BaseService
         ]);
 
         if (is_null($place->latitude) || is_null($place->longitude)) {
-            $this->getGeocodingInfo($place, $client);
+            $this->getGeocodingInfo($place);
         }
 
         return $place;
@@ -61,13 +59,12 @@ class CreatePlace extends BaseService
      * Get geocoding information about the place (lat/longitude).
      *
      * @param Place $place
-     * @param GuzzleClient $client the Guzzle client, only needed when unit testing
      * @return void
      */
-    private function getGeocodingInfo(Place $place, GuzzleClient $client = null)
+    private function getGeocodingInfo(Place $place)
     {
         if (config('monica.enable_geolocation') && ! is_null(config('monica.location_iq_api_key'))) {
-            GetGPSCoordinate::dispatch($place, $client);
+            GetGPSCoordinate::dispatch($place);
         }
     }
 }

--- a/app/Services/Account/Place/UpdatePlace.php
+++ b/app/Services/Account/Place/UpdatePlace.php
@@ -4,8 +4,8 @@ namespace App\Services\Account\Place;
 
 use App\Models\Account\Place;
 use App\Services\BaseService;
+use App\Jobs\GetGPSCoordinate;
 use GuzzleHttp\Client as GuzzleClient;
-use App\Services\Instance\Geolocalization\GetGPSCoordinate;
 
 class UpdatePlace extends BaseService
 {
@@ -54,7 +54,7 @@ class UpdatePlace extends BaseService
             'longitude' => $this->nullOrValue($data, 'longitude'),
         ]);
 
-        if (is_null($place->latitude)) {
+        if (is_null($place->latitude) || is_null($place->longitude)) {
             $this->getGeocodingInfo($place, $client);
         }
 
@@ -70,9 +70,8 @@ class UpdatePlace extends BaseService
      */
     private function getGeocodingInfo(Place $place, GuzzleClient $client = null)
     {
-        app(GetGPSCoordinate::class)->execute([
-            'account_id' => $place->account_id,
-            'place_id' => $place->id,
-        ], $client);
+        if (config('monica.enable_geolocation') && ! is_null(config('monica.location_iq_api_key'))) {
+            GetGPSCoordinate::dispatch($place, $client);
+        }
     }
 }

--- a/app/Services/Account/Place/UpdatePlace.php
+++ b/app/Services/Account/Place/UpdatePlace.php
@@ -5,7 +5,6 @@ namespace App\Services\Account\Place;
 use App\Models\Account\Place;
 use App\Services\BaseService;
 use App\Jobs\GetGPSCoordinate;
-use GuzzleHttp\Client as GuzzleClient;
 
 class UpdatePlace extends BaseService
 {
@@ -33,10 +32,9 @@ class UpdatePlace extends BaseService
      * Update a place.
      *
      * @param array $data
-     * @param GuzzleClient $client the Guzzle client, only needed when unit testing
      * @return Place
      */
-    public function execute(array $data, GuzzleClient $client = null): Place
+    public function execute(array $data): Place
     {
         $this->validate($data);
 
@@ -55,7 +53,7 @@ class UpdatePlace extends BaseService
         ]);
 
         if (is_null($place->latitude) || is_null($place->longitude)) {
-            $this->getGeocodingInfo($place, $client);
+            $this->getGeocodingInfo($place);
         }
 
         return $place;
@@ -65,13 +63,12 @@ class UpdatePlace extends BaseService
      * Get geocoding information about the place (lat/longitude).
      *
      * @param Place $place
-     * @param GuzzleClient $client the Guzzle client, only needed when unit testing
      * @return void
      */
-    private function getGeocodingInfo(Place $place, GuzzleClient $client = null)
+    private function getGeocodingInfo(Place $place)
     {
         if (config('monica.enable_geolocation') && ! is_null(config('monica.location_iq_api_key'))) {
-            GetGPSCoordinate::dispatch($place, $client);
+            GetGPSCoordinate::dispatch($place);
         }
     }
 }

--- a/app/Services/Instance/Weather/GetWeatherInformation.php
+++ b/app/Services/Instance/Weather/GetWeatherInformation.php
@@ -6,18 +6,14 @@ use Illuminate\Support\Str;
 use App\Models\Account\Place;
 use App\Services\BaseService;
 use App\Jobs\GetGPSCoordinate;
-use function Safe\json_decode;
 use App\Models\Account\Weather;
 use Illuminate\Support\Facades\Log;
-use GuzzleHttp\Client as GuzzleClient;
-use GuzzleHttp\Exception\ClientException;
+use Illuminate\Support\Facades\Http;
 use App\Exceptions\MissingEnvVariableException;
+use Illuminate\Http\Client\HttpClientException;
 
 class GetWeatherInformation extends BaseService
 {
-    /** @var GuzzleClient */
-    protected $client;
-
     /**
      * Get the validation rules that apply to the service.
      *
@@ -34,14 +30,12 @@ class GetWeatherInformation extends BaseService
      * Get the weather information.
      *
      * @param array $data
-     * @param GuzzleClient $client the Guzzle client, only needed when unit testing
      * @return Weather|null
      * @throws \Illuminate\Validation\ValidationException if the array that is given in parameter is not valid
      * @throws \App\Exceptions\MissingEnvVariableException if the weather services are not enabled
      * @throws \Illuminate\Database\Eloquent\ModelNotFoundException if the Place object is not found
-     * @throws \GuzzleHttp\Exception\ClientException if the request to Darksky crashed
      */
-    public function execute(array $data, GuzzleClient $client = null): ?Weather
+    public function execute(array $data): ?Weather
     {
         $this->validateWeatherEnvVariables();
 
@@ -55,12 +49,6 @@ class GetWeatherInformation extends BaseService
             if (is_null($place)) {
                 return null;
             }
-        }
-
-        if (! is_null($client)) {
-            $this->client = $client;
-        } else {
-            $this->client = new GuzzleClient();
         }
 
         return $this->query($place);
@@ -94,17 +82,17 @@ class GetWeatherInformation extends BaseService
         $query = $this->buildQuery($place);
 
         try {
-            $response = $this->client->request('GET', $query);
-            $response = json_decode($response->getBody());
+            $response = Http::get($query);
+            $response->throw();
 
             $weather = new Weather();
-            $weather->weather_json = $response;
+            $weather->weather_json = $response->object();
             $weather->account_id = $place->account_id;
             $weather->place_id = $place->id;
             $weather->save();
 
             return $weather;
-        } catch (ClientException $e) {
+        } catch (HttpClientException $e) {
             Log::error('Error making the call: '.$e);
         }
 
@@ -135,13 +123,12 @@ class GetWeatherInformation extends BaseService
      * Fetch missing longitude/latitude.
      *
      * @param Place $place
-     * @param GuzzleClient $client
      * @return Place|null
      */
-    private function fetchGPS(Place $place, GuzzleClient $client = null) : ?Place
+    private function fetchGPS(Place $place) : ?Place
     {
         if (config('monica.enable_geolocation') && ! is_null(config('monica.location_iq_api_key'))) {
-            GetGPSCoordinate::dispatchSync($place, $client);
+            GetGPSCoordinate::dispatchSync($place);
             $place->refresh();
             return $place;
         }

--- a/tests/Feature/ExportAccountAsSQLTest.php
+++ b/tests/Feature/ExportAccountAsSQLTest.php
@@ -18,7 +18,7 @@ class ExportAccountAsSQLTest extends FeatureTestCase
 
         $user = $this->signIn();
 
-        $path = dispatch_now(new ExportAccountAsSQL());
+        $path = ExportAccountAsSQL::dispatchSync();
 
         $this->assertStringStartsWith('exports/', $path);
         $this->assertStringEndsWith('.sql', $path);

--- a/tests/Feature/RegisterTest.php
+++ b/tests/Feature/RegisterTest.php
@@ -71,7 +71,7 @@ class RegisterTest extends FeatureTestCase
 
         $user = factory(User::class)->create();
 
-        dispatch(new SendNewUserAlert($user));
+        SendNewUserAlert::dispatch($user);
 
         Notification::assertSentTo($route, NewUserAlert::class);
 

--- a/tests/Unit/Jobs/ScheduleStayInTouchTest.php
+++ b/tests/Unit/Jobs/ScheduleStayInTouchTest.php
@@ -38,7 +38,7 @@ class ScheduleStayInTouchTest extends TestCase
             'timezone' => 'America/New_York',
         ]);
 
-        dispatch(new ScheduleStayInTouch($contact));
+        ScheduleStayInTouch::dispatch($contact);
 
         NotificationFacade::assertSentTo($user, StayInTouchEmail::class,
             function ($notification, $channels) use ($contact) {
@@ -81,7 +81,7 @@ class ScheduleStayInTouchTest extends TestCase
             'timezone' => 'America/New_York',
         ]);
 
-        dispatch(new ScheduleStayInTouch($contact));
+        ScheduleStayInTouch::dispatch($contact);
 
         NotificationFacade::assertNotSentTo($user, StayInTouchEmail::class);
         NotificationFacade::assertNothingSent();
@@ -113,7 +113,7 @@ class ScheduleStayInTouchTest extends TestCase
             'timezone' => 'America/New_York',
         ]);
 
-        dispatch(new ScheduleStayInTouch($contact));
+        ScheduleStayInTouch::dispatch($contact);
 
         NotificationFacade::assertNotSentTo($user, StayInTouchEmail::class);
         NotificationFacade::assertNothingSent();

--- a/tests/Unit/Jobs/UpdateLastConsultedDateTest.php
+++ b/tests/Unit/Jobs/UpdateLastConsultedDateTest.php
@@ -21,7 +21,7 @@ class UpdateLastConsultedDateTest extends TestCase
             'number_of_views' => 1,
         ]);
 
-        dispatch(new UpdateLastConsultedDate($contact));
+        UpdateLastConsultedDate::dispatch($contact);
 
         $this->assertDatabaseHas('contacts', [
             'id' => $contact->id,

--- a/tests/Unit/Models/ContactTest.php
+++ b/tests/Unit/Models/ContactTest.php
@@ -1003,7 +1003,7 @@ class ContactTest extends FeatureTestCase
             'timezone' => 'America/New_York',
         ]);
 
-        dispatch(new ScheduleStayInTouch($contact));
+        ScheduleStayInTouch::dispatch($contact);
 
         NotificationFacade::assertSentTo($user, StayInTouchEmail::class,
             function ($notification, $channels) use ($contact) {

--- a/tests/Unit/Services/Account/Place/CreatePlaceTest.php
+++ b/tests/Unit/Services/Account/Place/CreatePlaceTest.php
@@ -3,12 +3,9 @@
 namespace Tests\Unit\Services\Account\Place;
 
 use Tests\TestCase;
-use GuzzleHttp\Client;
-use GuzzleHttp\HandlerStack;
 use App\Models\Account\Place;
-use GuzzleHttp\Psr7\Response;
 use App\Models\Account\Account;
-use GuzzleHttp\Handler\MockHandler;
+use Illuminate\Support\Facades\Http;
 use App\Services\Account\Place\CreatePlace;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -55,9 +52,9 @@ class CreatePlaceTest extends TestCase
         config(['monica.location_iq_api_key' => 'test']);
 
         $body = file_get_contents(base_path('tests/Fixtures/Services/Account/Place/CreatePlaceSampleResponse.json'));
-        $mock = new MockHandler([new Response(200, [], $body)]);
-        $handler = HandlerStack::create($mock);
-        $client = new Client(['handler' => $handler]);
+        Http::fake([
+            'us1.locationiq.com/v1/*' => Http::response($body, 200)
+        ]);
 
         $account = factory(Account::class)->create([]);
 
@@ -72,7 +69,7 @@ class CreatePlaceTest extends TestCase
             'longitude' => '',
         ];
 
-        $place = app(CreatePlace::class)->execute($request, $client);
+        $place = app(CreatePlace::class)->execute($request);
 
         $this->assertDatabaseHas('places', [
             'id' => $place->id,
@@ -86,7 +83,7 @@ class CreatePlaceTest extends TestCase
     /** @test */
     public function it_fails_if_wrong_parameters_are_given()
     {
-        $account = factory(Account::class)->create([]);
+        factory(Account::class)->create([]);
 
         $request = [
             'street' => '199 Lafayette Street',

--- a/tests/Unit/Services/Account/Place/CreatePlaceTest.php
+++ b/tests/Unit/Services/Account/Place/CreatePlaceTest.php
@@ -53,7 +53,7 @@ class CreatePlaceTest extends TestCase
 
         $body = file_get_contents(base_path('tests/Fixtures/Services/Account/Place/CreatePlaceSampleResponse.json'));
         Http::fake([
-            'us1.locationiq.com/v1/*' => Http::response($body, 200)
+            'us1.locationiq.com/v1/*' => Http::response($body, 200),
         ]);
 
         $account = factory(Account::class)->create([]);

--- a/tests/Unit/Services/Account/Place/UpdatePlaceTest.php
+++ b/tests/Unit/Services/Account/Place/UpdatePlaceTest.php
@@ -55,7 +55,7 @@ class UpdatePlaceTest extends TestCase
 
         $body = file_get_contents(base_path('tests/Fixtures/Services/Account/Place/UpdatePlaceSampleResponse.json'));
         Http::fake([
-            'us1.locationiq.com/v1/*' => Http::response($body, 200)
+            'us1.locationiq.com/v1/*' => Http::response($body, 200),
         ]);
 
         $place = factory(Place::class)->create([]);

--- a/tests/Unit/Services/Account/Place/UpdatePlaceTest.php
+++ b/tests/Unit/Services/Account/Place/UpdatePlaceTest.php
@@ -3,12 +3,9 @@
 namespace Tests\Unit\Services\Account\Place;
 
 use Tests\TestCase;
-use GuzzleHttp\Client;
-use GuzzleHttp\HandlerStack;
 use App\Models\Account\Place;
-use GuzzleHttp\Psr7\Response;
 use App\Models\Account\Account;
-use GuzzleHttp\Handler\MockHandler;
+use Illuminate\Support\Facades\Http;
 use App\Services\Account\Place\UpdatePlace;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -57,9 +54,9 @@ class UpdatePlaceTest extends TestCase
         config(['monica.location_iq_api_key' => 'test']);
 
         $body = file_get_contents(base_path('tests/Fixtures/Services/Account/Place/UpdatePlaceSampleResponse.json'));
-        $mock = new MockHandler([new Response(200, [], $body)]);
-        $handler = HandlerStack::create($mock);
-        $client = new Client(['handler' => $handler]);
+        Http::fake([
+            'us1.locationiq.com/v1/*' => Http::response($body, 200)
+        ]);
 
         $place = factory(Place::class)->create([]);
 
@@ -75,7 +72,7 @@ class UpdatePlaceTest extends TestCase
             'longitude' => '',
         ];
 
-        $place = app(UpdatePlace::class)->execute($request, $client);
+        $place = app(UpdatePlace::class)->execute($request);
 
         $this->assertDatabaseHas('places', [
             'id' => $place->id,

--- a/tests/Unit/Services/Instance/Geolocalization/GetGPSCoordinateTest.php
+++ b/tests/Unit/Services/Instance/Geolocalization/GetGPSCoordinateTest.php
@@ -3,11 +3,8 @@
 namespace Tests\Unit\Services\Instance\Geolocalization;
 
 use Tests\TestCase;
-use GuzzleHttp\Client;
-use GuzzleHttp\HandlerStack;
 use App\Models\Account\Place;
-use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\Handler\MockHandler;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Validation\ValidationException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use App\Services\Instance\Geolocalization\GetGPSCoordinate;
@@ -40,9 +37,9 @@ class GetGPSCoordinateTest extends TestCase
         config(['monica.location_iq_api_key' => 'test']);
 
         $body = file_get_contents(base_path('tests/Fixtures/Services/Instance/Geolocalization/GetGPSCoordinateSampleResponse.json'));
-        $mock = new MockHandler([new Response(200, [], $body)]);
-        $handler = HandlerStack::create($mock);
-        $client = new Client(['handler' => $handler]);
+        Http::fake([
+            'us1.locationiq.com/v1/*' => Http::response($body, 200)
+        ]);
 
         $place = factory(Place::class)->create();
 
@@ -51,7 +48,7 @@ class GetGPSCoordinateTest extends TestCase
             'place_id' => $place->id,
         ];
 
-        $place = app(GetGPSCoordinate::class)->execute($request, $client);
+        $place = app(GetGPSCoordinate::class)->execute($request);
 
         $this->assertDatabaseHas('places', [
             'id' => $place->id,
@@ -70,9 +67,9 @@ class GetGPSCoordinateTest extends TestCase
         config(['monica.location_iq_api_key' => 'test']);
 
         $body = file_get_contents(base_path('tests/Fixtures/Services/Instance/Geolocalization/GetGPSCoordinateGarbageResponse.json'));
-        $mock = new MockHandler([new Response(200, [], $body)]);
-        $handler = HandlerStack::create($mock);
-        $client = new Client(['handler' => $handler]);
+        Http::fake([
+            'us1.locationiq.com/v1/*' => Http::response($body, 404)
+        ]);
 
         $place = factory(Place::class)->create([
             'country' => 'ewqr',

--- a/tests/Unit/Services/Instance/Geolocalization/GetGPSCoordinateTest.php
+++ b/tests/Unit/Services/Instance/Geolocalization/GetGPSCoordinateTest.php
@@ -38,7 +38,7 @@ class GetGPSCoordinateTest extends TestCase
 
         $body = file_get_contents(base_path('tests/Fixtures/Services/Instance/Geolocalization/GetGPSCoordinateSampleResponse.json'));
         Http::fake([
-            'us1.locationiq.com/v1/*' => Http::response($body, 200)
+            'us1.locationiq.com/v1/*' => Http::response($body, 200),
         ]);
 
         $place = factory(Place::class)->create();
@@ -68,7 +68,7 @@ class GetGPSCoordinateTest extends TestCase
 
         $body = file_get_contents(base_path('tests/Fixtures/Services/Instance/Geolocalization/GetGPSCoordinateGarbageResponse.json'));
         Http::fake([
-            'us1.locationiq.com/v1/*' => Http::response($body, 404)
+            'us1.locationiq.com/v1/*' => Http::response($body, 404),
         ]);
 
         $place = factory(Place::class)->create([

--- a/tests/Unit/Services/Instance/Weather/GetWeatherInformationTest.php
+++ b/tests/Unit/Services/Instance/Weather/GetWeatherInformationTest.php
@@ -3,12 +3,10 @@
 namespace Tests\Unit\Services\Instance\Weather;
 
 use Tests\TestCase;
-use GuzzleHttp\Client;
-use GuzzleHttp\HandlerStack;
 use App\Models\Account\Place;
-use GuzzleHttp\Psr7\Response;
+use App\Models\Account\Account;
 use App\Models\Account\Weather;
-use GuzzleHttp\Handler\MockHandler;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Validation\ValidationException;
 use App\Exceptions\MissingEnvVariableException;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -30,20 +28,70 @@ class GetWeatherInformationTest extends TestCase
         config(['monica.darksky_api_key' => 'test']);
 
         $body = file_get_contents(base_path('tests/Fixtures/Services/Instance/Weather/GetWeatherInformationSampleResponse.json'));
-        $mock = new MockHandler([new Response(200, [], $body)]);
-        $handler = HandlerStack::create($mock);
-        $client = new Client(['handler' => $handler]);
+        Http::fake([
+            'api.darksky.net/forecast/*' => Http::response($body, 200)
+        ]);
 
         $request = [
             'place_id' => $place->id,
         ];
 
-        $weather = app(GetWeatherInformation::class)->execute($request, $client);
+        $weather = app(GetWeatherInformation::class)->execute($request);
 
         $this->assertDatabaseHas('weather', [
             'id' => $weather->id,
             'account_id' => $place->account_id,
             'place_id' => $place->id,
+        ]);
+
+        $this->assertEquals(
+            'Partly Cloudy',
+            $weather->summary
+        );
+
+        $this->assertInstanceOf(
+            Weather::class,
+            $weather
+        );
+    }
+
+    /** @test */
+    public function it_gets_weather_information_for_new_place()
+    {
+        $account = factory(Account::class)->create();
+        $place = factory(Place::class)->create([
+            'account_id' => $account->id,
+        ]);
+
+        config(['monica.enable_weather' => true]);
+        config(['monica.darksky_api_key' => 'test']);
+        config(['monica.enable_geolocation' => true]);
+        config(['monica.location_iq_api_key' => 'test']);
+
+        $body = file_get_contents(base_path('tests/Fixtures/Services/Instance/Weather/GetWeatherInformationSampleResponse.json'));
+        $placeBody = file_get_contents(base_path('tests/Fixtures/Services/Account/Place/CreatePlaceSampleResponse.json'));
+        Http::fake([
+            'us1.locationiq.com/v1/*' => Http::response($placeBody, 200),
+            'api.darksky.net/forecast/*' => Http::response($body, 200)
+        ]);
+
+        $request = [
+            'place_id' => $place->id,
+        ];
+
+        $weather = app(GetWeatherInformation::class)->execute($request);
+
+        $this->assertDatabaseHas('weather', [
+            'id' => $weather->id,
+            'account_id' => $account->id,
+            'place_id' => $place->id,
+        ]);
+        $this->assertDatabaseHas('places', [
+            'id' => $place->id,
+            'account_id' => $account->id,
+            'street' => '12',
+            'latitude' => 34.0736204,
+            'longitude' => -118.4003563,
         ]);
 
         $this->assertEquals(
@@ -93,6 +141,7 @@ class GetWeatherInformationTest extends TestCase
         $this->expectException(MissingEnvVariableException::class);
         app(GetWeatherInformation::class)->execute($request);
     }
+
 
     /** @test */
     public function it_cant_get_weather_info_if_latitude_longitude_are_null()

--- a/tests/Unit/Services/Instance/Weather/GetWeatherInformationTest.php
+++ b/tests/Unit/Services/Instance/Weather/GetWeatherInformationTest.php
@@ -29,7 +29,7 @@ class GetWeatherInformationTest extends TestCase
 
         $body = file_get_contents(base_path('tests/Fixtures/Services/Instance/Weather/GetWeatherInformationSampleResponse.json'));
         Http::fake([
-            'api.darksky.net/forecast/*' => Http::response($body, 200)
+            'api.darksky.net/forecast/*' => Http::response($body, 200),
         ]);
 
         $request = [
@@ -72,7 +72,7 @@ class GetWeatherInformationTest extends TestCase
         $placeBody = file_get_contents(base_path('tests/Fixtures/Services/Account/Place/CreatePlaceSampleResponse.json'));
         Http::fake([
             'us1.locationiq.com/v1/*' => Http::response($placeBody, 200),
-            'api.darksky.net/forecast/*' => Http::response($body, 200)
+            'api.darksky.net/forecast/*' => Http::response($body, 200),
         ]);
 
         $request = [
@@ -141,7 +141,6 @@ class GetWeatherInformationTest extends TestCase
         $this->expectException(MissingEnvVariableException::class);
         app(GetWeatherInformation::class)->execute($request);
     }
-
 
     /** @test */
     public function it_cant_get_weather_info_if_latitude_longitude_are_null()


### PR DESCRIPTION
This adds a RateLimiter for get coordinates queries, using [Laravel RateLimiter](https://laravel.com/docs/8.x/queues#rate-limiting)

Also use Http facade to call apis.