### PR TITLE
feat: revoke session from other browser after a password change

### DIFF
--- a/app/Http/Controllers/Auth/InvitationController.php
+++ b/app/Http/Controllers/Auth/InvitationController.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Foundation\Auth\RedirectsUsers;
+use Illuminate\Validation\Rules\Password as PasswordRules;
 
 class InvitationController extends Controller
 {
@@ -68,7 +69,7 @@ class InvitationController extends Controller
             'first_name' => 'required|max:255',
             'email' => 'required|email|max:255|unique:users',
             'email_security' => 'required',
-            'password' => 'required|min:6|confirmed',
+            'password' => ['required', 'confirmed', PasswordRules::defaults()],
             'policy' => 'required',
         ]);
     }

--- a/app/Http/Controllers/Auth/PasswordChangeController.php
+++ b/app/Http/Controllers/Auth/PasswordChangeController.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Str;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Auth\Events\PasswordReset;
 use App\Http\Requests\PasswordChangeRequest;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Foundation\Auth\RedirectsUsers;
@@ -45,7 +46,7 @@ class PasswordChangeController extends Controller
 
         $response = $this->validateAndPasswordChange($credentials);
 
-        return $response == 'passwords.changed'
+        return $response === 'passwords.changed'
             ? $this->sendChangedResponse($response)
             : $this->sendChangedFailedResponse($response);
     }
@@ -127,6 +128,8 @@ class PasswordChangeController extends Controller
         $user->setRememberToken(Str::random(60));
 
         $user->save();
+
+        event(new PasswordReset($user));
 
         Auth::guard()->login($user);
     }

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Foundation\Auth\RegistersUsers;
+use Illuminate\Validation\Rules\Password as PasswordRules;
 
 class RegisterController extends Controller
 {
@@ -75,7 +76,7 @@ class RegisterController extends Controller
             'last_name' => 'required|max:255',
             'first_name' => 'required|max:255',
             'email' => 'required|email|max:255|unique:users',
-            'password' => 'required|min:6|confirmed',
+            'password' => ['required', 'confirmed', PasswordRules::defaults()],
             'policy' => 'required',
         ]);
     }

--- a/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\ResetsPasswords;
+use Illuminate\Validation\Rules\Password as PasswordRules;
 
 class ResetPasswordController extends Controller
 {
@@ -24,4 +25,18 @@ class ResetPasswordController extends Controller
      * @var string
      */
     protected $redirectTo = '/dashboard';
+
+    /**
+     * Get the password reset validation rules.
+     *
+     * @return array
+     */
+    protected function rules()
+    {
+        return [
+            'token' => 'required',
+            'email' => 'required|email',
+            'password' => ['required', 'confirmed', PasswordRules::defaults()],
+        ];
+    }
 }

--- a/app/Http/Requests/PasswordChangeRequest.php
+++ b/app/Http/Requests/PasswordChangeRequest.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Requests;
 
+use Illuminate\Validation\Rules\Password as PasswordRules;
+
 class PasswordChangeRequest extends AuthorizedRequest
 {
     /**
@@ -13,7 +15,7 @@ class PasswordChangeRequest extends AuthorizedRequest
     {
         return [
             'password_current' => 'required',
-            'password' => 'required|confirmed|min:6',
+            'password' => ['required', 'confirmed', PasswordRules::defaults()],
         ];
     }
 }

--- a/app/Listeners/LogoutUserDevices.php
+++ b/app/Listeners/LogoutUserDevices.php
@@ -52,9 +52,13 @@ class LogoutUserDevices
      *
      * @return SessionGuard
      */
-    protected function guard()
+    protected function guard(): SessionGuard
     {
-        return Auth::guard('web');
+        $guard = Auth::guard('web');
+        if (! $guard instanceof SessionGuard) {
+            throw new \LogicException('guard is not a SessionGuard kind');
+        }
+        return $guard;
     }
 
     /**
@@ -63,11 +67,12 @@ class LogoutUserDevices
      * @param SessionGuard $guard
      * @return \Illuminate\Auth\Recaller|null
      */
-    protected function recaller($guard)
+    protected function recaller($guard): ?Recaller
     {
         if ($recaller = request()->cookies->get($guard->getRecallerName())) {
             return new Recaller($recaller);
         }
+        return null;
     }
 
     /**

--- a/app/Listeners/LogoutUserDevices.php
+++ b/app/Listeners/LogoutUserDevices.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Models\User\User;
+use Illuminate\Auth\Events\PasswordReset;
+use Illuminate\Auth\Recaller;
+use Illuminate\Auth\SessionGuard;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class LogoutUserDevices
+{
+    /**
+     * Handle the event.
+     *
+     * @param  \Illuminate\Auth\Events\PasswordReset  $event
+     * @return void
+     */
+    public function handle(PasswordReset $event)
+    {
+        if ($event->user instanceof User) {
+            $this->logoutOtherDevices($event->user);
+
+            $this->deleteOtherSessionRecords($event->user);
+        }
+    }
+
+    /**
+     * Invalidate other sessions for the current user.
+     *
+     * The application must be using the AuthenticateSession middleware.
+     *
+     * @param User $user
+     * @throws \Illuminate\Auth\AuthenticationException
+     */
+    public function logoutOtherDevices($user)
+    {
+        $guard = $this->guard();
+        $cookieJar = $guard->getCookieJar();
+
+        if ($this->recaller($guard) ||
+            $cookieJar->hasQueued($guard->getRecallerName())) {
+            $cookieJar->queue($cookieJar->forever($guard->getRecallerName(),
+                $user->getAuthIdentifier().'|'.$user->getRememberToken().'|'.$user->getAuthPassword()
+            ));
+        }
+   }
+
+    /**
+     * Get the guard.
+     *
+     * @return SessionGuard
+     */
+    protected function guard()
+    {
+        return Auth::guard('web');
+    }
+
+    /**
+     * Get the decrypted recaller cookie for the request.
+     *
+     * @param SessionGuard $guard
+     * @return \Illuminate\Auth\Recaller|null
+     */
+    protected function recaller($guard)
+    {
+        if ($recaller = request()->cookies->get($guard->getRecallerName())) {
+            return new Recaller($recaller);
+        }
+    }
+
+    /**
+     * Delete the other browser session records from storage.
+     *
+     * @param User $user
+     * @return void
+     */
+    protected function deleteOtherSessionRecords($user)
+    {
+        if (config('session.driver') !== 'database') {
+            return;
+        }
+
+        DB::connection(config('session.connection'))->table(config('session.table', 'sessions'))
+            ->where('user_id', $user->id)
+            ->where('id', '!=', request()->session()->getId())
+            ->delete();
+    }
+}

--- a/app/Listeners/LogoutUserDevices.php
+++ b/app/Listeners/LogoutUserDevices.php
@@ -3,11 +3,11 @@
 namespace App\Listeners;
 
 use App\Models\User\User;
-use Illuminate\Auth\Events\PasswordReset;
 use Illuminate\Auth\Recaller;
 use Illuminate\Auth\SessionGuard;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Auth\Events\PasswordReset;
 
 class LogoutUserDevices
 {
@@ -45,7 +45,7 @@ class LogoutUserDevices
                 $user->getAuthIdentifier().'|'.$user->getRememberToken().'|'.$user->getAuthPassword()
             ));
         }
-   }
+    }
 
     /**
      * Get the guard.

--- a/app/Listeners/LogoutUserDevices.php
+++ b/app/Listeners/LogoutUserDevices.php
@@ -58,6 +58,7 @@ class LogoutUserDevices
         if (! $guard instanceof SessionGuard) {
             throw new \LogicException('guard is not a SessionGuard kind');
         }
+
         return $guard;
     }
 
@@ -72,6 +73,7 @@ class LogoutUserDevices
         if ($recaller = request()->cookies->get($guard->getRecallerName())) {
             return new Recaller($recaller);
         }
+
         return null;
     }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Validation\Rules\Password;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Auth\Notifications\VerifyEmail;
 use Werk365\EtagConditionals\EtagConditionals;
@@ -54,6 +55,10 @@ class AppServiceProvider extends ServiceProvider
         View::composer(
             'partials.check', 'App\Http\ViewComposers\InstanceViewComposer'
         );
+
+        Password::defaults(function () {
+            return Password::min(6);
+        });
 
         if (config('database.use_utf8mb4')
             && DBHelper::connection()->getDriverName() == 'mysql'

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -16,7 +16,7 @@ class EventServiceProvider extends ServiceProvider
             \Illuminate\Auth\Listeners\SendEmailVerificationNotification::class,
         ],
         \Illuminate\Auth\Events\PasswordReset::class => [
-            \App\Listeners\LogoutUserDevices::class
+            \App\Listeners\LogoutUserDevices::class,
         ],
     ];
 

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace App\Providers;
 
-use Illuminate\Support\Facades\Event;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 
 class EventServiceProvider extends ServiceProvider
@@ -15,6 +14,9 @@ class EventServiceProvider extends ServiceProvider
     protected $listen = [
         \Illuminate\Auth\Events\Registered::class => [
             \Illuminate\Auth\Listeners\SendEmailVerificationNotification::class,
+        ],
+        \Illuminate\Auth\Events\PasswordReset::class => [
+            \App\Listeners\LogoutUserDevices::class
         ],
     ];
 


### PR DESCRIPTION
This fix #5270
However, session removal is only working when session is handled by database, i.e. `SESSION_DRIVER=database`