### PR TITLE
fix: life event creation with unknown month/day

### DIFF
--- a/resources/js/components/people/lifeevent/CreateLifeEvent.vue
+++ b/resources/js/components/people/lifeevent/CreateLifeEvent.vue
@@ -261,10 +261,10 @@ export default {
      * Same for the month.
      */
     updateDate() {
-      if (this.selectedDay === 0) {
+      if (this.selectedDay === 0 || this.selectedDay === '0') {
         this.newLifeEvent.happened_at_day_unknown = true;
         this.newLifeEvent.happened_at = this.selectedYear + '-' + this.selectedMonth + '-01';
-      } else if (this.selectedMonth === 0) {
+      } else if (this.selectedMonth === 0 || this.selectedMonth === '0') {
         this.newLifeEvent.happened_at_month_unknown = true;
         this.newLifeEvent.happened_at_day_unknown = true;
         this.newLifeEvent.happened_at = this.selectedYear + '-01-01';


### PR DESCRIPTION
This is a JS problem, current version sends this on create:

```
happened_at	"2022-0-0"
happened_at_day_unknown	false
happened_at_month_unknown	false
```

Whereas old version sent this:
```
happened_at	"2022-1-1"
happened_at_day_unknown	true
happened_at_month_unknown	true
```

This issue was introduced by 57b31f6526e3628cc98c8c271108bc34dd2d074e

The strict comparison added in the `updateDate` function in CreateLifeEvent.vue broke it.
The values for `this.selectedMonth` and `this.selectedDay` can be numbers/integers or strings, depending on where they come from.
Initial values and values set by JS are numbers, whereas values set by user input are strings.

Fixes #5936



I guess there might be a nicer approach to this in vue, or in general, though I don't have an idea :)