### PR TITLE
feat: add `reminders/upcoming` API

### DIFF
--- a/app/Http/Resources/Reminder/ReminderOutbox.php
+++ b/app/Http/Resources/Reminder/ReminderOutbox.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Resources\Reminder;
+
+use App\Helpers\DateHelper;
+use Illuminate\Http\Resources\Json\JsonResource;
+use App\Http\Resources\Contact\ContactShort as ContactShortResource;
+
+/**
+ * @extends JsonResource<\App\Models\Contact\ReminderOutbox>
+ */
+class ReminderOutbox extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'reminder_id' => $this->reminder_id,
+            'object' => $this->nature,
+            'planned_date' => $this->planned_date,
+            'title' => $this->reminder->title,
+            'description' => $this->reminder->description,
+            'frequency_type' => $this->reminder->frequency_type,
+            'frequency_number' => $this->reminder->frequency_number,
+            'initial_date' => DateHelper::getTimestamp($this->reminder->initial_date),
+            'delible' => (bool) $this->reminder->delible,
+            'account' => [
+                'id' => $this->account_id,
+            ],
+            'contact' => new ContactShortResource($this->reminder->contact),
+            'created_at' => DateHelper::getTimestamp($this->created_at),
+            'updated_at' => DateHelper::getTimestamp($this->updated_at),
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -90,6 +90,7 @@ Route::group(['middleware' => ['auth:api']], function () {
         Route::get('/contacts/{contact}/activities', 'ApiActivitiesController@activities');
 
         // Reminders
+        Route::get('reminders/upcoming/{month}', 'ApiReminderController@upcoming');
         Route::apiResource('reminders', 'ApiReminderController')
             ->names(['index' => 'reminders']);
         Route::get('/contacts/{contact}/reminders', 'ApiReminderController@reminders');


### PR DESCRIPTION
Close #5778 

Docs close monicahq/marketing_site#642

### General checks
- [x] Make sure that the change you propose is the smallest possible.
- [x] The name of the PR should follow the [conventional commits guideline](https://github.com/monicahq/monica/blob/master/docs/contribute/readme.md#conventional-commits) that the project follows.

#### Backend/models changes
- [x] The API has been updated.
- [x] API's documentation has been added by submitting a pull request in the [marketing website repository](https://github.com/monicahq/marketing_site/pulls).
- [x] Tests have been added for the new code.

#### Usage
1. Get upcoming reminders for `current month`
```
GET /api/reminders/upcoming
```
or
```
GET /api/reminders/upcoming/0
```
2. Get upcoming reminders for `next month` (`month+1`)
```
GET /api/reminders/upcoming/1
```
3.  Get upcoming reminders for `next n month` (`month+n`)
```
GET /api/reminders/upcoming/n
```