### PR TITLE
fix: only include real contacts in carddav sync

### DIFF
--- a/app/Http/Controllers/DAV/Backend/CardDAV/CardDAVBackend.php
+++ b/app/Http/Controllers/DAV/Backend/CardDAV/CardDAVBackend.php
@@ -264,6 +264,7 @@ class CardDAVBackend extends AbstractBackend implements SyncSupport, IDAVBackend
     public function getObjects($collectionId)
     {
         return $this->user->account->contacts($collectionId)
+                    ->real()
                     ->active()
                     ->get();
     }


### PR DESCRIPTION
fixes #5150

Adds the real scope to the carddav sync query so that non-real contacts are not included.