### PR TITLE
docs: node 16 in debian and generic

### DIFF
--- a/docs/installation/providers/debian.md
+++ b/docs/installation/providers/debian.md
@@ -67,7 +67,7 @@ wget -q -O - https://getcomposer.org/installer | sudo php -- --install-dir=/usr/
 **Node.js:** Install node.js with package manager.
 
 ```sh
-wget -q -O - https://deb.nodesource.com/setup_14.x | sudo bash -
+wget -q -O - https://deb.nodesource.com/setup_16.x | sudo bash -
 sudo apt install -y nodejs
 ```
 

--- a/docs/installation/providers/generic.md
+++ b/docs/installation/providers/generic.md
@@ -56,7 +56,7 @@ php composer-setup.php --install-dir=/usr/local/bin/ --filename=composer
 php -r "unlink('composer-setup.php');"
 ```
 
-**Node.js:** Install node.js 14+ minimum
+**Node.js:** Install node.js 16+ minimum
 
 
 **Yarn:** Install yarn using npm


### PR DESCRIPTION
A few weeks ago, @aaronpk updated the Ubuntu installation doc in PR #5980 to note that Node.js 16 is now the minimum required version, but forgot to update the Debian and Generic docs with the same change. This PR simply updates those two docs.

Issue #6048 was recently opened pointing out this issue on Debian, so this PR solves that issue.

