### PR TITLE
feat: add total of participants in activity

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -52,3 +52,4 @@ Matthew Fitzgerald @mfitzgerald2 <matt@mfitz.net>
 Simon Van Accoleyen @SimonVanacco <simon@vanacco.fr>
 Michael Bianco <mike@mikebian.co>
 Ben Fesili @benfes
+Markus Dick @markusdick

--- a/resources/js/components/people/activity/ActivityList.vue
+++ b/resources/js/components/people/activity/ActivityList.vue
@@ -66,7 +66,7 @@
                 <li v-if="activity.attendees.total > 1" class="di">
                   <ul class="di list" :class="[ dirltr ? 'mr3' : 'ml3' ]">
                     <li class="di">
-                      {{ $t('people.activities_list_participants') }}
+                      {{ $t('people.activities_list_participants', { total: activity.attendees.total - 1}) }}
                     </li>
                     <li v-for="attendee in activity.attendees.contacts.filter(c => c.id !== contactId)" :key="attendee.id" class="di mr2">
                       <a :href="'people/' + attendee.hash_id">{{ attendee.complete_name }}</a>

--- a/resources/lang/en/people.php
+++ b/resources/lang/en/people.php
@@ -285,7 +285,7 @@ return [
     'activities_profile_year_summary_activity_types' => 'Here is a breakdown of the type of activities you’ve done together in :year',
     'activities_profile_year_summary' => 'Here is what you two have done in :year',
     'activities_profile_number_occurences' => ':value activity|:value activities',
-    'activities_list_participants' => 'Participants:',
+    'activities_list_participants' => 'Participants ({total}):',
     'activities_list_emotions' => 'Emotions felt:',
     'activities_list_date' => 'Happened on',
     'activities_list_category' => 'Category:',


### PR DESCRIPTION
Feat / Fix: #4204 

Adds total of participants in activities. See below for the screenshot.

I reduced the total by one, because in the array also the contact itself is indicated, but not in the displayed list.

### Checklist
#### Before submitting the PR
- [x] Read the [CONTRIBUTING document](https://github.com/monicahq/monica/blob/master/CONTRIBUTING.md) before submitting your PR.
- [x] If the PR is related to an issue or fix one, don't forget to indicate it.

### General checks
- [x] Make sure that the change you propose is the smallest possible.
- [x] The name of the PR should follow the [conventional commits guideline](https://github.com/monicahq/monica/blob/master/docs/contribute/readme.md#conventional-commits) that the project follows.

### Front-end changes
- [x] If you change the UI, make sure to ask repositories administrators first about your changes by pinging djaiss or asbiin in this PR. (pinged in the issue)
- [x] Screenshots are included if the PR changes the UI.

#### Other tasks
- [x] [CONTRIBUTORS](https://github.com/monicahq/monica/blob/master/CONTRIBUTORS) entry added, if necessary.

<img width="822" alt="show_total_participants_of_activity" src="https://user-images.githubusercontent.com/47363631/131407672-79934f88-8123-4a9c-84b6-ba50c04e2958.png">

