### PR TITLE
fix: update php version in Dockerfile

### DIFF
--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -6,7 +6,7 @@
 ### This file is based off of the `apache` variant in the above mentioned repo
 ###
 
-FROM php:8.0-apache
+FROM php:8.1-apache
 
 # opencontainers annotations https://github.com/opencontainers/image-spec/blob/master/annotations.md
 LABEL org.opencontainers.image.authors="Alexis Saettler <alexis@saettler.org>" \


### PR DESCRIPTION
When I tried to run `docker-compose -f docker-compose.dev.yml up -d`  it failed with composer error.
It required PHP 8.1, I found that Dockerfile is using the PHP version 8 and composer is set with dependency on 8.1

I changed this in Dockerfile to make it work. 