### PR TITLE
fix: adding missing configuration required for tests to pass locally

### DIFF
--- a/tests/Feature/RegisterTest.php
+++ b/tests/Feature/RegisterTest.php
@@ -16,6 +16,8 @@ class RegisterTest extends FeatureTestCase
 
     public function test_user_can_register()
     {
+        config(['monica.disable_signup' => false]);
+
         Mail::fake();
 
         $params = [
@@ -40,6 +42,8 @@ class RegisterTest extends FeatureTestCase
 
     public function test_user_cannot_register_twice()
     {
+        config(['monica.disable_signup' => false]);
+
         Mail::fake();
 
         $user = factory(User::class)->create();
@@ -64,6 +68,8 @@ class RegisterTest extends FeatureTestCase
 
     public function test_it_dispatches_an_email()
     {
+        config(['monica.disable_signup' => false]);
+
         $route = Notification::route('mail', 'test@test.com');
         Notification::fake();
 


### PR DESCRIPTION
As discussed in https://github.com/monicahq/monica/pull/5097