### PR TITLE
docs: refers missing php tokenizer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
         "ext-gmp": "*",
         "ext-intl": "*",
         "ext-redis": "*",
-        "ext-tokenizer": "*",
         "asbiin/laravel-adorable": "^1.0",
         "asbiin/laravel-webauthn": "^3.0",
         "bacon/bacon-qr-code": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "ext-gmp": "*",
         "ext-intl": "*",
         "ext-redis": "*",
+        "ext-tokenizer": "*",
         "asbiin/laravel-adorable": "^1.0",
         "asbiin/laravel-webauthn": "^3.0",
         "bacon/bacon-qr-code": "^2.0",

--- a/docs/installation/providers/cpanel.md
+++ b/docs/installation/providers/cpanel.md
@@ -23,22 +23,23 @@ Monica can be configured in shared hosting environments with a little difference
 
 **PHP:** Install php8.1 minimum. Generally cPanel will have a PHP 7 version installed, verify under the 'PHP Version' section from the cPanel section. Make sure these extensions are enabled:
 
--   bcmath
--   curl
--   dom
--   gd
--   gmp
--   iconv
--   intl
--   json
--   mbstring
--   mysqli
--   opcache
--   pdo_mysql
--   redis
--   sodium
--   xml
--   zip
+- bcmath
+- curl
+- dom
+- gd
+- gmp
+- iconv
+- intl
+- json
+- mbstring
+- mysqli
+- opcache
+- pdo_mysql
+- redis
+- sodium
+- tokenizer
+- xml
+- zip
 
 In most cases, this will be under the section called 'PHP Version' in cPanel where you can enable and disable modules. 
 

--- a/docs/installation/providers/debian.md
+++ b/docs/installation/providers/debian.md
@@ -53,27 +53,28 @@ sudo apt update
 
 Install PHP 8.1 with these extensions:
 
--   bcmath
--   curl
--   dom
--   gd
--   gmp
--   iconv
--   intl
--   json
--   mbstring
--   mysqli
--   opcache
--   pdo_mysql
--   redis
--   sodium
--   xml
--   zip
+- bcmath
+- curl
+- dom
+- gd
+- gmp
+- iconv
+- intl
+- json
+- mbstring
+- mysqli
+- opcache
+- pdo_mysql
+- redis
+- sodium
+- tokenizer
+- xml
+- zip
 
 Run:
 ```sh
 sudo apt install -y php8.1 php8.1-bcmath php8.1-curl php8.1-gd php8.1-gmp \
-    php8.1-intl php8.1-mbstring php8.1-mysql php8.1-redis php8.1-xml php8.1-zip
+    php8.1-intl php8.1-mbstring php8.1-mysql php8.1-redis php8.1-tokenizer php8.1-xml php8.1-zip
 ```
 
 **Composer:** After you're done installing PHP, you'll need the Composer dependency manager.

--- a/docs/installation/providers/generic.md
+++ b/docs/installation/providers/generic.md
@@ -31,22 +31,23 @@ If you don't want to use Docker, the best way to setup the project is to use the
 
 **PHP:** Install php8.1 minimum, with these extensions:
 
--   bcmath
--   curl
--   dom
--   gd
--   gmp
--   iconv
--   intl
--   json
--   mbstring
--   mysqli
--   opcache
--   pdo_mysql
--   redis
--   sodium
--   xml
--   zip
+- bcmath
+- curl
+- dom
+- gd
+- gmp
+- iconv
+- intl
+- json
+- mbstring
+- mysqli
+- opcache
+- pdo_mysql
+- redis
+- sodium
+- tokenizer
+- xml
+- zip
 
 **Composer:** After you're done installing PHP, you'll need the Composer dependency manager. It is not enough to just install Composer, you also need to make sure it is installed globally for Monica's installation to run smoothly:
 


### PR DESCRIPTION
This PR adds the php tokenizer extension as a dependency in composer.json, which will prevent user from suffering unexpected consequences such as the cryptic error message in #6469 

Composer will now warn on install  that the extension is needed. Also, the installations docs have been updated to document this dependency.

Closes #6524 and #6469 