### PR TITLE
fix: fix quick contact creation

### DIFF
--- a/resources/views/people/create.blade.php
+++ b/resources/views/people/create.blade.php
@@ -58,7 +58,6 @@
             :required="false"
             :title="'{{ trans('people.people_add_lastname') }}'"
             value="{{ $lastName }}">
-
           </form-input>
         </div>
 


### PR DESCRIPTION
This fix addresses quick contact creation functionality - adding new contact from search box.
If the contact name contained an apostrophe the new contact form would fail and display blank page.

The root cause was the way the arguments were passed from php request to vue components.

The simplest solution is to drop prop binding which is not needed anyway as we're providing the values from php.

this should close #5475 