### PR TITLE
feat: 4190 load more activities

### DIFF
--- a/resources/js/components/people/activity/ActivityList.vue
+++ b/resources/js/components/people/activity/ActivityList.vue
@@ -188,7 +188,7 @@ export default {
       return this.$root.htmldir === 'ltr';
     },
     isLastPage () {
-      return this.lastPage === this.currentPage
+      return this.lastPage === this.currentPage;
     }
   },
 

--- a/resources/js/components/people/activity/ActivityList.vue
+++ b/resources/js/components/people/activity/ActivityList.vue
@@ -126,6 +126,9 @@
                          @cancel="$set(activity, 'edit', false); displayLogActivity = false"
         />
       </div>
+      <a v-if="!isLastPage" @click.prevent="getActivities" class="pointer mr1" style="float: right">
+        {{ $t('app.load_more') }}
+      </a>
     </div>
 
     <p v-if="activities.length > 0" class="tc">
@@ -175,12 +178,17 @@ export default {
       displayParticipants: false,
       destroyActivityId: 0,
       errors: [],
+      currentPage: 0,
+      lastPage: null
     };
   },
 
   computed: {
     dirltr() {
       return this.$root.htmldir === 'ltr';
+    },
+    isLastPage () {
+      return this.lastPage === this.currentPage
     }
   },
 
@@ -199,9 +207,12 @@ export default {
     },
 
     getActivities() {
-      axios.get('api/contacts/' + this.contactId + '/activities')
+      this.currentPage++;
+      axios.get('api/contacts/' + this.contactId + '/activities?page=' + this.currentPage)
         .then(response => {
-          this.activities = response.data.data;
+          this.activities.push(...response.data.data);
+          this.currentPage = response.data.meta.current_page;
+          this.lastPage = response.data.meta.last_page;
         });
     },
 

--- a/resources/js/components/people/activity/ActivityList.vue
+++ b/resources/js/components/people/activity/ActivityList.vue
@@ -126,7 +126,7 @@
                          @cancel="$set(activity, 'edit', false); displayLogActivity = false"
         />
       </div>
-      <a v-if="!isLastPage" @click.prevent="getActivities" class="pointer mr1" style="float: right">
+      <a v-if="!isLastPage" class="pointer mr1" style="float: right" @click.prevent="getActivities">
         {{ $t('app.load_more') }}
       </a>
     </div>


### PR DESCRIPTION
Feature for #4190

Added the "Load More" option in the activities. Now users can see more than 15 entries of their activities.
![Screenshot from 2022-02-07 23-25-58](https://user-images.githubusercontent.com/40805789/152840123-674bba94-0928-4a1e-a315-ac6fb39cfdc3.png)

