### PR TITLE
fix: 5906 Journal sidebar width on mobile

### DIFF
--- a/resources/js/components/journal/JournalList.vue
+++ b/resources/js/components/journal/JournalList.vue
@@ -46,7 +46,7 @@
     </div>
 
     <!-- Right sidebar -->
-    <div :class="[ dirltr ? 'fl' : 'fr' ]" class="w-30 pa2">
+    <div :class="[ dirltr ? 'fl' : 'fr' ]" class="w-30-ns w-100 pa2">
       <a v-cy-name="'add-entry-button'" href="journal/add" class="btn btn-primary w-100 mb4">
         {{ $t('journal.journal_add') }}
       </a>


### PR DESCRIPTION
Fixes #5906

The journal sidebar was not responsive

Before : 

![image](https://user-images.githubusercontent.com/5305627/155848499-cf7953d0-b3bd-4d9d-829e-0ebceddf277e.png)


After : 

![image](https://user-images.githubusercontent.com/5305627/155848505-b322963b-7178-41cf-b743-bd693f2acf38.png)
