### PR TITLE
feat: add next reminder date to stayintouch

### DIFF
--- a/app/Http/Controllers/ContactsController.php
+++ b/app/Http/Controllers/ContactsController.php
@@ -640,7 +640,7 @@ class ContactsController extends Controller
 
         $contact->setStayInTouchTriggerDate($frequency);
 
-        return ["frequency" => $frequency, "trigger_date" => $contact->stay_in_touch_trigger_date];
+        return ['frequency' => $frequency, 'trigger_date' => $contact->stay_in_touch_trigger_date];
     }
 
     /**

--- a/app/Http/Controllers/ContactsController.php
+++ b/app/Http/Controllers/ContactsController.php
@@ -640,7 +640,7 @@ class ContactsController extends Controller
 
         $contact->setStayInTouchTriggerDate($frequency);
 
-        return $frequency;
+        return ["frequency" => $frequency, "trigger_date" => $contact->stay_in_touch_trigger_date];
     }
 
     /**

--- a/app/Http/Controllers/ContactsController.php
+++ b/app/Http/Controllers/ContactsController.php
@@ -615,7 +615,7 @@ class ContactsController extends Controller
      *
      * @param  Request $request
      * @param  Contact $contact
-     * @return int|RedirectResponse
+     * @return array
      */
     public function stayInTouch(Request $request, Contact $contact)
     {

--- a/resources/js/components/people/StayInTouch.vue
+++ b/resources/js/components/people/StayInTouch.vue
@@ -10,6 +10,10 @@
     display: block;
     color:#f57f6c;
   }
+
+  .dashed {
+    border-bottom-style: dashed;
+  }
 </style>
 
 <template>
@@ -23,8 +27,8 @@
 
     <!-- Contact has a frequency set -->
     <div v-else class="di">
-      <span>
-        {{ $tc('people.stay_in_touch_frequency', frequency, { count: frequency, date: formatDate(next_trigger_date) }) }}
+      <span class="bb dashed dib pointer nowrap-link" v-tooltip.bottom="$t('people.stay_in_touch_next_date', { date: formatDate(next_trigger_date)} )">
+        {{ $tc('people.stay_in_touch_frequency', frequency, { count: frequency }) }}
       </span>
       <a class="pointer" href="" @click.prevent="showUpdate">
         {{ $t('app.edit') }}
@@ -243,7 +247,7 @@ export default {
       moment.locale(this._i18n.locale);
       moment.tz.setDefault('UTC');
       var date = moment.tz(moment(dateAsString), this.$root.timezone);
-      return date.format('ll');
+      return date.format('LL');
     },
 
     showUpdate() {

--- a/resources/js/components/people/StayInTouch.vue
+++ b/resources/js/components/people/StayInTouch.vue
@@ -27,7 +27,7 @@
 
     <!-- Contact has a frequency set -->
     <div v-else class="di">
-      <span v-tooltip.bottom="$t('people.stay_in_touch_next_date', { date: formatDate(next_trigger_date)} )" class="bb dashed dib pointer nowrap-link">
+      <span v-tooltip.bottom="$t('people.stay_in_touch_next_date', { date: formatDate(next_trigger_date) })" class="bb dashed dib pointer nowrap-link">
         {{ $tc('people.stay_in_touch_frequency', frequency, { count: frequency }) }}
       </span>
       <a class="pointer" href="" @click.prevent="showUpdate">

--- a/resources/js/components/people/StayInTouch.vue
+++ b/resources/js/components/people/StayInTouch.vue
@@ -27,7 +27,7 @@
 
     <!-- Contact has a frequency set -->
     <div v-else class="di">
-      <span class="bb dashed dib pointer nowrap-link" v-tooltip.bottom="$t('people.stay_in_touch_next_date', { date: formatDate(next_trigger_date)} )">
+      <span v-tooltip.bottom="$t('people.stay_in_touch_next_date', { date: formatDate(next_trigger_date)} )" class="bb dashed dib pointer nowrap-link">
         {{ $tc('people.stay_in_touch_frequency', frequency, { count: frequency }) }}
       </span>
       <a class="pointer" href="" @click.prevent="showUpdate">

--- a/resources/js/components/people/StayInTouch.vue
+++ b/resources/js/components/people/StayInTouch.vue
@@ -24,7 +24,7 @@
     <!-- Contact has a frequency set -->
     <div v-else class="di">
       <span>
-        {{ $tc('people.stay_in_touch_frequency', frequency, { count: frequency }) }}
+        {{ $tc('people.stay_in_touch_frequency', frequency, { count: frequency, date: formatDate(next_trigger_date) }) }}
       </span>
       <a class="pointer" href="" @click.prevent="showUpdate">
         {{ $t('app.edit') }}
@@ -227,6 +227,7 @@ export default {
         this.frequency = 0;
       } else {
         this.frequency = parseInt(this.contact.stay_in_touch_frequency);
+        this.next_trigger_date = this.contact.stay_in_touch_trigger_date;
       }
       this.isActive = (this.frequency > 0);
 
@@ -235,6 +236,14 @@ export default {
       // the counter
       this.stateInput = this.isActive;
       this.frequencyInput = this.frequency;
+    },
+    
+    formatDate(dateAsString) {
+      const moment = require('moment-timezone');
+      moment.locale(this._i18n.locale);
+      moment.tz.setDefault('UTC');
+      var date = moment.tz(moment(dateAsString), this.$root.timezone);
+      return date.format('ll');
     },
 
     showUpdate() {
@@ -266,6 +275,7 @@ export default {
           this.$refs.updateModal.close();
           this.isActive = this.stateInput;
           this.frequency = this.frequencyInput;
+          this.next_trigger_date = response.data.trigger_date;
 
           this.$notify({
             group: 'main',

--- a/resources/lang/en/people.php
+++ b/resources/lang/en/people.php
@@ -89,7 +89,7 @@ return [
 
     // Stay in touch
     'stay_in_touch' => 'Stay in touch',
-    'stay_in_touch_frequency' => 'Stay in touch every day|Stay in touch every {count} days',
+    'stay_in_touch_frequency' => 'Stay in touch every day|Stay in touch every {count} days (next due {date})',
     'stay_in_touch_invalid' => 'The frequency must be a number greater than 0.',
     'stay_in_touch_premium' => 'You need to upgrade your account to make use of this feature',
     'stay_in_touch_modal_title' => 'Stay in touch',

--- a/resources/lang/en/people.php
+++ b/resources/lang/en/people.php
@@ -89,7 +89,8 @@ return [
 
     // Stay in touch
     'stay_in_touch' => 'Stay in touch',
-    'stay_in_touch_frequency' => 'Stay in touch every day|Stay in touch every {count} days (next due {date})',
+    'stay_in_touch_frequency' => 'Stay in touch every day|Stay in touch every {count} days',
+    'stay_in_touch_next_date' => 'Next due: {date}',
     'stay_in_touch_invalid' => 'The frequency must be a number greater than 0.',
     'stay_in_touch_premium' => 'You need to upgrade your account to make use of this feature',
     'stay_in_touch_modal_title' => 'Stay in touch',


### PR DESCRIPTION
Fix #5158 

The screenshot of this feature:
<img width="1394" alt="next_reminder_stay_in_touch" src="https://user-images.githubusercontent.com/47363631/132521496-88390a5b-ca0a-4077-a207-3233775bb1fa.png">

I had to change the ContactController stayInTouch function because I needed the new calculated next reminder date when I update the frequency of the reminder.
Otherwise I'ld have needed to make a second request to the API.

### Checklist

#### Before submitting the PR
- [x] Read the [CONTRIBUTING document](https://github.com/monicahq/monica/blob/master/CONTRIBUTING.md) before submitting your PR.
- [x] If the PR is related to an issue or fix one, don't forget to indicate it.

### General checks
- [x] Make sure that the change you propose is the smallest possible.
- [x] The name of the PR should follow the [conventional commits guideline](https://github.com/monicahq/monica/blob/master/docs/contribute/readme.md#conventional-commits) that the project follows.

### Front-end changes
- [x] If you change the UI, make sure to ask repositories administrators first about your changes by pinging djaiss or asbiin in this PR. (pinged in issue)
- [x] Screenshots are included if the PR changes the UI.

