### PR TITLE
style: rename pt-BR to Brazilian Portuguese

### DIFF
--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -91,7 +91,7 @@ return [
     'locale_ja' => 'Japanese',
     'locale_nl' => 'Dutch',
     'locale_pt' => 'Portuguese',
-    'locale_pt-BR' => 'Portuguese, Brazil',
+    'locale_pt-BR' => 'Brazilian Portuguese',
     'locale_ru' => 'Russian',
     'locale_sv' => 'Swedish',
     'locale_vi' => 'Vietnamese',


### PR DESCRIPTION
It's the definition used here: https://en.wikipedia.org/wiki/Brazilian_Portuguese