### PR TITLE
fix: reset notification date when user adds call, activity, or conversation

### DIFF
--- a/app/Http/Controllers/Contacts/ConversationsController.php
+++ b/app/Http/Controllers/Contacts/ConversationsController.php
@@ -103,6 +103,9 @@ class ConversationsController extends Controller
                 ->withErrors($result);
         }
 
+        // Reset and update stay in touch trigger date
+        Contact::find($data['contact_id'])->resetStayInTouchTriggerDate();
+
         return redirect()->route('people.show', $contact)
             ->with('success', trans('people.conversation_add_success'));
     }

--- a/app/Http/Controllers/Contacts/ConversationsController.php
+++ b/app/Http/Controllers/Contacts/ConversationsController.php
@@ -103,9 +103,6 @@ class ConversationsController extends Controller
                 ->withErrors($result);
         }
 
-        // Reset and update stay in touch trigger date
-        Contact::find($data['contact_id'])->resetStayInTouchTriggerDate();
-
         return redirect()->route('people.show', $contact)
             ->with('success', trans('people.conversation_add_success'));
     }

--- a/app/Models/Contact/Contact.php
+++ b/app/Models/Contact/Contact.php
@@ -1523,6 +1523,16 @@ class Contact extends Model
     }
 
     /**
+     * Reset the notification date from current time
+     *
+     * @return void
+     */
+    public function resetStayInTouchTriggerDate()
+    {
+        $this->setStayInTouchTriggerDate($this->stay_in_touch_frequency ?? 0);
+    }
+
+    /**
      * Get the weather information for this contact, based on the first address
      * on the profile.
      *

--- a/app/Services/Account/Activity/Activity/AttachContactToActivity.php
+++ b/app/Services/Account/Activity/Activity/AttachContactToActivity.php
@@ -56,6 +56,11 @@ class AttachContactToActivity extends BaseService
         /** @var Activity */
         $activity = Activity::find($data['activity_id']);
 
+        // Reset and update stay in touch trigger date
+        foreach ($data['contacts'] as $contactId) {
+            Contact::find($contactId)->resetStayInTouchTriggerDate();
+        }
+
         $this->attach($data, $activity);
 
         return $activity;

--- a/app/Services/Contact/Call/CreateCall.php
+++ b/app/Services/Contact/Call/CreateCall.php
@@ -47,7 +47,10 @@ class CreateCall extends BaseService
 
         $this->updateLastCallInfo($contact, $call);
 
-        if (! empty($data['emotions'])) {
+        // Reset and update stay in touch trigger date
+        Contact::find($data['contact_id'])->resetStayInTouchTriggerDate();
+
+        if (!empty($data['emotions'])) {
             if ($data['emotions'] != '') {
                 $this->addEmotions($data['emotions'], $call);
             }

--- a/app/Services/Contact/Call/CreateCall.php
+++ b/app/Services/Contact/Call/CreateCall.php
@@ -50,7 +50,7 @@ class CreateCall extends BaseService
         // Reset and update stay in touch trigger date
         Contact::find($data['contact_id'])->resetStayInTouchTriggerDate();
 
-        if (!empty($data['emotions'])) {
+        if (! empty($data['emotions'])) {
             if ($data['emotions'] != '') {
                 $this->addEmotions($data['emotions'], $call);
             }

--- a/app/Services/Contact/Conversation/CreateConversation.php
+++ b/app/Services/Contact/Conversation/CreateConversation.php
@@ -47,6 +47,9 @@ class CreateConversation extends BaseService
         ContactFieldType::where('account_id', $data['account_id'])
                         ->findOrFail($data['contact_field_type_id']);
 
+        // Reset and update stay in touch trigger date
+        Contact::find($data['contact_id'])->resetStayInTouchTriggerDate();
+
         return Conversation::create($data);
     }
 }


### PR DESCRIPTION
Pushes the next notification date from "stay in touch" setting by the number of dates user selected. Intended to do so only when _adding_ calls, activities, or conversations to contact, not updating.

Fixes issue #1814 when adding calls, activities, or conversations to a contact.