### PR TITLE
fix: vcard bday export format with unknown year

### DIFF
--- a/app/Services/VCard/ExportVCard.php
+++ b/app/Services/VCard/ExportVCard.php
@@ -196,6 +196,8 @@ class ExportVCard extends BaseService
     /**
      * @param  Contact  $contact
      * @param  VCard  $vcard
+     *
+     * @see https://datatracker.ietf.org/doc/html/rfc6350#section-6.2.5
      */
     private function exportBirthday(Contact $contact, VCard $vcard)
     {
@@ -203,7 +205,7 @@ class ExportVCard extends BaseService
 
         if (! is_null($contact->birthdate)) {
             if ($contact->birthdate->is_year_unknown) {
-                $date = $contact->birthdate->date->format('--m-d');
+                $date = $contact->birthdate->date->format('--md');
             } else {
                 $date = $contact->birthdate->date->format('Ymd');
             }

--- a/tests/Unit/Services/VCard/ExportVCardTest.php
+++ b/tests/Unit/Services/VCard/ExportVCardTest.php
@@ -312,6 +312,24 @@ class ExportVCardTest extends TestCase
     }
 
     /** @test */
+    public function vcard_add_birthday_with_unknown_year()
+    {
+        $account = factory(Account::class)->create();
+        $contact = factory(Contact::class)->create(['account_id' => $account->id]);
+        $contact->setSpecialDate('birthdate', 0, 10, 5);
+        $vCard = new VCard();
+
+        $exportVCard = app(ExportVCard::class);
+        $this->invokePrivateMethod($exportVCard, 'exportBirthday', [$contact, $vCard]);
+
+        $this->assertCount(
+            self::defaultPropsCount + 1,
+            $vCard->children()
+        );
+        $this->assertStringContainsString('BDAY:--1005', $vCard->serialize());
+    }
+
+    /** @test */
     public function vcard_add_contact_fields_empty()
     {
         $account = factory(Account::class)->create();


### PR DESCRIPTION
Fix #6079 

The vCard export is incorrect when the year is unknown.
It exported the birthday like:
`--mm-dd`

.. but it should be:
`--mmdd`

Referring to https://datatracker.ietf.org/doc/html/rfc6350/#section-6.2.5
Added test and fix.



### Checklist

#### Before submitting the PR
- [x] Read the [CONTRIBUTING document](https://github.com/monicahq/monica/blob/main/CONTRIBUTING.md) before submitting your PR.
- [x] If the PR is related to an issue or fix one, don't forget to indicate it.

### General checks
- [x] Make sure that the change you propose is the smallest possible.
- [x] The name of the PR should follow the [conventional commits guideline](https://github.com/monicahq/monica/blob/main/docs/contribute/readme.md#conventional-commits) that the project follows.

#### Backend/models changes
- [x] Tests have been added for the new code.
