### PR TITLE
fix: 5817 blurry modals from sweet-modal-vue

### DIFF
--- a/resources/sass/modal.scss
+++ b/resources/sass/modal.scss
@@ -91,3 +91,7 @@
   -webkit-transform: scale(1.1);
   transform: scale(1.1);
 }
+
+.sweet-modal-overlay {
+  -webkit-perspective: none !important;
+}


### PR DESCRIPTION
Fixes #5817

Some modals are spawned in Vue with the help of the sweet-modal-vue package. 

This package uses the "-webkit-perspective" CSS property which leads to blurry text while not being useful in the use-case of Monica. 

This PR removes disables this property and restores sharp text in modals. 
I wasn't too sure where to put the fix, don't hesitate to ask me to move it to a better file. 