### PR TITLE
fix: Contact name population on delete confirmation

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -51,3 +51,4 @@ Martijn van der Ven @Zegnat <martijn@vanderven.se>
 Matthew Fitzgerald @mfitzgerald2 <matt@mfitz.net>
 Simon Van Accoleyen @SimonVanacco <simon@vanacco.fr>
 Michael Bianco <mike@mikebian.co>
+Ben Fesili @benfes

--- a/resources/views/people/profile.blade.php
+++ b/resources/views/people/profile.blade.php
@@ -74,7 +74,7 @@
               <form method="POST" action="{{ route('people.destroy', $contact) }}">
                 @method('DELETE')
                 @csrf
-                <confirm id="link-delete-contact" message="{{ trans('people.people_delete_confirmation') }}">
+                <confirm id="link-delete-contact" message="{{ trans('people.people_delete_confirmation', ['name' => $contact->name]) }}">
                   {{ trans('people.people_delete_message') }}
                 </confirm>
               </form>


### PR DESCRIPTION
Fix bug where the contacts name is not populating the delete confirmation

Resolves: https://github.com/monicahq/monica/issues/5412