### PR TITLE
fix(docs): specify docker-compose.dev.yaml argument

### DIFF
--- a/docs/contribute/docker.md
+++ b/docs/contribute/docker.md
@@ -12,8 +12,8 @@ Edit `.env` to set `DB_HOST=mysql` (as `mysql` is the creative name of the MySQL
 Then run:
 
 ```sh
-docker-compose build
-docker-compose up
+docker-compose -f docker-compose.dev.yml build
+docker-compose -f docker-compose.dev.yml up
 ```
 
 ## Use Docker directly to run with your own database


### PR DESCRIPTION
By default, docker-compose expect a `docker-compose.yaml` or `docker-compose.yml` file. If missing, this lead to the following error : 

```
$ docker-compose build
ERROR: 
        Can't find a suitable configuration file in this directory or any
        parent. Are you in the right directory?

        Supported filenames: docker-compose.yml, docker-compose.yaml
```

First of all thanks so much for taking the time to open a pull request and help the project. It's because of people like you that we love working on this project.

Please read the list below. Feel free to delete this text after but we need you to read it so we make sure that the project is consistent and remains of quality.

### Checklist

#### Before submitting the PR
- [x] Read the [CONTRIBUTING document](https://github.com/monicahq/monica/blob/master/CONTRIBUTING.md) before submitting your PR.
- [x] If the PR is related to an issue or fix one, don't forget to indicate it.
- [x] Create your PR as draft if it is not final yet. Mark it as ready... when it’s ready. Otherwise the PR will be considered complete and rejected if it's not working.

### General checks
- [x] Make sure that the change you propose is the smallest possible.
- [x] The name of the PR should follow the [conventional commits guideline](https://github.com/monicahq/monica/blob/master/docs/contribute/readme.md#conventional-commits) that the project follows.
