### PR TITLE
fix: 6023 Allow empty completed_at task date

### DIFF
--- a/app/Http/Controllers/Contacts/TasksController.php
+++ b/app/Http/Controllers/Contacts/TasksController.php
@@ -21,7 +21,7 @@ class TasksController extends Controller
                 'title' => $task->title,
                 'description' => $task->description,
                 'completed' => $task->completed,
-                'completed_at' => DateHelper::getShortDate($task->completed_at),
+                'completed_at' => ($task->completed_at) ? DateHelper::getShortDate($task->completed_at): null,
                 'edit' => false,
             ];
             $tasks->push($data);

--- a/app/Http/Controllers/Contacts/TasksController.php
+++ b/app/Http/Controllers/Contacts/TasksController.php
@@ -21,7 +21,7 @@ class TasksController extends Controller
                 'title' => $task->title,
                 'description' => $task->description,
                 'completed' => $task->completed,
-                'completed_at' => ($task->completed_at) ? DateHelper::getShortDate($task->completed_at): null,
+                'completed_at' => ($task->completed_at) ? DateHelper::getShortDate($task->completed_at) : null,
                 'edit' => false,
             ];
             $tasks->push($data);


### PR DESCRIPTION
Fixes #6023

Currently the code crashes if a contact has a non-completed task, as DateHelper::getShortDate requires a non-null Carbon object. 

This PR allows the completed_at value to be null without a crash. 
