### PR TITLE
fix: fix month reminder view

### DIFF
--- a/app/Helpers/AccountHelper.php
+++ b/app/Helpers/AccountHelper.php
@@ -138,7 +138,7 @@ class AccountHelper
             ->orderBy('planned_date', 'asc')
             ->get()
             ->filter(function ($reminderOutbox) {
-                return ! $reminderOutbox->reminder->contact->trashed();
+                return $reminderOutbox->reminder->contact !== null;
             });
     }
 

--- a/app/Helpers/AccountHelper.php
+++ b/app/Helpers/AccountHelper.php
@@ -136,7 +136,10 @@ class AccountHelper
                 'nature' => 'reminder',
             ])
             ->orderBy('planned_date', 'asc')
-            ->get();
+            ->get()
+            ->filter(function ($reminderOutbox) {
+                return ! $reminderOutbox->reminder->contact->trashed();
+            });
     }
 
     /**

--- a/app/Jobs/Reminder/NotifyUserAboutReminder.php
+++ b/app/Jobs/Reminder/NotifyUserAboutReminder.php
@@ -53,15 +53,14 @@ class NotifyUserAboutReminder implements ShouldQueue
     }
 
     /**
-     * Send the notification to this user
+     * Send the notification to this user.
      *
      * @param  MailNotification  $message
      * @return void
      */
     private function sendNotification(MailNotification $message): void
     {
-        if (! $this->reminderOutbox->contact->trashed())
-        {
+        if (! $this->reminderOutbox->contact->trashed()) {
             $account = $this->reminderOutbox->user->account;
             $hasLimitations = AccountHelper::hasLimitations($account);
             if (! $hasLimitations) {
@@ -71,7 +70,7 @@ class NotifyUserAboutReminder implements ShouldQueue
     }
 
     /**
-     * Schedule the next reminder for this user
+     * Schedule the next reminder for this user.
      *
      * @return void
      */

--- a/app/Jobs/Reminder/NotifyUserAboutReminder.php
+++ b/app/Jobs/Reminder/NotifyUserAboutReminder.php
@@ -60,7 +60,7 @@ class NotifyUserAboutReminder implements ShouldQueue
      */
     private function sendNotification(MailNotification $message): void
     {
-        if (! $this->reminderOutbox->contact->trashed()) {
+        if ($this->reminderOutbox->contact !== null) {
             $account = $this->reminderOutbox->user->account;
             $hasLimitations = AccountHelper::hasLimitations($account);
             if (! $hasLimitations) {

--- a/app/Jobs/Reminder/NotifyUserAboutReminder.php
+++ b/app/Jobs/Reminder/NotifyUserAboutReminder.php
@@ -60,7 +60,7 @@ class NotifyUserAboutReminder implements ShouldQueue
      */
     private function sendNotification(MailNotification $message): void
     {
-        if ($this->reminderOutbox->contact !== null) {
+        if ($this->reminderOutbox->reminder->contact !== null) {
             $account = $this->reminderOutbox->user->account;
             $hasLimitations = AccountHelper::hasLimitations($account);
             if (! $hasLimitations) {

--- a/app/Jobs/Reminder/NotifyUserAboutReminder.php
+++ b/app/Jobs/Reminder/NotifyUserAboutReminder.php
@@ -44,26 +44,48 @@ class NotifyUserAboutReminder implements ShouldQueue
         $message = $this->getMessage();
 
         if (! is_null($message)) {
-            // send the notification to this user
+            $this->sendNotification($message);
+            $this->scheduleNextReminder();
+        }
+
+        // delete the reminder outbox
+        $this->reminderOutbox->delete();
+    }
+
+    /**
+     * Send the notification to this user
+     *
+     * @param  MailNotification  $message
+     * @return void
+     */
+    private function sendNotification(MailNotification $message): void
+    {
+        if (! $this->reminderOutbox->contact->trashed())
+        {
             $account = $this->reminderOutbox->user->account;
             $hasLimitations = AccountHelper::hasLimitations($account);
             if (! $hasLimitations) {
                 Notification::send($this->reminderOutbox->user, $message);
             }
-
-            // schedule the next reminder for this user
-            /** @var \App\Models\Contact\Reminder */
-            $reminder = $this->reminderOutbox->reminder;
-            if ($reminder->frequency_type == 'one_time') {
-                $reminder->inactive = true;
-                $reminder->save();
-            } else {
-                $reminder->schedule($this->reminderOutbox->user);
-            }
         }
+    }
 
-        // delete the reminder outbox
-        $this->reminderOutbox->delete();
+    /**
+     * Schedule the next reminder for this user
+     *
+     * @return void
+     */
+    private function scheduleNextReminder(): void
+    {
+        /** @var \App\Models\Contact\Reminder */
+        $reminder = $this->reminderOutbox->reminder;
+
+        if ($reminder->frequency_type == 'one_time') {
+            $reminder->inactive = true;
+            $reminder->save();
+        } else {
+            $reminder->schedule($this->reminderOutbox->user);
+        }
     }
 
     /**

--- a/resources/views/dashboard/_monthReminder.blade.php
+++ b/resources/views/dashboard/_monthReminder.blade.php
@@ -3,7 +3,7 @@
     <ul class="mb4">
         @if(count($reminderOutboxes) > 0)
             @foreach($reminderOutboxes as $reminderOutbox)
-            @if (!is_object($reminderOutbox->reminder) || $reminderOutbox->reminder->contact === null)
+            @if (!is_object($reminderOutbox->reminder))
                 @continue;
             @endif
             <li class="pb2">

--- a/resources/views/dashboard/_monthReminder.blade.php
+++ b/resources/views/dashboard/_monthReminder.blade.php
@@ -3,25 +3,23 @@
     <ul class="mb4">
         @if(count($reminderOutboxes) > 0)
             @foreach($reminderOutboxes as $reminderOutbox)
-            @if (!is_object($reminderOutbox->reminder))
+            @if (!is_object($reminderOutbox->reminder) || $reminderOutbox->reminder->contact === null)
                 @continue;
             @endif
             <li class="pb2">
                 <span class="ttu f6 mr2 black-60">{{ \App\Helpers\DateHelper::getShortDateWithoutYear($reminderOutbox->planned_date) }}</span>
-                @if ($reminderOutbox->reminder->contact !== null)
-                  <span>
-                      @if ($reminderOutbox->reminder->contact->is_partial)
+                <span>
+                    @if ($reminderOutbox->reminder->contact->is_partial)
 
-                          @php($relatedRealContact = $reminderOutbox->reminder->contact->getRelatedRealContact())
-                          <a href="{{ route('people.show', $relatedRealContact) }}">{{ $relatedRealContact->getIncompleteName() }}</a>
+                        @php($relatedRealContact = $reminderOutbox->reminder->contact->getRelatedRealContact())
+                        <a href="{{ route('people.show', $relatedRealContact) }}">{{ $relatedRealContact->getIncompleteName() }}</a>
 
-                      @else
+                    @else
 
-                          <a href="{{ route('people.show', $reminderOutbox->reminder->contact) }}">{{ $reminderOutbox->reminder->contact->getIncompleteName() }}</a>
+                        <a href="{{ route('people.show', $reminderOutbox->reminder->contact) }}">{{ $reminderOutbox->reminder->contact->getIncompleteName() }}</a>
 
-                      @endif
-                  </span>
-                @endif
+                    @endif
+                </span>
                 {{ $reminderOutbox->reminder->title }}
             </li>
             @endforeach

--- a/resources/views/dashboard/_monthReminder.blade.php
+++ b/resources/views/dashboard/_monthReminder.blade.php
@@ -8,18 +8,20 @@
             @endif
             <li class="pb2">
                 <span class="ttu f6 mr2 black-60">{{ \App\Helpers\DateHelper::getShortDateWithoutYear($reminderOutbox->planned_date) }}</span>
-                <span>
-                    @if ($reminderOutbox->reminder->contact->is_partial)
+                @if ($reminderOutbox->reminder->contact !== null)
+                  <span>
+                      @if ($reminderOutbox->reminder->contact->is_partial)
 
-                        @php($relatedRealContact = $reminderOutbox->reminder->contact->getRelatedRealContact())
-                        <a href="{{ route('people.show', $relatedRealContact) }}">{{ $relatedRealContact->getIncompleteName() }}</a>
+                          @php($relatedRealContact = $reminderOutbox->reminder->contact->getRelatedRealContact())
+                          <a href="{{ route('people.show', $relatedRealContact) }}">{{ $relatedRealContact->getIncompleteName() }}</a>
 
-                    @else
+                      @else
 
-                        <a href="{{ route('people.show', $reminderOutbox->reminder->contact) }}">{{ $reminderOutbox->reminder->contact->getIncompleteName() }}</a>
+                          <a href="{{ route('people.show', $reminderOutbox->reminder->contact) }}">{{ $reminderOutbox->reminder->contact->getIncompleteName() }}</a>
 
-                    @endif
-                </span>
+                      @endif
+                  </span>
+                @endif
                 {{ $reminderOutbox->reminder->title }}
             </li>
             @endforeach


### PR DESCRIPTION
Fix #5912 
This is due to the recent soft delete contacts: when a contact is (soft) deleted, the reminder is still there, and it brokes the dashboard.