### PR TITLE
feat: add a name order with the last name outside of brackets

### DIFF
--- a/app/Models/Contact/Contact.php
+++ b/app/Models/Contact/Contact.php
@@ -879,7 +879,7 @@ class Contact extends Model
                 break;
             case 'nickname_bracketed_firstname_lastname':
                 $completeName = $this->first_name;
-                
+
                 if (! is_null($this->middle_name)) {
                     $completeName = $completeName.' '.$this->middle_name;
                 }

--- a/app/Models/Contact/Contact.php
+++ b/app/Models/Contact/Contact.php
@@ -877,6 +877,21 @@ class Contact extends Model
                     $completeName = $completeName.' '.$this->middle_name;
                 }
                 break;
+            case 'nickname_bracketed_firstname_lastname':
+                $completeName = $this->first_name;
+                
+                if (! is_null($this->middle_name)) {
+                    $completeName = $completeName.' '.$this->middle_name;
+                }
+
+                if (! is_null($this->nickname)) {
+                    $completeName = $this->nickname.' ('.$completeName.')';
+                }
+
+                if (! is_null($this->last_name)) {
+                    $completeName = $completeName.' '.$this->last_name;
+                }
+                break;
             case 'nickname':
                 if (! is_null($this->nickname)) {
                     $completeName = $this->nickname;
@@ -907,7 +922,11 @@ class Contact extends Model
     public function getIncompleteName()
     {
         $incompleteName = '';
-        $incompleteName = $this->first_name;
+        if ($this->nameOrder == 'nickname_bracketed_firstname_lastname' && ! is_null($this->nickname)) {
+            $incompleteName = $this->nickname;
+        } else {
+            $incompleteName = $this->first_name;
+        }
 
         if (! is_null($this->last_name)) {
             $incompleteName .= ' '.mb_substr($this->last_name, 0, 1);

--- a/app/Models/Contact/Contact.php
+++ b/app/Models/Contact/Contact.php
@@ -922,10 +922,10 @@ class Contact extends Model
     public function getIncompleteName()
     {
         $incompleteName = '';
+        $incompleteName = $this->first_name;
+
         if ($this->nameOrder == 'nickname_bracketed_firstname_lastname' && ! is_null($this->nickname)) {
             $incompleteName = $this->nickname;
-        } else {
-            $incompleteName = $this->first_name;
         }
 
         if (! is_null($this->last_name)) {

--- a/app/Models/User/User.php
+++ b/app/Models/User/User.php
@@ -90,6 +90,7 @@ class User extends Authenticatable implements MustVerifyEmail, HasLocalePreferen
         'lastname_nickname_firstname',
         'nickname_firstname_lastname',
         'nickname_lastname_firstname',
+        'nickname_bracketed_firstname_lastname',
         'nickname',
     ];
 

--- a/resources/lang/en/settings.php
+++ b/resources/lang/en/settings.php
@@ -69,6 +69,7 @@ return [
     'name_order_lastname_nickname_firstname' => '<Last name> (<Nickname>) <First name> – Doe (Rambo) John',
     'name_order_nickname_firstname_lastname' => '<Nickname> (<First name> <Last name>) – Rambo (John Doe)',
     'name_order_nickname_lastname_firstname' => '<Nickname> (<Last name> <First name>) – Rambo (Doe John)',
+    'name_order_nickname_bracketed_firstname_lastname' => '<Nickname> (<First name>) <Last name> - Rambo (John) Doe',
     'name_order_nickname' => '<Nickname> – Rambo',
     'currency' => 'Currency',
     'name' => 'Your name: :name',

--- a/tests/Unit/Models/ContactTest.php
+++ b/tests/Unit/Models/ContactTest.php
@@ -340,6 +340,39 @@ class ContactTest extends FeatureTestCase
         $contact->middle_name = 'H';
         $contact->last_name = 'Gregory';
         $contact->nickname = 'Rambo';
+        $contact->nameOrder('nickname_bracketed_firstname_lastname');
+        $this->assertEquals(
+            'Rambo (Peter H) Gregory',
+            $contact->name
+        );
+
+        $contact = new Contact;
+        $contact->first_name = 'Peter';
+        $contact->middle_name = 'H';
+        $contact->last_name = null;
+        $contact->nickname = 'Rambo';
+        $contact->nameOrder('nickname_bracketed_firstname_lastname');
+        $this->assertEquals(
+            'Rambo (Peter H)',
+            $contact->name
+        );
+
+        $contact = new Contact;
+        $contact->first_name = 'Peter';
+        $contact->middle_name = null;
+        $contact->last_name = 'Gregory';
+        $contact->nickname = 'Rambo';
+        $contact->nameOrder('nickname_bracketed_firstname_lastname');
+        $this->assertEquals(
+            'Rambo (Peter) Gregory',
+            $contact->name
+        );
+
+        $contact = new Contact;
+        $contact->first_name = 'Peter';
+        $contact->middle_name = 'H';
+        $contact->last_name = 'Gregory';
+        $contact->nickname = 'Rambo';
         $contact->nameOrder('nickname');
         $this->assertEquals(
             'Rambo',


### PR DESCRIPTION
This fixes #6285.

Where nicknames are used as diminutives of full first names, it (hopefuly) makes sense to indicate as such in both the full name and short name fields.
