### PR TITLE
fix: Show fields in correct order on "Add Contact" page

### DIFF
--- a/resources/views/people/create.blade.php
+++ b/resources/views/people/create.blade.php
@@ -30,7 +30,17 @@
 
       <div class="pa4-ns ph3 pv2 bb b--gray-monica">
         {{-- This check is for the cultures that are used to say the last name first --}}
-        @if ($formNameOrder == 'firstname')
+        @if ($formNameOrder == 'lastname')
+
+        <div class="mb3">
+          <form-input
+            :id="'last_name'"
+            :input-type="'text'"
+            :required="false"
+            :title="'{{ trans('people.people_add_lastname') }}'"
+            :value="'{{ $lastName }}'">
+          </form-input>
+        </div>
 
         <div class="mb3">
           <form-input
@@ -48,16 +58,6 @@
             :input-type="'text'"
             :required="false"
             :title="'{{ trans('people.people_add_middlename') }}'">
-          </form-input>
-        </div>
-
-        <div class="mb3">
-          <form-input
-            :id="'last_name'"
-            :input-type="'text'"
-            :required="false"
-            :title="'{{ trans('people.people_add_lastname') }}'"
-            :value="'{{ $lastName }}'">
           </form-input>
         </div>
 
@@ -74,16 +74,6 @@
 
         <div class="mb3">
           <form-input
-            :id="'last_name'"
-            :input-type="'text'"
-            :required="false"
-            :title="'{{ trans('people.people_add_lastname') }}'"
-            :value="'{{ $lastName }}'">
-          </form-input>
-        </div>
-
-        <div class="mb3">
-          <form-input
             :id="'first_name'"
             :input-type="'text'"
             :required="true"
@@ -98,6 +88,16 @@
             :input-type="'text'"
             :required="false"
             :title="'{{ trans('people.people_add_middlename') }}'">
+          </form-input>
+        </div>
+
+        <div class="mb3">
+          <form-input
+            :id="'last_name'"
+            :input-type="'text'"
+            :required="false"
+            :title="'{{ trans('people.people_add_lastname') }}'"
+            :value="'{{ $lastName }}'">
           </form-input>
         </div>
 


### PR DESCRIPTION
The `if`-`else` statement here didn't appear to work correctly -- it always displayed the last-name field before the first-name field.  This fixes is so that it displays first-name ahead of last-name by default, and uses the `if`-`else` to flip it for languages that use last/first.