### PR TITLE
docs: fix case-sensitive readme-link in contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 First off, thank you for considering contributing to Monica. We need people like
 you to make Monica the best tool it can be.
 
-Before you do anything else, please read the [README.md](readme.md) of this project first.
+Before you do anything else, please read the [README.md](README.md) of this project first.
 This is where we highlight the vision and the strategy. Please make sure you
 accept this vision before contributing to this project.
 


### PR DESCRIPTION
### Checklist

#### Before submitting the PR
- [x] Read the [CONTRIBUTING document](https://github.com/monicahq/monica/blob/master/CONTRIBUTING.md) before submitting your PR. (There I found it 😀)


### General checks
- [x] Make sure that the change you propose is the smallest possible.
- [x] The name of the PR should follow the [conventional commits guideline](https://github.com/monicahq/monica/blob/master/docs/contribute/readme.md#conventional-commits) that the project follows.

The README.md link seems to be case sensitiv at github, so i fixed it.

Before:
<img width="1413" alt="readme - broken link" src="https://user-images.githubusercontent.com/47363631/131373668-f40b782c-1682-4f22-9fef-1cb86aeb9f4f.png">