### PR TITLE
fix: show todays reminders on the dashboard too

### DIFF
--- a/app/Models/Contact/Reminder.php
+++ b/app/Models/Contact/Reminder.php
@@ -114,11 +114,8 @@ class Reminder extends Model
             $date = $this->initial_date;
         }
 
-        while ($date->isPast()) {
-            $date = DateHelper::addTimeAccordingToFrequencyType($date, $this->frequency_type, $this->frequency_number);
-        }
-
-        if ($date->isToday()) {
+        // Only schedule reminders week/month/year out IF it is in the past
+        while ($date->isPast() && !$date->isToday()) {
             $date = DateHelper::addTimeAccordingToFrequencyType($date, $this->frequency_type, $this->frequency_number);
         }
 


### PR DESCRIPTION
I am not sure why the `while()` and then the `if()` here: https://github.com/monicahq/monica/blob/main/app/Models/Contact/Reminder.php#L117-L121

Seems redundant. So, I reworked it to fix #6570 

Could use another pair of eyes to validate my approach, however.