### PR TITLE
feat: Debian update script (closes #5567)

### DIFF
--- a/docs/installation/update.md
+++ b/docs/installation/update.md
@@ -39,7 +39,7 @@ or if you have installed Monica on your own server, you need to follow the steps
    php artisan monica:update --force
    ```
 
-The `monica:update` command will run migrations scripts for database, and flush all cache for config, route, and view, as an optimization process. It's easier than run every need command independently.
+The `monica:update` command runs migration scripts for the database, and flushes all caches for config, route, and view as an optimization process. It’s easier than running every required command individually.
 
 
 Note: if you have just change some setting in your `.env` file, as the configuration of the application is cached, any update on the `.env` file will not be detected after that. You may have to run `php artisan config:cache` manually after every update of `.env` file.

--- a/scripts/update/debian.sh
+++ b/scripts/update/debian.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# And now starting the upgrade itself...
+
+# 1. Open Monica's directory
+
+     cd /var/www/monica  ; \
+
+# 2. Checkout the current version
+
+     git fetch upstream  ; \
+
+# ...and make sure we're working on master
+
+     git checkout master  ; \
+
+# 3. Delete Composer packages
+
+     rm -rf vendor  ; \
+
+# Note: This step might *not* be strictly necessary, but it avoids fatal
+#       fatal errors when attempting to update Monica on a Debian system.
+#       More information: https://github.com/monicahq/monica/issues/5308
+
+# 4. Now (re)install all required Composer packages
+
+     composer install --no-dev  ; \
+
+# 5. Install required yarn packages
+
+     yarn install  ; \
+
+# 6. Generate assets (CSS, JS, others) using yarn
+
+     yarn run production  ; \
+
+# 7. Update Monica itself.  Per the README, this "will run migration
+#    scripts for database, and flush all cache for config, route, and 
+#    view, as an optimization process. It's easier than running every 
+#    required command individually".
+
+     php artisan monica:update --force  ; \
+
+# 8. And finally, set correct ownership and permissions for Monica.
+#    This is another step that may not be necessary, but it should avoid
+#    any "permission denied" or HTTP 500 errors being created.
+
+     chown -R www-data:www-data /var/www/monica  ; \
+
+     find  /var/www/monica -type f -exec chmod 664 {}  ; \
+
+     find /var/www/monica -type d -exec chmod 775 {}
+
+# And that's it!

--- a/scripts/update/debian.sh
+++ b/scripts/update/debian.sh
@@ -77,8 +77,8 @@
 
      chown -R www-data:www-data /var/www/monica  ; \
 
-     find  /var/www/monica -type f -exec chmod 664 {}  ; \
+     find /var/www/monica -type f -exec chmod 664 {} \;
 
-     find /var/www/monica -type d -exec chmod 775 {}
+     find /var/www/monica -type d -exec chmod 775 {} \;
 
 # And that's it!

--- a/scripts/update/debian.sh
+++ b/scripts/update/debian.sh
@@ -1,47 +1,77 @@
 #!/bin/bash
+#
+# ABOUT THIS SCRIPT
+# -----------------
+# Last updated: 2021-10-26
+# Last tested:  Monica v3.3.1
+#
+# USE AT YOUR OWN RISK!  Make sure you have a good, working backup of
+# your database and other files before using this script.
+#
+# WHAT THIS SCRIPT DOES
+# ---------------------
+# This script has been written to run the various steps required to
+# upgrade Monica to the specified version.  You can check which is the
+# current version here: https://github.com/monicahq/monica/releases
+#
+# HOW TO USE THIS SCRIPT
+# ----------------------
+# To run this command, you run the shell script and specify the version
+# you want to update to, like so:
+#
+#       $ ./debian.sh 3.3.1
+#
+# Replacing "3.3.1" with the version you want.  The script will then run
+# through the required steps to update you to 3.3.1.
 
-# And now starting the upgrade itself...
-
+# THE SCRIPT ITSELF
+# -----------------
 # 1. Open Monica's directory
 
-     cd /var/www/monica  ; \
+     cd /var/www/monica ; \
 
 # 2. Checkout the current version
 
-     git fetch upstream  ; \
+     git fetch ; \
 
-# ...and make sure we're working on master
-
-     git checkout master  ; \
+     git checkout tags/v$1
 
 # 3. Delete Composer packages
 
      rm -rf vendor  ; \
 
 # Note: This step might *not* be strictly necessary, but it avoids fatal
-#       fatal errors when attempting to update Monica on a Debian system.
+#       errors when attempting to update Monica on a Debian system.
 #       More information: https://github.com/monicahq/monica/issues/5308
 
 # 4. Now (re)install all required Composer packages
 
      composer install --no-dev  ; \
 
-# 5. Install required yarn packages
+# 5. Delete all the node modules installed by yarn
+
+     rm -rf node_modules
+
+# Note: This step might *not* be strictly necessary, but it avoids yarn
+#       throwing 126 exit errors that I can't otherwise fix.
+
+
+# 6. Now (re)install required yarn packages
 
      yarn install  ; \
 
-# 6. Generate assets (CSS, JS, others) using yarn
+# 7. Generate assets (CSS, JS, others) using yarn
 
      yarn run production  ; \
 
-# 7. Update Monica itself.  Per the README, this "runs migration scripts 
+# 8. Update Monica itself.  Per the README, this "runs migration scripts
 #    for the database, and flushes all caches for config, route, and
 #    view as an optimization process. It’s easier than running every
 #    required command individually".
 
      php artisan monica:update --force  ; \
 
-# 8. And finally, set correct ownership and permissions for Monica.
+# 9. And finally, set correct ownership and permissions for Monica.
 #    This is another step that may not be necessary, but it should avoid
 #    any "permission denied" or HTTP 500 errors being created.
 

--- a/scripts/update/debian.sh
+++ b/scripts/update/debian.sh
@@ -34,9 +34,9 @@
 
      yarn run production  ; \
 
-# 7. Update Monica itself.  Per the README, this "will run migration
-#    scripts for database, and flush all cache for config, route, and 
-#    view, as an optimization process. It's easier than running every 
+# 7. Update Monica itself.  Per the README, this "runs migration scripts 
+#    for the database, and flushes all caches for config, route, and
+#    view as an optimization process. It’s easier than running every
 #    required command individually".
 
      php artisan monica:update --force  ; \


### PR DESCRIPTION
This is very much a “use at your own risk”, but it’s a tidied-up version of what I use to update Monica on Debian.  It’s worked successfully for me for several versions now.

It’s got several mitigations in place to address the wonkiness and brittleness I discussed #5510.  Specifically, it deletes all the composer and node modules before reinstalling them.  I’ve found that doing this is often the only way to successfully update Monica – it breaks mid-update otherwise.