### PR TITLE
style: Added theme-color meta tag

### DIFF
--- a/resources/views/layouts/skeleton.blade.php
+++ b/resources/views/layouts/skeleton.blade.php
@@ -2,10 +2,16 @@
 <html lang="{{ \App::getLocale() }}" dir="{{ htmldir() }}">
   <head>
     <base href="{{ url('/') }}/" />
+
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="apple-mobile-web-app-title" content="Monica">
+    <meta name="application-name" content="Monica">
+    <meta name="theme-color" content="#325776">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
     <title>@yield('title', trans('app.application_title'))</title>
+
     <link rel="manifest" href="manifest.webmanifest">
 
     <link rel="stylesheet" href="{{ asset(mix('css/app-'.htmldir().'.css')) }}">
@@ -16,13 +22,11 @@
 
     <link rel="shortcut icon" href="img/favicon.png">
 
-    <meta name="apple-mobile-web-app-title" content="Monica">
     <link rel="apple-touch-icon" href="img/icons/touch-icon-iphone.png">
     <link rel="apple-touch-icon" sizes="152x152" href="img/icons/touch-icon-ipad.png">
     <link rel="apple-touch-icon" sizes="180x180" href="img/icons/touch-icon-iphone-retina.png">
     <link rel="apple-touch-icon" sizes="167x167" href="img/icons/touch-icon-ipad-retina.png">
 
-    <meta name="application-name" content="Monica">
     <link rel="shortcut icon" sizes="196x196" href="img/icons/favicon-196.png">
 
     <script>


### PR DESCRIPTION
This makes changes the status bar and over scroll areas to Monica’s dark blue on recent iOS and Android devices.  There’s a good [write-up of it here](https://stuffandnonsense.co.uk/blog/time-to-update-your-theme-color-meta-tag-for-safari).

I’ve also grouped the `meta` tags together, to be more consistent with the other tags in the `head` area which were also grouped by type.