### PR TITLE
fix: nickname label wrong on contact edit

### DIFF
--- a/resources/views/people/edit.blade.php
+++ b/resources/views/people/edit.blade.php
@@ -92,7 +92,7 @@
                   :input-type="'text'"
                   :id="'nickname'"
                   :required="false"
-                  :title="'{{ trans('people.information_edit_description') }}'">
+                  :title="'{{ trans('people.people_add_nickname') }}'">
                 </form-input>
               </div>
             </div>


### PR DESCRIPTION
When having the "name order" layout setting set to sth which does not start with firstname field, the label of the `nickname` field was wrong.

Fixes #5450 