### PR TITLE
refactor: remove api call in vue

### DIFF
--- a/app/Http/Controllers/Api/ApiContactController.php
+++ b/app/Http/Controllers/Api/ApiContactController.php
@@ -8,13 +8,11 @@ use App\Models\Contact\Contact;
 use Illuminate\Http\JsonResponse;
 use App\Jobs\UpdateLastConsultedDate;
 use Illuminate\Database\QueryException;
-use App\Services\Contact\Contact\SetMeContact;
 use Illuminate\Validation\ValidationException;
 use App\Services\Contact\Contact\CreateContact;
 use App\Services\Contact\Contact\UpdateContact;
 use App\Services\Contact\Contact\DestroyContact;
 use Illuminate\Http\Resources\Json\JsonResource;
-use App\Services\Contact\Contact\DeleteMeContact;
 use App\Services\Contact\Contact\UpdateWorkInformation;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use App\Http\Resources\Contact\Contact as ContactResource;
@@ -173,50 +171,6 @@ class ApiContactController extends ApiController
         DestroyContact::dispatch($data);
 
         return $this->respondObjectDeleted($contactId);
-    }
-
-    /**
-     * Set a contact as 'me'.
-     *
-     * @param  Request  $request
-     * @param  int  $contactId
-     * @return string
-     */
-    public function setMe(Request $request, $contactId)
-    {
-        $data = [
-            'contact_id' => $contactId,
-            'account_id' => auth()->user()->account_id,
-            'user_id' => auth()->user()->id,
-        ];
-
-        try {
-            app(SetMeContact::class)->execute($data);
-        } catch (ModelNotFoundException $e) {
-            return $this->respondNotFound();
-        } catch (ValidationException $e) {
-            return $this->respondValidatorFailed($e->validator);
-        }
-
-        return $this->respond(['true']);
-    }
-
-    /**
-     * Removes contact as 'me' association.
-     *
-     * @param  Request  $request
-     * @return string
-     */
-    public function removeMe(Request $request)
-    {
-        $data = [
-            'account_id' => auth()->user()->account_id,
-            'user_id' => auth()->user()->id,
-        ];
-
-        app(DeleteMeContact::class)->execute($data);
-
-        return $this->respond(['true']);
     }
 
     /**

--- a/app/Http/Controllers/Api/ApiMeController.php
+++ b/app/Http/Controllers/Api/ApiMeController.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use Illuminate\Http\Request;
+use App\Services\Contact\Contact\SetMeContact;
+use Illuminate\Validation\ValidationException;
+use App\Services\Contact\Contact\DeleteMeContact;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+class ApiMeController extends ApiController
+{
+    /**
+     * Instantiate a new controller instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->middleware('limitations')->only('store');
+        parent::__construct();
+    }
+
+    /**
+     * Set a contact as 'me'.
+     *
+     * @param  Request  $request
+     * @return string
+     */
+    public function store(Request $request)
+    {
+        $data = [
+            'contact_id' => $request->input('contact_id'),
+            'account_id' => auth()->user()->account_id,
+            'user_id' => auth()->user()->id,
+        ];
+
+        try {
+            app(SetMeContact::class)->execute($data);
+        } catch (ModelNotFoundException $e) {
+            return $this->respondNotFound();
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
+        }
+
+        return $this->respond(['true']);
+    }
+
+    /**
+     * Removes contact as 'me' association.
+     *
+     * @param  Request  $request
+     * @return string
+     */
+    public function destroy(Request $request)
+    {
+        $data = [
+            'account_id' => auth()->user()->account_id,
+            'user_id' => auth()->user()->id,
+        ];
+
+        app(DeleteMeContact::class)->execute($data);
+
+        return $this->respond(['true']);
+    }
+}

--- a/app/Http/Controllers/Contacts/ActivitiesController.php
+++ b/app/Http/Controllers/Contacts/ActivitiesController.php
@@ -152,7 +152,7 @@ class ActivitiesController extends Controller
      * Store the activity.
      *
      * @param  Request  $request
-     * @return \Illuminate\Http\Resources\Json\ResourceResponse
+     * @return \Illuminate\Contracts\Support\Responsable
      */
     public function store(Request $request)
     {
@@ -171,8 +171,8 @@ class ActivitiesController extends Controller
      * Update the activity.
      *
      * @param  Request  $request
-     * @param  int  $activityId
-     * @return \Illuminate\Http\Resources\Json\ResourceResponse
+     * @param  Activity  $activity
+     * @return \Illuminate\Contracts\Support\Responsable
      */
     public function update(Request $request, Activity $activity)
     {
@@ -192,6 +192,7 @@ class ActivitiesController extends Controller
      * Delete an activity.
      *
      * @param  Request  $request
+     * @param  Activity  $activity
      * @return \Illuminate\Http\JsonResponse
      */
     public function destroy(Request $request, Activity $activity)

--- a/app/Http/Controllers/Contacts/ActivitiesController.php
+++ b/app/Http/Controllers/Contacts/ActivitiesController.php
@@ -2,20 +2,20 @@
 
 namespace App\Http\Controllers\Contacts;
 
-use App\Helpers\AccountHelper;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
+use App\Helpers\AccountHelper;
 use App\Models\Contact\Contact;
+use App\Models\Account\Activity;
 use Illuminate\Support\Collection;
 use App\Http\Controllers\Controller;
 use App\Models\Account\ActivityType;
 use App\Traits\JsonRespondController;
+use App\Services\Account\Activity\Activity\CreateActivity;
+use App\Services\Account\Activity\Activity\UpdateActivity;
+use App\Services\Account\Activity\Activity\DestroyActivity;
 use App\Services\Account\Activity\ActivityStatisticService;
 use App\Http\Resources\Activity\Activity as ActivityResource;
-use App\Models\Account\Activity;
-use App\Services\Account\Activity\Activity\CreateActivity;
-use App\Services\Account\Activity\Activity\DestroyActivity;
-use App\Services\Account\Activity\Activity\UpdateActivity;
 
 class ActivitiesController extends Controller
 {
@@ -147,7 +147,6 @@ class ActivitiesController extends Controller
             ->withYear($year)
             ->withContact($contact);
     }
-
 
     /**
      * Store the activity.

--- a/app/Http/Controllers/MeController.php
+++ b/app/Http/Controllers/MeController.php
@@ -4,9 +4,9 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\Contact\Contact;
-use App\Services\Contact\Contact\DeleteMeContact;
-use App\Services\Contact\Contact\SetMeContact;
 use App\Traits\JsonRespondController;
+use App\Services\Contact\Contact\SetMeContact;
+use App\Services\Contact\Contact\DeleteMeContact;
 
 class MeController extends Controller
 {

--- a/app/Http/Controllers/MeController.php
+++ b/app/Http/Controllers/MeController.php
@@ -16,13 +16,16 @@ class MeController extends Controller
      * Set a contact as 'me'.
      *
      * @param  Request  $request
-     * @param  int  $contactId
      * @return string
      */
-    public function store(Request $request, int $contactId)
+    public function store(Request $request)
     {
+        $this->validate($request, [
+            'contact_id' => 'required|integer|exists:contacts,id',
+        ]);
+
         app(SetMeContact::class)->execute([
-            'contact_id' => $contactId,
+            'contact_id' => $request->input('contact_id'),
             'account_id' => $request->user()->account_id,
             'user_id' => $request->user()->id,
         ]);

--- a/app/Http/Controllers/MeController.php
+++ b/app/Http/Controllers/MeController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Contact\Contact;
+use App\Services\Contact\Contact\DeleteMeContact;
+use App\Services\Contact\Contact\SetMeContact;
+use App\Traits\JsonRespondController;
+
+class MeController extends Controller
+{
+    use JsonRespondController;
+
+    /**
+     * Set a contact as 'me'.
+     *
+     * @param  Request  $request
+     * @param  int  $contactId
+     * @return string
+     */
+    public function store(Request $request, int $contactId)
+    {
+        app(SetMeContact::class)->execute([
+            'contact_id' => $contactId,
+            'account_id' => $request->user()->account_id,
+            'user_id' => $request->user()->id,
+        ]);
+
+        return $this->respond(['true']);
+    }
+
+    /**
+     * Removes contact as 'me' association.
+     *
+     * @param  Request  $request
+     * @return string
+     */
+    public function destroy(Request $request)
+    {
+        app(DeleteMeContact::class)->execute([
+            'account_id' => $request->user()->account_id,
+            'user_id' => $request->user()->id,
+        ]);
+
+        return $this->respond(['true']);
+    }
+}

--- a/app/Notifications/NewUserAlert.php
+++ b/app/Notifications/NewUserAlert.php
@@ -43,13 +43,11 @@ class NewUserAlert extends Notification implements ShouldQueue
      */
     public function toMail(): MailMessage
     {
-        $tuser = $this->user;
-
         return (new MailMessage)
-            ->subject("New registration: {$tuser->first_name} {$tuser->last_name}")
+            ->subject("New registration: {$this->user->first_name} {$this->user->last_name}")
             ->greeting('New registration')
-            ->line("User: {$tuser->first_name} {$tuser->last_name}")
-            ->line("ID: {$tuser->id}")
-            ->line("Email: {$tuser->email}");
+            ->line("User: {$this->user->first_name} {$this->user->last_name}")
+            ->line("ID: {$this->user->id}")
+            ->line("Email: {$this->user->email}");
     }
 }

--- a/resources/js/components/people/MeContact.vue
+++ b/resources/js/components/people/MeContact.vue
@@ -106,7 +106,7 @@ export default {
 
   methods: {
     save() {
-      axios.put('api/me/contact/'+this.newContact.id)
+      axios.post(`me/contact/${this.newContact.id}`)
         .then(response => {
           this.$emit('change', this.newContact);
           this.meContact = this.newContact;
@@ -116,7 +116,7 @@ export default {
 
     remove() {
       this.newContact = null;
-      axios.delete('api/me/contact')
+      axios.delete('me/contact')
         .then(response => {
           this.$emit('change', null);
           this.meContact = null;

--- a/resources/js/components/people/MeContact.vue
+++ b/resources/js/components/people/MeContact.vue
@@ -106,7 +106,9 @@ export default {
 
   methods: {
     save() {
-      axios.post(`me/contact/${this.newContact.id}`)
+      axios.post('me/contact', {
+        contact_id: this.newContact.id
+      })
         .then(response => {
           this.$emit('change', this.newContact);
           this.meContact = this.newContact;

--- a/resources/js/components/people/activity/ActivityList.vue
+++ b/resources/js/components/people/activity/ActivityList.vue
@@ -207,7 +207,7 @@ export default {
 
     updateList(activity) {
       this.displayLogActivity = false;
-      let index = this.activities.indexOf(this.activities.find(item => item.id === activity.id));
+      const index = this.activities.indexOf(this.activities.find(item => item.id === activity.id));
       Vue.set(this.activities, index >= 0 ? index : this.activities.length, activity);
     },
 

--- a/resources/js/components/people/activity/ActivityList.vue
+++ b/resources/js/components/people/activity/ActivityList.vue
@@ -199,7 +199,7 @@ export default {
     },
 
     getActivities() {
-      axios.get('api/contacts/' + this.contactId + '/activities')
+      axios.get(`people/${this.hash}/activities`)
         .then(response => {
           this.activities = response.data.data;
         });
@@ -207,7 +207,8 @@ export default {
 
     updateList(activity) {
       this.displayLogActivity = false;
-      Vue.set(this.activities, this.activities.indexOf(this.activities.find(item => item.id === activity.id)), activity);
+      let index = this.activities.indexOf(this.activities.find(item => item.id === activity.id));
+      Vue.set(this.activities, index >= 0 ? index : this.activities.length, activity);
     },
 
     showDestroyActivity(activity) {
@@ -215,7 +216,7 @@ export default {
     },
 
     destroyActivity(activity) {
-      axios.delete('api/activities/' + activity.id)
+      axios.delete(`activities/${activity.id}`)
         .then(response => {
           this.activities.splice(this.activities.indexOf(activity), 1);
         });

--- a/resources/js/components/people/activity/CreateActivity.vue
+++ b/resources/js/components/people/activity/CreateActivity.vue
@@ -252,7 +252,7 @@ export default {
 
     store() {
       const method = this.activity ? 'put' : 'post';
-      const url = this.activity ? 'api/activities/'+this.activity.id : 'api/activities';
+      const url = this.activity ? 'activities/'+this.activity.id : 'activities';
 
       if (! this.newActivity.contacts.includes(this.contactId)) {
         this.newActivity.contacts.push(this.contactId);

--- a/resources/js/components/people/gifts/CreateGift.vue
+++ b/resources/js/components/people/gifts/CreateGift.vue
@@ -166,6 +166,7 @@
           <photo-upload
             v-show="photos.length === 0"
             ref="upload"
+            :hash="hash"
             :contact-id="contactId"
             @upload.stop="handlePhoto($event)"
           />

--- a/resources/js/components/people/photo/PhotoList.vue
+++ b/resources/js/components/people/photo/PhotoList.vue
@@ -40,6 +40,7 @@
 
     <photo-upload
       ref="upload"
+      :hash="hash"
       :contact-id="contactId"
       @newphoto="handleNewPhoto($event)"
     />

--- a/resources/js/components/people/photo/PhotoUpload.vue
+++ b/resources/js/components/people/photo/PhotoUpload.vue
@@ -149,10 +149,9 @@ export default {
       this.displayUploadProgress = true;
 
       const formData = new FormData();
-      formData.append('contact_id', this.contactId);
       formData.append('photo', this.file);
 
-      return axios.post('api/photos',
+      return axios.post(`people/${this.hash}/photos`,
         formData,
         {
           headers: {

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,8 +20,8 @@ Route::group(['middleware' => ['auth:api']], function () {
         // Contacts
         Route::apiResource('contacts', 'ApiContactController')
             ->names(['index' => 'contacts', 'show' => 'contact']);
-        Route::put('/me/contact/{contact}', 'ApiContactController@setMe');
-        Route::delete('/me/contact', 'ApiContactController@removeMe');
+        Route::post('/me/contact', 'ApiMeController@store');
+        Route::delete('/me/contact', 'ApiMeController@destroy');
 
         // Contacts properties
         Route::put('/contacts/{contact}/work', 'ApiContactController@updateWork');

--- a/routes/web.php
+++ b/routes/web.php
@@ -57,6 +57,9 @@ Route::middleware(['auth', 'verified', 'mfa'])->group(function () {
     Route::get('/emotions/primaries/{emotion}/secondaries', 'EmotionController@secondaries');
     Route::get('/emotions/primaries/{emotion}/secondaries/{secondaryEmotion}/emotions', 'EmotionController@emotions');
 
+    Route::post('/me/contact/{contactId}', 'MeController@store');
+    Route::delete('/me/contact', 'MeController@destroy');
+
     Route::name('people.')->group(function () {
         Route::get('/people/notfound', 'ContactsController@missing')->name('missing');
         Route::get('/people/archived', 'ContactsController@archived')->name('archived');
@@ -193,6 +196,7 @@ Route::middleware(['auth', 'verified', 'mfa'])->group(function () {
         Route::get('/people/{contact}/activities/contacts', 'Contacts\\ActivitiesController@contacts')->name('activities.contacts');
         Route::get('/people/{contact}/activities/summary', 'Contacts\\ActivitiesController@summary')->name('activities.summary');
         Route::get('/people/{contact}/activities/{year}', 'Contacts\\ActivitiesController@year')->name('activities.year');
+        Route::resource('activities', 'Contacts\\ActivitiesController')->only(['store', 'update', 'destroy']);
 
         // Audit logs
         Route::get('/people/{contact}/auditlogs', 'Contacts\\ContactAuditLogController@index')->name('auditlogs');

--- a/routes/web.php
+++ b/routes/web.php
@@ -57,7 +57,7 @@ Route::middleware(['auth', 'verified', 'mfa'])->group(function () {
     Route::get('/emotions/primaries/{emotion}/secondaries', 'EmotionController@secondaries');
     Route::get('/emotions/primaries/{emotion}/secondaries/{secondaryEmotion}/emotions', 'EmotionController@emotions');
 
-    Route::post('/me/contact/{contactId}', 'MeController@store');
+    Route::post('/me/contact', 'MeController@store');
     Route::delete('/me/contact', 'MeController@destroy');
 
     Route::name('people.')->group(function () {

--- a/tests/Api/Contact/ApiContactControllerTest.php
+++ b/tests/Api/Contact/ApiContactControllerTest.php
@@ -1386,67 +1386,6 @@ class ApiContactControllerTest extends ApiTestCase
     }
 
     /** @test */
-    public function it_sets_me_contact()
-    {
-        $user = $this->signin();
-        $contact = factory(Contact::class)->create([
-            'account_id' => $user->account_id,
-        ]);
-
-        $response = $this->json('PUT', '/api/me/contact/'.$contact->id);
-
-        $response->assertStatus(200);
-
-        $this->assertDatabaseHas('users', [
-            'account_id' => $user->account_id,
-            'me_contact_id' => $contact->id,
-        ]);
-    }
-
-    /** @test */
-    public function it_throws_an_error_if_wrong_account_on_sets_me_contact()
-    {
-        $this->signin();
-        $contact = factory(Contact::class)->create();
-
-        $response = $this->json('PUT', '/api/me/contact/'.$contact->id);
-
-        $this->expectNotFound($response);
-    }
-
-    /** @test */
-    public function it_throws_an_error_if_account_not_exists_on_sets_me_contact()
-    {
-        $this->signin();
-
-        $response = $this->json('PUT', '/api/me/contact/0');
-
-        $this->expectDataError($response, [
-            'The selected contact id is invalid.',
-        ]);
-    }
-
-    /** @test */
-    public function it_removes_me_contact()
-    {
-        $user = $this->signin();
-        $contact = factory(Contact::class)->create([
-            'account_id' => $user->account_id,
-        ]);
-        $user->me_contact_id = $contact->id;
-        $user->save();
-
-        $response = $this->json('DELETE', '/api/me/contact/');
-
-        $response->assertStatus(200);
-
-        $this->assertDatabaseHas('users', [
-            'account_id' => $user->account_id,
-            'me_contact_id' => null,
-        ]);
-    }
-
-    /** @test */
     public function it_gets_me_contact()
     {
         $user = $this->signin();

--- a/tests/Api/Contact/ApiMeControllerTest.php
+++ b/tests/Api/Contact/ApiMeControllerTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Api\Contact;
+
+use Tests\ApiTestCase;
+use App\Models\Contact\Contact;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class ApiMeControllerTest extends ApiTestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function it_sets_me_contact()
+    {
+        $user = $this->signin();
+        $contact = factory(Contact::class)->create([
+            'account_id' => $user->account_id,
+        ]);
+
+        $response = $this->json('POST', '/api/me/contact', ['contact_id' => $contact->id]);
+
+        $response->assertStatus(200);
+
+        $this->assertDatabaseHas('users', [
+            'account_id' => $user->account_id,
+            'me_contact_id' => $contact->id,
+        ]);
+    }
+
+    /** @test */
+    public function it_throws_an_error_if_wrong_account_on_sets_me_contact()
+    {
+        $this->signin();
+        $contact = factory(Contact::class)->create();
+
+        $response = $this->json('POST', '/api/me/contact', ['contact_id' => $contact->id]);
+
+        $this->expectNotFound($response);
+    }
+
+    /** @test */
+    public function it_throws_an_error_if_account_not_exists_on_sets_me_contact()
+    {
+        $this->signin();
+
+        $response = $this->json('POST', '/api/me/contact', ['contact_id' => 0]);
+
+        $this->expectDataError($response, [
+            'The selected contact id is invalid.',
+        ]);
+    }
+
+    /** @test */
+    public function it_removes_me_contact()
+    {
+        $user = $this->signin();
+        $contact = factory(Contact::class)->create([
+            'account_id' => $user->account_id,
+        ]);
+        $user->me_contact_id = $contact->id;
+        $user->save();
+
+        $response = $this->json('DELETE', '/api/me/contact');
+
+        $response->assertStatus(200);
+
+        $this->assertDatabaseHas('users', [
+            'account_id' => $user->account_id,
+            'me_contact_id' => null,
+        ]);
+    }
+}

--- a/tests/Feature/ActivityTest.php
+++ b/tests/Feature/ActivityTest.php
@@ -249,7 +249,7 @@ class ActivityTest extends FeatureTestCase
             'errors' => [
                 'summary' => ['The summary field is required.'],
                 'happened_at' => ['The happened at field is required.'],
-                'contacts' => ['The contacts field is required.']
+                'contacts' => ['The contacts field is required.'],
             ],
         ]);
     }
@@ -476,7 +476,7 @@ class ActivityTest extends FeatureTestCase
 
         $response->assertStatus(404);
         $response->assertJson([
-            'message' => "No query results for model [App\\Models\\Account\\Activity] 0",
+            'message' => 'No query results for model [App\\Models\\Account\\Activity] 0',
         ]);
     }
 
@@ -555,7 +555,7 @@ class ActivityTest extends FeatureTestCase
 
         $response->assertStatus(404);
         $response->assertJson([
-            'message' => "No query results for model [App\\Models\\Account\\Activity] 0",
+            'message' => 'No query results for model [App\\Models\\Account\\Activity] 0',
         ]);
     }
 

--- a/tests/Feature/ActivityTest.php
+++ b/tests/Feature/ActivityTest.php
@@ -6,6 +6,7 @@ use App\Models\User\User;
 use Tests\FeatureTestCase;
 use App\Models\Contact\Contact;
 use App\Models\Account\Activity;
+use App\Models\Account\ActivityType;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class ActivityTest extends FeatureTestCase
@@ -34,6 +35,91 @@ class ActivityTest extends FeatureTestCase
     protected $jsonStructureContacts = [
         'id',
         'name',
+    ];
+
+    protected $jsonActivity = [
+        'id',
+        'object',
+        'summary',
+        'description',
+        'happened_at',
+        'activity_type' => [
+            'id',
+            'object',
+            'name',
+            'location_type',
+            'activity_type_category' => [
+                'id',
+                'object',
+                'name',
+                'account' => [
+                    'id',
+                ],
+                'created_at',
+                'updated_at',
+            ],
+            'account'=> [
+                'id',
+            ],
+            'created_at',
+            'updated_at',
+        ],
+        'attendees' => [
+            'total',
+            'contacts' => [
+                '*' => [
+                    'id',
+                    'object',
+                    'first_name',
+                    'last_name',
+                    'complete_name',
+                ],
+            ],
+        ],
+        'emotions' => [
+            '*' => [
+                'id',
+                'object',
+                'name',
+            ],
+        ],
+        'account' => [
+            'id',
+        ],
+        'created_at',
+        'updated_at',
+    ];
+
+    protected $jsonActivityNoCategory = [
+        'id',
+        'object',
+        'summary',
+        'description',
+        'happened_at',
+        'attendees' => [
+            'total',
+            'contacts' => [
+                '*' => [
+                    'id',
+                    'object',
+                    'first_name',
+                    'last_name',
+                    'complete_name',
+                ],
+            ],
+        ],
+        'emotions' => [
+            '*' => [
+                'id',
+                'object',
+                'name',
+            ],
+        ],
+        'account' => [
+            'id',
+        ],
+        'created_at',
+        'updated_at',
     ];
 
     private function createActivityAndAttachToContact(User $user, Contact $contact)
@@ -99,5 +185,391 @@ class ActivityTest extends FeatureTestCase
             3,
             $response->decodeResponseJson()
         );
+    }
+
+    /** @test */
+    public function activities_create()
+    {
+        $user = $this->signin();
+        $contact = factory(Contact::class)->create([
+            'account_id' => $user->account_id,
+        ]);
+        $activityType = factory(ActivityType::class)->create([
+            'account_id' => $user->account_id,
+        ]);
+
+        $response = $this->json('POST', '/activities', [
+            'contacts' => [$contact->id],
+            'description' => 'the description',
+            'summary' => 'the activity',
+            'happened_at' => '2018-05-01',
+            'activity_type_id' => $activityType->id,
+        ]);
+
+        $response->assertStatus(201);
+        $response->assertJsonStructure([
+            'data' => $this->jsonActivity,
+        ]);
+        $activity_id = $response->json('data.id');
+        $response->assertJsonFragment([
+            'object' => 'activity',
+            'id' => $activity_id,
+        ]);
+
+        $this->assertGreaterThan(0, $activity_id);
+        $this->assertDatabaseHas('activities', [
+            'account_id' => $user->account_id,
+            'id' => $activity_id,
+            'summary' => 'the activity',
+            'description' => 'the description',
+            'happened_at' => '2018-05-01',
+        ]);
+        $this->assertDatabaseHas('activity_contact', [
+            'account_id' => $user->account_id,
+            'contact_id' => $contact->id,
+            'activity_id' => $activity_id,
+        ]);
+    }
+
+    /** @test */
+    public function activities_create_error_wrong_parameter()
+    {
+        $user = $this->signin();
+        $contact = factory(Contact::class)->create([
+            'account_id' => $user->account_id,
+        ]);
+
+        $response = $this->json('POST', '/activities', [
+            'contact_id' => [$contact->id],
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJson([
+            'message' => 'The given data was invalid.',
+            'errors' => [
+                'summary' => ['The summary field is required.'],
+                'happened_at' => ['The happened at field is required.'],
+                'contacts' => ['The contacts field is required.']
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function activities_create_error_bad_account()
+    {
+        $this->signin();
+
+        $contact = factory(Contact::class)->create();
+
+        $response = $this->json('POST', '/activities', [
+            'contacts' => [$contact->id],
+            'description' => 'the description',
+            'summary' => 'the activity',
+            'happened_at' => '2018-05-01',
+        ]);
+
+        $response->assertStatus(404);
+        $response->assertJson([
+            'message' => "No query results for model [App\\Models\\Contact\\Contact] {$contact->id}",
+        ]);
+    }
+
+    /** @test */
+    public function activities_create_error_bad_account2()
+    {
+        $user = $this->signin();
+        $contact = factory(Contact::class)->create([
+            'account_id' => $user->account_id,
+        ]);
+
+        $activityType = factory(ActivityType::class)->create();
+
+        $response = $this->json('POST', '/activities', [
+            'contacts' => [$contact->id],
+            'description' => 'the description',
+            'summary' => 'the activity',
+            'happened_at' => '2018-05-01',
+            'activity_type_id' => $activityType->id,
+        ]);
+
+        $response->assertStatus(404);
+        $response->assertJson([
+            'message' => "No query results for model [App\\Models\\Account\\ActivityType] {$activityType->id}",
+        ]);
+    }
+
+    /** @test */
+    public function activities_update()
+    {
+        $user = $this->signin();
+        $contact = factory(Contact::class)->create([
+            'account_id' => $user->account_id,
+        ]);
+        $activity = factory(Activity::class)->create([
+            'account_id' => $user->account_id,
+        ]);
+
+        $response = $this->json('PUT', '/activities/'.$activity->id, [
+            'contacts' => [$contact->id],
+            'description' => 'the description',
+            'summary' => 'the activity',
+            'happened_at' => '2018-05-01',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'data' => $this->jsonActivityNoCategory,
+        ]);
+        $activity_id = $response->json('data.id');
+        $this->assertEquals($activity->id, $activity_id);
+        $response->assertJsonFragment([
+            'object' => 'activity',
+            'id' => $activity_id,
+        ]);
+
+        $this->assertGreaterThan(0, $activity_id);
+        $this->assertDatabaseHas('activities', [
+            'account_id' => $user->account_id,
+            'id' => $activity_id,
+            'summary' => 'the activity',
+            'happened_at' => '2018-05-01',
+        ]);
+        $this->assertDatabaseHas('activity_contact', [
+            'account_id' => $user->account_id,
+            'contact_id' => $contact->id,
+            'activity_id' => $activity_id,
+        ]);
+    }
+
+    /** @test */
+    public function activities_update_category()
+    {
+        $user = $this->signin();
+        $contact = factory(Contact::class)->create([
+            'account_id' => $user->account_id,
+        ]);
+        $activity = factory(Activity::class)->create([
+            'account_id' => $user->account_id,
+        ]);
+        $activityType = factory(ActivityType::class)->create([
+            'account_id' => $user->account_id,
+        ]);
+
+        $response = $this->json('PUT', '/activities/'.$activity->id, [
+            'contacts' => [$contact->id],
+            'description' => 'the description',
+            'summary' => 'the activity',
+            'happened_at' => '2018-05-01',
+            'activity_type_id' => $activityType->id,
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'data' => $this->jsonActivity,
+        ]);
+        $activity_id = $response->json('data.id');
+        $this->assertEquals($activity->id, $activity_id);
+        $response->assertJsonFragment([
+            'object' => 'activity',
+            'id' => $activity_id,
+        ]);
+
+        $activity_type_id = $response->json('data.activity_type.id');
+        $this->assertEquals($activityType->id, $activity_type_id);
+        $response->assertJsonFragment([
+            'object' => 'activityType',
+            'id' => $activity_type_id,
+        ]);
+
+        $this->assertGreaterThan(0, $activity_id);
+        $this->assertDatabaseHas('activities', [
+            'account_id' => $user->account_id,
+            'id' => $activity_id,
+            'summary' => 'the activity',
+            'happened_at' => '2018-05-01',
+            'activity_type_id' => $activityType->id,
+        ]);
+        $this->assertDatabaseHas('activity_contact', [
+            'account_id' => $user->account_id,
+            'contact_id' => $contact->id,
+            'activity_id' => $activity_id,
+        ]);
+    }
+
+    /** @test */
+    public function activities_update_existing()
+    {
+        $user = $this->signin();
+        $activity = factory(Activity::class)->create([
+            'account_id' => $user->account_id,
+        ]);
+        $contact = factory(Contact::class)->create([
+            'account_id' => $user->account_id,
+        ]);
+        $contact->activities()->attach($activity, [
+            'account_id' => $user->account_id,
+        ]);
+        $contact2 = factory(Contact::class)->create([
+            'account_id' => $user->account_id,
+        ]);
+        $contact2->activities()->attach($activity, [
+            'account_id' => $user->account_id,
+        ]);
+        $this->assertDatabaseHas('activity_contact', [
+            'account_id' => $user->account_id,
+            'contact_id' => $contact->id,
+            'activity_id' => $activity->id,
+        ]);
+        $this->assertDatabaseHas('activity_contact', [
+            'account_id' => $user->account_id,
+            'contact_id' => $contact2->id,
+            'activity_id' => $activity->id,
+        ]);
+
+        $response = $this->json('PUT', '/activities/'.$activity->id, [
+            'contacts' => [$contact->id],
+            'description' => 'the description',
+            'summary' => 'the activity',
+            'happened_at' => '2018-05-01',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'data' => $this->jsonActivityNoCategory,
+        ]);
+        $activity_id = $response->json('data.id');
+        $this->assertEquals($activity->id, $activity_id);
+        $response->assertJsonFragment([
+            'object' => 'activity',
+            'id' => $activity_id,
+        ]);
+
+        $this->assertGreaterThan(0, $activity_id);
+        $this->assertDatabaseHas('activities', [
+            'account_id' => $user->account_id,
+            'id' => $activity_id,
+            'summary' => 'the activity',
+            'happened_at' => '2018-05-01',
+        ]);
+        $this->assertDatabaseHas('activity_contact', [
+            'account_id' => $user->account_id,
+            'contact_id' => $contact->id,
+            'activity_id' => $activity_id,
+        ]);
+        $this->assertDatabaseMissing('activity_contact', [
+            'account_id' => $user->account_id,
+            'contact_id' => $contact2->id,
+            'activity_id' => $activity_id,
+        ]);
+    }
+
+    /** @test */
+    public function activities_update_error_wrong_parameter()
+    {
+        $user = $this->signin();
+
+        $response = $this->json('PUT', '/activities/0', [
+            'description' => 'the description',
+            'summary' => 'the activity',
+            'happened_at' => '2018-05-01',
+        ]);
+
+        $response->assertStatus(404);
+        $response->assertJson([
+            'message' => "No query results for model [App\\Models\\Account\\Activity] 0",
+        ]);
+    }
+
+    /** @test */
+    public function activities_update_error_wrong_account_for_activity()
+    {
+        $user = $this->signin();
+
+        $contact = factory(Contact::class)->create([
+            'account_id' => $user->account_id,
+        ]);
+        $activity = factory(Activity::class)->create();
+
+        $response = $this->json('PUT', '/activities/'.$activity->id, [
+            'contacts' => [$contact->id],
+            'description' => 'the description',
+            'summary' => 'the activity',
+            'happened_at' => '2018-05-01',
+        ]);
+
+        $response->assertStatus(404);
+        $response->assertJson([
+            'message' => "No query results for model [App\\Models\\Account\\Activity] {$activity->id}",
+        ]);
+    }
+
+    /** @test */
+    public function activities_update_error_wrong_account_for_contacts()
+    {
+        $user = $this->signin();
+
+        $contact = factory(Contact::class)->create();
+        $activity = factory(Activity::class)->create([
+            'account_id' => $user->account_id,
+        ]);
+
+        $response = $this->json('PUT', '/activities/'.$activity->id, [
+            'contacts' => [$contact->id],
+            'description' => 'the description',
+            'summary' => 'the activity',
+            'happened_at' => '2018-05-01',
+        ]);
+
+        $response->assertStatus(404);
+        $response->assertJson([
+            'message' => "No query results for model [App\\Models\\Contact\\Contact] {$contact->id}",
+        ]);
+    }
+
+    /** @test */
+    public function activities_delete()
+    {
+        $user = $this->signin();
+        $activity = factory(Activity::class)->create([
+            'account_id' => $user->account_id,
+        ]);
+        $this->assertDatabaseHas('activities', [
+            'account_id' => $user->account_id,
+        ]);
+
+        $response = $this->json('DELETE', '/activities/'.$activity->id);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseMissing('activities', [
+            'account_id' => $user->account_id,
+            'id' => $activity->id,
+        ]);
+    }
+
+    /** @test */
+    public function activities_delete_error()
+    {
+        $this->signin();
+
+        $response = $this->json('DELETE', '/activities/0');
+
+        $response->assertStatus(404);
+        $response->assertJson([
+            'message' => "No query results for model [App\\Models\\Account\\Activity] 0",
+        ]);
+    }
+
+    /** @test */
+    public function activities_delete_with_wrong_account()
+    {
+        $this->signin();
+        $activity = factory(Activity::class)->create();
+
+        $response = $this->json('DELETE', '/activities/'.$activity->id);
+
+        $response->assertStatus(404);
+        $response->assertJson([
+            'message' => "No query results for model [App\\Models\\Account\\Activity] {$activity->id}",
+        ]);
     }
 }

--- a/tests/Feature/MeTest.php
+++ b/tests/Feature/MeTest.php
@@ -10,7 +10,6 @@ class MeTest extends FeatureTestCase
 {
     use DatabaseTransactions;
 
-
     /** @test */
     public function it_stores_me()
     {

--- a/tests/Feature/MeTest.php
+++ b/tests/Feature/MeTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\FeatureTestCase;
+use App\Models\Contact\Contact;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class MeTest extends FeatureTestCase
+{
+    use DatabaseTransactions;
+
+
+    /** @test */
+    public function it_stores_me()
+    {
+        $user = $this->signin();
+        $contact = factory(Contact::class)->create([
+            'account_id' => $user->account_id,
+        ]);
+
+        $response = $this->json('POST', '/me/contact', [
+            'contact_id' => $contact->id,
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'true',
+        ]);
+
+        $this->assertDatabaseHas('users', [
+            'id' => $user->id,
+            'me_contact_id' => $contact->id,
+        ]);
+    }
+
+    /** @test */
+    public function it_stores_error_wrong_parameter()
+    {
+        $this->signin();
+
+        $response = $this->json('POST', '/me/contact', []);
+
+        $response->assertStatus(422);
+        $response->assertJson([
+            'message' => 'The given data was invalid.',
+            'errors' => [
+                'contact_id' => ['The contact id field is required.'],
+            ],
+        ]);
+    }
+
+    /** @test */
+    public function it_stores_error_bad_account()
+    {
+        $this->signin();
+
+        $contact = factory(Contact::class)->create();
+
+        $response = $this->json('POST', '/me/contact', [
+            'contact_id' => $contact->id,
+        ]);
+
+        $response->assertStatus(404);
+        $response->assertJson([
+            'message' => "No query results for model [App\\Models\\Contact\\Contact] {$contact->id}",
+        ]);
+    }
+
+    /** @test */
+    public function it_deletes_me()
+    {
+        $user = $this->signin();
+        $contact = factory(Contact::class)->create([
+            'account_id' => $user->account_id,
+        ]);
+        $user->me_contact_id = $contact->id;
+        $user->save();
+
+        $response = $this->json('DELETE', '/me/contact');
+
+        $response->assertStatus(200);
+
+        $this->assertDatabaseHas('users', [
+            'id' => $user->id,
+            'me_contact_id' => null,
+        ]);
+    }
+}


### PR DESCRIPTION
This removes all api call in vue.
It will remove the necessity of creating oauth keys on a deployment to make UI works.

This fix #6000