### PR TITLE
chore: upgrade Larastan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
         "matthiasnoback/live-code-coverage": "^1",
         "mockery/mockery": "^1.0",
         "nunomaduro/collision": "^6.1",
-        "nunomaduro/larastan": "^2.0",
+        "nunomaduro/larastan": "^2.2",
         "phpunit/phpcov": "^8.0",
         "phpunit/phpunit": "^9.0",
         "psalm/plugin-laravel": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "058c753117c80674f9909927b3ee58ee",
+    "content-hash": "f7893304f5945ef17cdbf132438205c6",
     "packages": [
         {
             "name": "asbiin/laravel-adorable",
@@ -14485,16 +14485,16 @@
         },
         {
             "name": "nunomaduro/larastan",
-            "version": "v2.1.12",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/larastan.git",
-                "reference": "65cfc54fa195e509c2e2be119761552017d22a56"
+                "reference": "980199077a49d71ef7c03b65b9d6bcce1f6d7bad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/larastan/zipball/65cfc54fa195e509c2e2be119761552017d22a56",
-                "reference": "65cfc54fa195e509c2e2be119761552017d22a56",
+                "url": "https://api.github.com/repos/nunomaduro/larastan/zipball/980199077a49d71ef7c03b65b9d6bcce1f6d7bad",
+                "reference": "980199077a49d71ef7c03b65b9d6bcce1f6d7bad",
                 "shasum": ""
             },
             "require": {
@@ -14560,7 +14560,7 @@
             ],
             "support": {
                 "issues": "https://github.com/nunomaduro/larastan/issues",
-                "source": "https://github.com/nunomaduro/larastan/tree/v2.1.12"
+                "source": "https://github.com/nunomaduro/larastan/tree/v2.2.0"
             },
             "funding": [
                 {
@@ -14580,7 +14580,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2022-07-17T15:23:33+00:00"
+            "time": "2022-08-30T19:02:01+00:00"
         },
         {
             "name": "openlss/lib-array2xml",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,7 +9,6 @@ parameters:
     checkMissingIterableValueType: false
     level: 5
     ignoreErrors:
-        - '#Call to an undefined method Illuminate\\View\\View::with[a-zA-Z0-9\\_]+\(\)\.#'
         - '#Access to an undefined property Sabre\\VObject\\Component\\[a-zA-Z0-9\\_]+::\$[a-zA-Z0-9_]+\.#'
         - '#Unsafe call to private method .* through static::\.#'
         - '#Unsafe access to private property .* through static::\.#'


### PR DESCRIPTION
This PR upgrades the `nunomaduro/larastan` dependency to the latest version. Which gets rid of an ignored error.