### PR TITLE
fix: fix duplicate reminders on dashboard

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -53,3 +53,4 @@ Simon Van Accoleyen @SimonVanacco <simon@vanacco.fr>
 Michael Bianco <mike@mikebian.co>
 Ben Fesili @benfes
 Markus Dick @markusdick
+Jacek Sawoszczuk @jsawo

--- a/app/Helpers/AccountHelper.php
+++ b/app/Helpers/AccountHelper.php
@@ -131,6 +131,7 @@ class AccountHelper
         return $account->reminderOutboxes()
             ->with(['reminder', 'reminder.contact'])
             ->whereBetween('planned_date', [$startOfMonth, $endOfMonth])
+            ->where('user_id', auth()->user()->id)
             ->where('nature', 'reminder')
             ->orderBy('planned_date', 'asc')
             ->get();

--- a/tests/Unit/Helpers/AccountHelperTest.php
+++ b/tests/Unit/Helpers/AccountHelperTest.php
@@ -147,6 +147,9 @@ class AccountHelperTest extends TestCase
     public function get_reminders_for_month_returns_no_reminders(): void
     {
         $account = factory(Account::class)->create();
+        $user = factory(User::class)->create([
+            'account_id' => $account->id,
+        ]);
 
         Carbon::setTestNow(Carbon::create(2017, 1, 1));
         factory(Reminder::class, 3)->create([
@@ -154,7 +157,7 @@ class AccountHelperTest extends TestCase
         ]);
 
         // check if there are reminders for the month of March
-        $this->assertCount(0, AccountHelper::getUpcomingRemindersForMonth($account, 3));
+        $this->actingAs($user)->assertCount(0, AccountHelper::getUpcomingRemindersForMonth($account, 3));
     }
 
     /** @test */
@@ -177,7 +180,7 @@ class AccountHelperTest extends TestCase
             $reminder->schedule($user);
         }
 
-        $this->assertCount(3, AccountHelper::getUpcomingRemindersForMonth($account, 2));
+        $this->actingAs($user)->assertCount(3, AccountHelper::getUpcomingRemindersForMonth($account, 2));
     }
 
     /** @test */

--- a/tests/Unit/Helpers/AccountHelperTest.php
+++ b/tests/Unit/Helpers/AccountHelperTest.php
@@ -184,6 +184,33 @@ class AccountHelperTest extends TestCase
     }
 
     /** @test */
+    public function get_reminders_for_month_returns_reminders_for_current_user_only(): void
+    {
+        $account = factory(Account::class)->create();
+        $user1 = factory(User::class)->create([
+            'account_id' => $account->id,
+        ]);
+        $user2 = factory(User::class)->create([
+            'account_id' => $account->id,
+        ]);
+
+        Carbon::setTestNow(Carbon::create(2017, 1, 1));
+
+        // add 3 reminders for the month of March
+        for ($i = 0; $i < 3; $i++) {
+            $reminder = factory(Reminder::class)->create([
+                'account_id' => $account->id,
+                'initial_date' => '2017-03-03 00:00:00',
+            ]);
+
+            $reminder->schedule($user1);
+            $reminder->schedule($user2);
+        }
+
+        $this->actingAs($user1)->assertCount(3, AccountHelper::getUpcomingRemindersForMonth($account, 2));
+    }
+
+    /** @test */
     public function it_retrieves_yearly_activities_statistics(): void
     {
         $account = factory(Account::class)->create();


### PR DESCRIPTION
This PR addresses the issue with multiple reminders being shown on dashboard that was reported in #5381.
The problem occured when more than one user was assigned to a single account. The dashboard was displaying all reminders assigned to an account, which means one for every user. 

The proposed change restricts the reminders shown to a currently logged in user.

this should close #5381 