### PR TITLE
feat: add path style URL support for S3 buckets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -127,6 +127,10 @@ AWS_REGION=us-east-1
 AWS_BUCKET=
 AWS_SERVER=
 
+# Set to true if you use S3 and need path style URL support for bucket access
+# The default is to use virtual-hosted style URLs which may not work everywhere
+S3_PATH_STYLE=
+
 # Allow Two Factor Authentication feature on your instance
 MFA_ENABLED=true
 

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -67,6 +67,7 @@ return [
                 'expire' => env('S3_CACHE_EXPIRE', 600),
                 'prefix' => env('S3_CACHE_PREFIX', 's3'),
             ],
+            'use_path_style_endpoint' => env('S3_PATH_STYLE', false),
         ],
 
     ],


### PR DESCRIPTION
Hello,

I have added path style URL support to Monica by adding a single line relying on a new `S3_PATH_STYLE` environment variable, kept to false by default as to not have any impact whatsoever if left unconfigured of course. This was already supported by the underlying S3 library so the edit was quite trivial.

This is necessary for a lot of people depending on e.g. self-hosted MinIO setups, where virtual-hosted style URLs may not be enabled or supported. This was my case so after a bit of research, I found and added this option. I believe it can help others and won't impact anyone who doesn't explicitly set this to true so… may as well PR it!