### PR TITLE
feat: Add filter to journal

### DIFF
--- a/app/Http/Controllers/JournalController.php
+++ b/app/Http/Controllers/JournalController.php
@@ -28,10 +28,26 @@ class JournalController extends Controller
      *
      * @return array
      */
-    public function list()
+    public function list(Request $request)
     {
+
+        $startDate = $request->input('start_date');
+        $endDate = $request->input('end_date');
+        $sortBy = $request->input('sort_by', 'created_at'); 
+        $sortOrder = $request->input('sort_order', 'desc'); 
+        $perPage = $request->input('per_page', 30);
+
         $entries = collect([]);
-        $journalEntries = auth()->user()->account->journalEntries()->paginate(30);
+        
+        $journalEntriesQuery = auth()->user()->account->journalEntries();
+
+        if ($startDate && $endDate) {
+            $journalEntriesQuery->whereDate('date', '>=', $startDate)
+                ->whereDate('date', '<=', $endDate);
+        }
+        $journalEntries = $journalEntriesQuery->orderBy($sortBy, $sortOrder)
+        ->paginate($perPage);
+
 
         // this is needed to determine if we need to display the calendar
         // (month + year) next to the journal entry

--- a/resources/js/components/journal/JournalList.vue
+++ b/resources/js/components/journal/JournalList.vue
@@ -9,31 +9,36 @@
   <div class="mw9 center">
     <!-- Left sidebar -->
     <div :class="[dirltr ? 'fl' : 'fr']" class="w-70-ns w-100 pa2">
-
       <!-- Filters -->
       <div class="filter mb-4">
         <div class="d-flex pb-2">
           <div class="dt">
             <label for="start-date">{{ $t('journal.start_date') }}:</label>
-            <input type="date" id="start-date" class="form-control" v-model="startDate">
+            <input id="start-date" v-model="startDate" type="date" class="form-control" />
           </div>
           <div class="dt pl-2">
             <label for="end-date py-2">{{ $t('journal.end_date') }}:</label>
-            <input type="date" id="end-date" class="form-control" v-model="endDate">
+            <input id="end-date" v-model="endDate" type="date" class="form-control" />
           </div>
           <div class="dt pl-2">
             <label for="per-page">{{ $t('journal.per_page') }}:</label>
-            <input type="number" id="per-page" class="form-control" v-model="perPage">
+            <input id="per-page" v-model="perPage" type="number" class="form-control" />
           </div>
           <div class="dt pl-2">
             <label for="sort-order">{{ $t('journal.sort_order') }} :</label>
-            <select id="sort-order" class="form-control" v-model="sortOrder">
-              <option value="asc">{{ $t('journal.ascending') }}</option>
-              <option value="desc">{{ $t('journal.descending') }}</option>
+            <select id="sort-order" v-model="sortOrder" class="form-control">
+              <option value="asc">
+                {{ $t('journal.ascending') }}
+              </option>
+              <option value="desc">
+                {{ $t('journal.descending') }}
+              </option>
             </select>
           </div>
-      </div>
-      <button @click="getEntries" class="btn btn-primary">{{ $t('journal.apply_filter') }}</button>
+        </div>
+        <button class="btn btn-primary" @click="getEntries">
+          {{ $t('journal.apply_filter') }}
+        </button>
       </div>
 
 
@@ -42,22 +47,28 @@
 
       <!-- Logs -->
       <div v-if="journalEntries.data" v-cy-name="'journal-entries-body'" v-cy-items="journalEntries.data.map(j => j.id)"
-        :cy-object-items="journalEntries.data.map(j => j.object.id)">
+           :cy-object-items="journalEntries.data.map(j => j.object.id)"
+      >
         <div v-for="journalEntry in journalEntries.data" :key="journalEntry.id"
-          v-cy-name="'entry-body-' + journalEntry.id" class="cf">
+             v-cy-name="'entry-body-' + journalEntry.id" class="cf"
+        >
           <journal-content-rate v-if="journalEntry.journalable_type === 'App\\Models\\Journal\\Day'"
-            :journal-entry="journalEntry" @deleteJournalEntry="deleteJournalEntry" />
+                                :journal-entry="journalEntry" @deleteJournalEntry="deleteJournalEntry"
+          />
 
           <journal-content-activity v-else-if="journalEntry.journalable_type === 'App\\Models\\Account\\Activity'"
-            :journal-entry="journalEntry" />
+                                    :journal-entry="journalEntry"
+          />
 
           <journal-content-entry v-else-if="journalEntry.journalable_type === 'App\\Models\\Journal\\Entry'"
-            :journal-entry="journalEntry" @deleteJournalEntry="deleteJournalEntry" />
+                                 :journal-entry="journalEntry" @deleteJournalEntry="deleteJournalEntry"
+          />
         </div>
       </div>
 
       <div v-if="(journalEntries.per_page * journalEntries.current_page) <= journalEntries.total"
-        class="br3 ba b--gray-monica bg-white pr3 pb3 pt3 mb3 tc">
+           class="br3 ba b--gray-monica bg-white pr3 pb3 pt3 mb3 tc"
+      >
         <p class="mb0 pointer" @click="loadMore()">
           <span v-if="!loadingMore">
             {{ $t('app.load_more') }}
@@ -69,7 +80,8 @@
       </div>
 
       <div v-if="journalEntries.total === 0" v-cy-name="'journal-blank-state'"
-        class="br3 ba b--gray-monica bg-white pr3 pb3 pt3 mb3 tc">
+           class="br3 ba b--gray-monica bg-white pr3 pb3 pt3 mb3 tc"
+      >
         <div class="tc mb4">
           <img src="img/journal/blank.svg" :alt="$t('journal.journal_empty')" />
         </div>

--- a/resources/js/components/journal/JournalList.vue
+++ b/resources/js/components/journal/JournalList.vue
@@ -26,7 +26,7 @@
             <input type="number" id="per-page" class="form-control" v-model="perPage">
           </div>
           <div class="dt pl-2">
-            <label for="sort-order">{{ $t('journal.sort_order') }}:</label>
+            <label for="sort-order">{{ $t('journal.sort_order') }} :</label>
             <select id="sort-order" class="form-control" v-model="sortOrder">
               <option value="asc">{{ $t('journal.ascending') }}</option>
               <option value="desc">{{ $t('journal.descending') }}</option>

--- a/resources/js/components/journal/JournalList.vue
+++ b/resources/js/components/journal/JournalList.vue
@@ -1,29 +1,63 @@
 <style scoped>
 .fade-enter-active,
 .fade-leave-active {
-    transition: opacity .4s
+  transition: opacity .4s
 }
 </style>
 
 <template>
   <div class="mw9 center">
     <!-- Left sidebar -->
-    <div :class="[ dirltr ? 'fl' : 'fr' ]" class="w-70-ns w-100 pa2">
+    <div :class="[dirltr ? 'fl' : 'fr']" class="w-70-ns w-100 pa2">
+
+      <!-- Filters -->
+      <div class="filter mb-4">
+        <div class="d-flex pb-2">
+          <div class="dt">
+            <label for="start-date">{{ $t('journal.start_date') }}:</label>
+            <input type="date" id="start-date" class="form-control" v-model="startDate">
+          </div>
+          <div class="dt pl-2">
+            <label for="end-date py-2">{{ $t('journal.end_date') }}:</label>
+            <input type="date" id="end-date" class="form-control" v-model="endDate">
+          </div>
+          <div class="dt pl-2">
+            <label for="per-page">{{ $t('journal.per_page') }}:</label>
+            <input type="number" id="per-page" class="form-control" v-model="perPage">
+          </div>
+          <div class="dt pl-2">
+            <label for="sort-order">{{ $t('journal.sort_order') }}:</label>
+            <select id="sort-order" class="form-control" v-model="sortOrder">
+              <option value="asc">{{ $t('journal.ascending') }}</option>
+              <option value="desc">{{ $t('journal.descending') }}</option>
+            </select>
+          </div>
+      </div>
+      <button @click="getEntries" class="btn btn-primary">{{ $t('journal.apply_filter') }}</button>
+      </div>
+
+
       <!-- How was your day -->
       <journal-rate-day @hasRated="hasRated" />
 
       <!-- Logs -->
-      <div v-if="journalEntries.data" v-cy-name="'journal-entries-body'" v-cy-items="journalEntries.data.map(j => j.id)" :cy-object-items="journalEntries.data.map(j => j.object.id)">
-        <div v-for="journalEntry in journalEntries.data" :key="journalEntry.id" v-cy-name="'entry-body-' + journalEntry.id" class="cf">
-          <journal-content-rate v-if="journalEntry.journalable_type === 'App\\Models\\Journal\\Day'" :journal-entry="journalEntry" @deleteJournalEntry="deleteJournalEntry" />
+      <div v-if="journalEntries.data" v-cy-name="'journal-entries-body'" v-cy-items="journalEntries.data.map(j => j.id)"
+        :cy-object-items="journalEntries.data.map(j => j.object.id)">
+        <div v-for="journalEntry in journalEntries.data" :key="journalEntry.id"
+          v-cy-name="'entry-body-' + journalEntry.id" class="cf">
+          <journal-content-rate v-if="journalEntry.journalable_type === 'App\\Models\\Journal\\Day'"
+            :journal-entry="journalEntry" @deleteJournalEntry="deleteJournalEntry" />
 
-          <journal-content-activity v-else-if="journalEntry.journalable_type === 'App\\Models\\Account\\Activity'" :journal-entry="journalEntry" />
+          <journal-content-activity v-else-if="journalEntry.journalable_type === 'App\\Models\\Account\\Activity'"
+            :journal-entry="journalEntry" />
 
-          <journal-content-entry v-else-if="journalEntry.journalable_type === 'App\\Models\\Journal\\Entry'" :journal-entry="journalEntry" @deleteJournalEntry="deleteJournalEntry" />
+          <journal-content-entry v-else-if="journalEntry.journalable_type === 'App\\Models\\Journal\\Entry'"
+            :journal-entry="journalEntry" @deleteJournalEntry="deleteJournalEntry" />
         </div>
       </div>
 
-      <div v-if="(journalEntries.per_page * journalEntries.current_page) <= journalEntries.total" class="br3 ba b--gray-monica bg-white pr3 pb3 pt3 mb3 tc">
+      <div v-if="(journalEntries.per_page * journalEntries.current_page) <= journalEntries.total"
+        class="br3 ba b--gray-monica bg-white pr3 pb3 pt3 mb3 tc">
         <p class="mb0 pointer" @click="loadMore()">
           <span v-if="!loadingMore">
             {{ $t('app.load_more') }}
@@ -34,7 +68,8 @@
         </p>
       </div>
 
-      <div v-if="journalEntries.total === 0" v-cy-name="'journal-blank-state'" class="br3 ba b--gray-monica bg-white pr3 pb3 pt3 mb3 tc">
+      <div v-if="journalEntries.total === 0" v-cy-name="'journal-blank-state'"
+        class="br3 ba b--gray-monica bg-white pr3 pb3 pt3 mb3 tc">
         <div class="tc mb4">
           <img src="img/journal/blank.svg" :alt="$t('journal.journal_empty')" />
         </div>
@@ -46,7 +81,7 @@
     </div>
 
     <!-- Right sidebar -->
-    <div :class="[ dirltr ? 'fl' : 'fr' ]" class="w-30-ns w-100 pa2">
+    <div :class="[dirltr ? 'fl' : 'fr']" class="w-30-ns w-100 pa2">
       <a v-cy-name="'add-entry-button'" href="journal/add" class="btn btn-primary w-100 mb4">
         {{ $t('journal.journal_add') }}
       </a>
@@ -68,7 +103,11 @@ export default {
       showSadSmileyColor: false,
       showHappySmileyColor: false,
       loadingMore: false,
-
+      startDate: '',
+      endDate: '',
+      sortBy: 'created_at', // Specify the field to sort by (e.g., 'created_at', 'updated_at')
+      sortOrder: 'desc', // Specify the sort order ('asc' or 'desc')
+      perPage: 30, // Specify the number of entries per page
     };
   },
 
@@ -76,7 +115,7 @@ export default {
     dirltr() {
       return this.$root.htmldir === 'ltr';
     },
-    hasMorePage: function() {
+    hasMorePage: function () {
       var total = this.journalEntries.per_page * this.journalEntries.current_page;
 
       if (total >= this.journalEntries.total) {
@@ -97,7 +136,15 @@ export default {
     },
 
     getEntries() {
-      axios.get('journal/entries')
+      axios.get('journal/entries', {
+        params: {
+          start_date: this.startDate,
+          end_date: this.endDate,
+          per_page: this.perPage,
+          sort_order: this.sortOrder,
+          sort_by: this.sortBy,
+        },
+      })
         .then(response => {
           this.journalEntries = response.data;
           this.journalEntries.current_page = response.data.current_page;
@@ -109,22 +156,22 @@ export default {
     },
 
     // This event is omited from the child component
-    deleteJournalEntry: function($journalEntryId) {
+    deleteJournalEntry: function ($journalEntryId) {
       // check if the deleted entry date is today. If that's the case
       // we need to put back the Rate box. This is only necessary if
       // the user does all his actions on the same page without ever
       // reloading the page.
-      this.journalEntries.data.filter(function(obj) {
+      this.journalEntries.data.filter(function (obj) {
         return obj.id === $journalEntryId;
       });
 
       // Filter out the array without the deleted Journal Entry
-      this.journalEntries.data = this.journalEntries.data.filter(function(element) {
+      this.journalEntries.data = this.journalEntries.data.filter(function (element) {
         return element.id !== $journalEntryId;
       });
     },
 
-    hasRated: function(journalObject) {
+    hasRated: function (journalObject) {
       this.journalEntries.data.unshift(journalObject);
     },
 

--- a/resources/js/components/journal/JournalList.vue
+++ b/resources/js/components/journal/JournalList.vue
@@ -177,7 +177,15 @@ export default {
 
     loadMore() {
       this.loadingMore = true;
-      axios.get('journal/entries?page=' + (this.journalEntries.current_page + 1))
+      axios.get('journal/entries?page=' + (this.journalEntries.current_page + 1),{
+        params: {
+          start_date: this.startDate,
+          end_date: this.endDate,
+          per_page: this.perPage,
+          sort_order: this.sortOrder,
+          sort_by: this.sortBy,
+        },
+      })
         .then(response => {
           this.journalEntries.current_page = response.data.current_page;
           this.journalEntries.next_page_url = response.data.next_page_url;

--- a/resources/lang/ar/journal.php
+++ b/resources/lang/ar/journal.php
@@ -28,4 +28,11 @@ return [
     'journal_blank_cta' => 'قم بتدوين مذكرتك الأولى',
     'journal_blank_description' => 'المذكرة تدَعُك تدون الأحداث التي حصلت لك، لتتذكرها.',
     'delete_confirmation' => 'هل أنت متأكد من حذف تدوين هذه المذكرة؟',
+    'apply_filter' => 'طبق الفلترة',
+    "start_date" => "تاريخ البدء" ,
+     "end_date" => "تاريخ الانتهاء" ,
+     "per_page" => "لكل صفحة" ,
+     'Sort_order' => 'ترتيب الفرز' ,
+     "ascending" => "تصاعدي" ,
+     "descending" => "تنازلي" ,
 ];

--- a/resources/lang/ar/journal.php
+++ b/resources/lang/ar/journal.php
@@ -32,7 +32,7 @@ return [
     "start_date" => "تاريخ البدء" ,
      "end_date" => "تاريخ الانتهاء" ,
      "per_page" => "لكل صفحة" ,
-     'Sort_order' => 'ترتيب الفرز' ,
+     'Sort_order' => 'فرز حسب تاريخ الإنشاء',
      "ascending" => "تصاعدي" ,
      "descending" => "تنازلي" ,
 ];

--- a/resources/lang/cs/journal.php
+++ b/resources/lang/cs/journal.php
@@ -28,4 +28,11 @@ return [
     'journal_blank_cta' => 'Přidej svůj první deníkový záznam',
     'journal_blank_description' => 'Deník umožňuje zaznamenávání událostí které se staly a ulehčuje jejich zapamatování.',
     'delete_confirmation' => 'Opravdu chcete smazat tento deníkový záznam?',
+    'apply_filter' => 'Apply filter',
+    'start_date' => 'Start Date',
+    'end_date' => 'End Date',
+    'per_page' => 'Per Page',
+    'sort_order' => 'Sort Order',
+    'ascending' => 'Ascending',
+    'descending' => 'Descending',
 ];

--- a/resources/lang/cs/journal.php
+++ b/resources/lang/cs/journal.php
@@ -32,7 +32,7 @@ return [
     'start_date' => 'Start Date',
     'end_date' => 'End Date',
     'per_page' => 'Per Page',
-    'sort_order' => 'Sort Order',
+    'sort_order' => 'Sort By Created At',
     'ascending' => 'Ascending',
     'descending' => 'Descending',
 ];

--- a/resources/lang/da/journal.php
+++ b/resources/lang/da/journal.php
@@ -28,4 +28,11 @@ return [
     'journal_blank_cta' => 'Add your first journal entry',
     'journal_blank_description' => 'The journal lets you write events that happened to you, and remember them.',
     'delete_confirmation' => 'Are you sure you want to delete this journal entry?',
+    'apply_filter' => 'Apply filter',
+    'start_date' => 'Start Date',
+    'end_date' => 'End Date',
+    'per_page' => 'Per Page',
+    'sort_order' => 'Sort Order',
+    'ascending' => 'Ascending',
+    'descending' => 'Descending',
 ];

--- a/resources/lang/da/journal.php
+++ b/resources/lang/da/journal.php
@@ -32,7 +32,7 @@ return [
     'start_date' => 'Start Date',
     'end_date' => 'End Date',
     'per_page' => 'Per Page',
-    'sort_order' => 'Sort Order',
+    'sort_order' => 'Sort By Created At',
     'ascending' => 'Ascending',
     'descending' => 'Descending',
 ];

--- a/resources/lang/de/journal.php
+++ b/resources/lang/de/journal.php
@@ -28,4 +28,11 @@ return [
     'journal_blank_cta' => 'Schreibe deinen ersten Eintrag',
     'journal_blank_description' => 'Im Tagebuch kannst du deine Erlebnisse festhalten und dich später an sie erinnern.',
     'delete_confirmation' => 'Willst du diesen Eintrag wirklich löschen?',
+    'apply_filter' => 'Apply filter',
+    'start_date' => 'Start Date',
+    'end_date' => 'End Date',
+    'per_page' => 'Per Page',
+    'sort_order' => 'Sort Order',
+    'ascending' => 'Ascending',
+    'descending' => 'Descending',
 ];

--- a/resources/lang/de/journal.php
+++ b/resources/lang/de/journal.php
@@ -32,7 +32,7 @@ return [
     'start_date' => 'Start Date',
     'end_date' => 'End Date',
     'per_page' => 'Per Page',
-    'sort_order' => 'Sort Order',
+    'sort_order' => 'Sort By Created At',
     'ascending' => 'Ascending',
     'descending' => 'Descending',
 ];

--- a/resources/lang/el/journal.php
+++ b/resources/lang/el/journal.php
@@ -32,7 +32,7 @@ return [
     'start_date' => 'Start Date',
     'end_date' => 'End Date',
     'per_page' => 'Per Page',
-    'sort_order' => 'Sort Order',
+    'sort_order' => 'Sort By Created At',
     'ascending' => 'Ascending',
     'descending' => 'Descending',
 ];

--- a/resources/lang/el/journal.php
+++ b/resources/lang/el/journal.php
@@ -28,7 +28,7 @@ return [
     'journal_blank_cta' => 'Προσθέστε την πρώτη καταχώρηση ημερολογίου',
     'journal_blank_description' => 'Το ημερολόγιο σας επιτρέπει να γράφετε γεγονότα που σας συνέβησαν και να τα θυμάστε.',
     'delete_confirmation' => 'Είστε βέβαιοι ότι θέλετε να διαγράψετε αυτή την καταχώρηση ημερολογίου;',
-    'Apply_filter' => 'Apply filter',
+    'apply_filter' => 'Apply filter',
     'start_date' => 'Start Date',
     'end_date' => 'End Date',
     'per_page' => 'Per Page',

--- a/resources/lang/el/journal.php
+++ b/resources/lang/el/journal.php
@@ -28,4 +28,11 @@ return [
     'journal_blank_cta' => 'Προσθέστε την πρώτη καταχώρηση ημερολογίου',
     'journal_blank_description' => 'Το ημερολόγιο σας επιτρέπει να γράφετε γεγονότα που σας συνέβησαν και να τα θυμάστε.',
     'delete_confirmation' => 'Είστε βέβαιοι ότι θέλετε να διαγράψετε αυτή την καταχώρηση ημερολογίου;',
+    'Apply_filter' => 'Apply filter',
+    'start_date' => 'Start Date',
+    'end_date' => 'End Date',
+    'per_page' => 'Per Page',
+    'sort_order' => 'Sort Order',
+    'ascending' => 'Ascending',
+    'descending' => 'Descending',
 ];

--- a/resources/lang/en-GB/journal.php
+++ b/resources/lang/en-GB/journal.php
@@ -28,4 +28,11 @@ return [
     'journal_blank_cta' => 'Add your first journal entry',
     'journal_blank_description' => 'The journal lets you write events that happened to you, and remember them.',
     'delete_confirmation' => 'Are you sure you want to delete this journal entry?',
+    'apply_filter' => 'Apply filter',
+    'start_date' => 'Start Date',
+    'end_date' => 'End Date',
+    'per_page' => 'Per Page',
+    'sort_order' => 'Sort Order',
+    'ascending' => 'Ascending',
+    'descending' => 'Descending',
 ];

--- a/resources/lang/en-GB/journal.php
+++ b/resources/lang/en-GB/journal.php
@@ -32,7 +32,7 @@ return [
     'start_date' => 'Start Date',
     'end_date' => 'End Date',
     'per_page' => 'Per Page',
-    'sort_order' => 'Sort Order',
+    'sort_order' => 'Sort By Created At',
     'ascending' => 'Ascending',
     'descending' => 'Descending',
 ];

--- a/resources/lang/en/journal.php
+++ b/resources/lang/en/journal.php
@@ -28,4 +28,11 @@ return [
     'journal_blank_cta' => 'Add your first journal entry',
     'journal_blank_description' => 'The journal lets you write events that happened to you, and remember them.',
     'delete_confirmation' => 'Are you sure you want to delete this journal entry?',
+    'apply_filter' => 'Apply filter',
+    'start_date' => 'Start Date',
+    'end_date' => 'End Date',
+    'per_page' => 'Per Page',
+    'sort_order' => 'Sort Order',
+    'ascending' => 'Ascending',
+    'descending' => 'Descending',
 ];

--- a/resources/lang/en/journal.php
+++ b/resources/lang/en/journal.php
@@ -32,7 +32,7 @@ return [
     'start_date' => 'Start Date',
     'end_date' => 'End Date',
     'per_page' => 'Per Page',
-    'sort_order' => 'Sort Order',
+    'sort_order' => 'Sort By Created At',
     'ascending' => 'Ascending',
     'descending' => 'Descending',
 ];

--- a/resources/lang/es/journal.php
+++ b/resources/lang/es/journal.php
@@ -28,4 +28,11 @@ return [
     'journal_blank_cta' => 'Añade tu primera entrada de diario',
     'journal_blank_description' => 'El diario te permite escribir eventos que te han pasado y recordarlos.',
     'delete_confirmation' => '¿Seguro que deseas eliminar esta entrada de tu diario?',
+    'apply_filter' => 'Apply filter',
+    'start_date' => 'Start Date',
+    'end_date' => 'End Date',
+    'per_page' => 'Per Page',
+    'sort_order' => 'Sort Order',
+    'ascending' => 'Ascending',
+    'descending' => 'Descending',
 ];

--- a/resources/lang/es/journal.php
+++ b/resources/lang/es/journal.php
@@ -32,7 +32,7 @@ return [
     'start_date' => 'Start Date',
     'end_date' => 'End Date',
     'per_page' => 'Per Page',
-    'sort_order' => 'Sort Order',
+    'sort_order' => 'Sort By Created At',
     'ascending' => 'Ascending',
     'descending' => 'Descending',
 ];

--- a/resources/lang/fa/journal.php
+++ b/resources/lang/fa/journal.php
@@ -28,4 +28,11 @@ return [
     'journal_blank_cta' => 'Add your first journal entry',
     'journal_blank_description' => 'The journal lets you write events that happened to you, and remember them.',
     'delete_confirmation' => 'Are you sure you want to delete this journal entry?',
+    'apply_filter' => 'Apply filter',
+    'start_date' => 'Start Date',
+    'end_date' => 'End Date',
+    'per_page' => 'Per Page',
+    'sort_order' => 'Sort Order',
+    'ascending' => 'Ascending',
+    'descending' => 'Descending',
 ];

--- a/resources/lang/fa/journal.php
+++ b/resources/lang/fa/journal.php
@@ -32,7 +32,7 @@ return [
     'start_date' => 'Start Date',
     'end_date' => 'End Date',
     'per_page' => 'Per Page',
-    'sort_order' => 'Sort Order',
+    'sort_order' => 'Sort By Created At',
     'ascending' => 'Ascending',
     'descending' => 'Descending',
 ];

--- a/resources/lang/fi/journal.php
+++ b/resources/lang/fi/journal.php
@@ -28,4 +28,11 @@ return [
     'journal_blank_cta' => 'Add your first journal entry',
     'journal_blank_description' => 'The journal lets you write events that happened to you, and remember them.',
     'delete_confirmation' => 'Are you sure you want to delete this journal entry?',
+    'apply_filter' => 'Apply filter',
+    'start_date' => 'Start Date',
+    'end_date' => 'End Date',
+    'per_page' => 'Per Page',
+    'sort_order' => 'Sort Order',
+    'ascending' => 'Ascending',
+    'descending' => 'Descending',
 ];

--- a/resources/lang/fi/journal.php
+++ b/resources/lang/fi/journal.php
@@ -32,7 +32,7 @@ return [
     'start_date' => 'Start Date',
     'end_date' => 'End Date',
     'per_page' => 'Per Page',
-    'sort_order' => 'Sort Order',
+    'sort_order' => 'Sort By Created At',
     'ascending' => 'Ascending',
     'descending' => 'Descending',
 ];

--- a/resources/lang/fr/journal.php
+++ b/resources/lang/fr/journal.php
@@ -28,4 +28,11 @@ return [
     'journal_blank_cta' => 'Ajouter votre première entrée dans le journal',
     'journal_blank_description' => 'Le journal vous permet de vous rappeler d’évènements passés, ou à venir.',
     'delete_confirmation' => 'Êtes-vous sûr de vouloir supprimer cette entrée ?',
+    'apply_filter' => 'Apply filter',
+    'start_date' => 'Start Date',
+    'end_date' => 'End Date',
+    'per_page' => 'Per Page',
+    'sort_order' => 'Sort Order',
+    'ascending' => 'Ascending',
+    'descending' => 'Descending',
 ];

--- a/resources/lang/fr/journal.php
+++ b/resources/lang/fr/journal.php
@@ -32,7 +32,7 @@ return [
     'start_date' => 'Start Date',
     'end_date' => 'End Date',
     'per_page' => 'Per Page',
-    'sort_order' => 'Sort Order',
+    'sort_order' => 'Sort By Created At',
     'ascending' => 'Ascending',
     'descending' => 'Descending',
 ];

--- a/resources/lang/he/journal.php
+++ b/resources/lang/he/journal.php
@@ -28,4 +28,11 @@ return [
     'journal_blank_cta' => 'ניתן להוסיף את רשומת היומן הראשונה שלך',
     'journal_blank_description' => 'היומן מאפשר לך לכתוב אירועים שעברו עליך ולזכור אותם.',
     'delete_confirmation' => 'למחוק את הרשומה הזאת ביומן?',
+    'apply_filter' => 'Apply filter',
+    'start_date' => 'Start Date',
+    'end_date' => 'End Date',
+    'per_page' => 'Per Page',
+    'sort_order' => 'Sort Order',
+    'ascending' => 'Ascending',
+    'descending' => 'Descending',
 ];

--- a/resources/lang/he/journal.php
+++ b/resources/lang/he/journal.php
@@ -32,7 +32,7 @@ return [
     'start_date' => 'Start Date',
     'end_date' => 'End Date',
     'per_page' => 'Per Page',
-    'sort_order' => 'Sort Order',
+    'sort_order' => 'Sort By Created At',
     'ascending' => 'Ascending',
     'descending' => 'Descending',
 ];

--- a/resources/lang/hr/journal.php
+++ b/resources/lang/hr/journal.php
@@ -28,4 +28,11 @@ return [
     'journal_blank_cta' => 'Add your first journal entry',
     'journal_blank_description' => 'The journal lets you write events that happened to you, and remember them.',
     'delete_confirmation' => 'Are you sure you want to delete this journal entry?',
+    'apply_filter' => 'Apply filter',
+    'start_date' => 'Start Date',
+    'end_date' => 'End Date',
+    'per_page' => 'Per Page',
+    'sort_order' => 'Sort Order',
+    'ascending' => 'Ascending',
+    'descending' => 'Descending',
 ];

--- a/resources/lang/hr/journal.php
+++ b/resources/lang/hr/journal.php
@@ -32,7 +32,7 @@ return [
     'start_date' => 'Start Date',
     'end_date' => 'End Date',
     'per_page' => 'Per Page',
-    'sort_order' => 'Sort Order',
+    'sort_order' => 'Sort By Created At',
     'ascending' => 'Ascending',
     'descending' => 'Descending',
 ];

--- a/resources/lang/id/journal.php
+++ b/resources/lang/id/journal.php
@@ -28,4 +28,11 @@ return [
     'journal_blank_cta' => 'Tambahkan entri jurnal pertama Anda',
     'journal_blank_description' => 'Jurnal memungkinkan Anda menulis peristiwa yang terjadi pada Anda, dan mengingatnya.',
     'delete_confirmation' => 'Apakah Anda yakin ingin menghapus entri jurnal ini?',
+    'apply_filter' => 'Apply filter',
+    'start_date' => 'Start Date',
+    'end_date' => 'End Date',
+    'per_page' => 'Per Page',
+    'sort_order' => 'Sort Order',
+    'ascending' => 'Ascending',
+    'descending' => 'Descending',
 ];

--- a/resources/lang/id/journal.php
+++ b/resources/lang/id/journal.php
@@ -32,7 +32,7 @@ return [
     'start_date' => 'Start Date',
     'end_date' => 'End Date',
     'per_page' => 'Per Page',
-    'sort_order' => 'Sort Order',
+    'sort_order' => 'Sort By Created At',
     'ascending' => 'Ascending',
     'descending' => 'Descending',
 ];

--- a/resources/lang/it/journal.php
+++ b/resources/lang/it/journal.php
@@ -28,4 +28,11 @@ return [
     'journal_blank_cta' => 'Scrivi qualcosa nel diario',
     'journal_blank_description' => 'Il diario ti permette di appuntare cose che ti succedono, e ricordarle.',
     'delete_confirmation' => 'Sei sicuro di voler rimuovere questa pagina dal diario?',
+    'apply_filter' => 'Apply filter',
+    'start_date' => 'Start Date',
+    'end_date' => 'End Date',
+    'per_page' => 'Per Page',
+    'sort_order' => 'Sort Order',
+    'ascending' => 'Ascending',
+    'descending' => 'Descending',
 ];

--- a/resources/lang/it/journal.php
+++ b/resources/lang/it/journal.php
@@ -32,7 +32,7 @@ return [
     'start_date' => 'Start Date',
     'end_date' => 'End Date',
     'per_page' => 'Per Page',
-    'sort_order' => 'Sort Order',
+    'sort_order' => 'Sort By Created At',
     'ascending' => 'Ascending',
     'descending' => 'Descending',
 ];

--- a/resources/lang/ja/journal.php
+++ b/resources/lang/ja/journal.php
@@ -28,4 +28,11 @@ return [
     'journal_blank_cta' => 'Add your first journal entry',
     'journal_blank_description' => 'The journal lets you write events that happened to you, and remember them.',
     'delete_confirmation' => 'Are you sure you want to delete this journal entry?',
+    'apply_filter' => 'Apply filter',
+    'start_date' => 'Start Date',
+    'end_date' => 'End Date',
+    'per_page' => 'Per Page',
+    'sort_order' => 'Sort Order',
+    'ascending' => 'Ascending',
+    'descending' => 'Descending',
 ];

--- a/resources/lang/ja/journal.php
+++ b/resources/lang/ja/journal.php
@@ -32,7 +32,7 @@ return [
     'start_date' => 'Start Date',
     'end_date' => 'End Date',
     'per_page' => 'Per Page',
-    'sort_order' => 'Sort Order',
+    'sort_order' => 'Sort By Created At',
     'ascending' => 'Ascending',
     'descending' => 'Descending',
 ];

--- a/resources/lang/nl/journal.php
+++ b/resources/lang/nl/journal.php
@@ -28,4 +28,11 @@ return [
     'journal_blank_cta' => 'Voeg je eerst dagboek-invoer toe',
     'journal_blank_description' => 'Het dagboek laat je gebeurtenissen registreren, zodat je ze kunt onthouden.',
     'delete_confirmation' => 'Weet je zeker dat je deze dagboek-invoer wilt verwijderen?',
+    'apply_filter' => 'Apply filter',
+    'start_date' => 'Start Date',
+    'end_date' => 'End Date',
+    'per_page' => 'Per Page',
+    'sort_order' => 'Sort Order',
+    'ascending' => 'Ascending',
+    'descending' => 'Descending',
 ];

--- a/resources/lang/nl/journal.php
+++ b/resources/lang/nl/journal.php
@@ -32,7 +32,7 @@ return [
     'start_date' => 'Start Date',
     'end_date' => 'End Date',
     'per_page' => 'Per Page',
-    'sort_order' => 'Sort Order',
+    'sort_order' => 'Sort By Created At',
     'ascending' => 'Ascending',
     'descending' => 'Descending',
 ];

--- a/resources/lang/no/journal.php
+++ b/resources/lang/no/journal.php
@@ -28,4 +28,11 @@ return [
     'journal_blank_cta' => 'Legg til din første journaloppføring',
     'journal_blank_description' => 'Journalen lar deg skrive innlegg slik at du husker hva som skjer i løpet av en dag.',
     'delete_confirmation' => 'Er du sikker på at du vil slette denne journaloppføringen?',
+    'apply_filter' => 'Apply filter',
+    'start_date' => 'Start Date',
+    'end_date' => 'End Date',
+    'per_page' => 'Per Page',
+    'sort_order' => 'Sort Order',
+    'ascending' => 'Ascending',
+    'descending' => 'Descending',
 ];

--- a/resources/lang/no/journal.php
+++ b/resources/lang/no/journal.php
@@ -32,7 +32,7 @@ return [
     'start_date' => 'Start Date',
     'end_date' => 'End Date',
     'per_page' => 'Per Page',
-    'sort_order' => 'Sort Order',
+    'sort_order' => 'Sort By Created At',
     'ascending' => 'Ascending',
     'descending' => 'Descending',
 ];

--- a/resources/lang/pt-BR/journal.php
+++ b/resources/lang/pt-BR/journal.php
@@ -28,4 +28,11 @@ return [
     'journal_blank_cta' => 'Adicione sua primeira informação no diário',
     'journal_blank_description' => 'O diário permite que você escreva eventos que aconteceram com você para que lembre-se deles.',
     'delete_confirmation' => 'Tem certeza que deseja excluir este registro do diário?',
+    'apply_filter' => 'Apply filter',
+    'start_date' => 'Start Date',
+    'end_date' => 'End Date',
+    'per_page' => 'Per Page',
+    'sort_order' => 'Sort Order',
+    'ascending' => 'Ascending',
+    'descending' => 'Descending',
 ];

--- a/resources/lang/pt-BR/journal.php
+++ b/resources/lang/pt-BR/journal.php
@@ -32,7 +32,7 @@ return [
     'start_date' => 'Start Date',
     'end_date' => 'End Date',
     'per_page' => 'Per Page',
-    'sort_order' => 'Sort Order',
+    'sort_order' => 'Sort By Created At',
     'ascending' => 'Ascending',
     'descending' => 'Descending',
 ];

--- a/resources/lang/pt/journal.php
+++ b/resources/lang/pt/journal.php
@@ -28,4 +28,11 @@ return [
     'journal_blank_cta' => 'Adicione seu primeiro registro no diário',
     'journal_blank_description' => 'O diário permite que você escreva eventos que aconteceram com você, para te lembrar.',
     'delete_confirmation' => 'Tem certeza que quer apagar esta entrada de diário?',
+    'apply_filter' => 'Apply filter',
+    'start_date' => 'Start Date',
+    'end_date' => 'End Date',
+    'per_page' => 'Per Page',
+    'sort_order' => 'Sort Order',
+    'ascending' => 'Ascending',
+    'descending' => 'Descending',
 ];

--- a/resources/lang/pt/journal.php
+++ b/resources/lang/pt/journal.php
@@ -32,7 +32,7 @@ return [
     'start_date' => 'Start Date',
     'end_date' => 'End Date',
     'per_page' => 'Per Page',
-    'sort_order' => 'Sort Order',
+    'sort_order' => 'Sort By Created At',
     'ascending' => 'Ascending',
     'descending' => 'Descending',
 ];

--- a/resources/lang/ru/journal.php
+++ b/resources/lang/ru/journal.php
@@ -28,4 +28,11 @@ return [
     'journal_blank_cta' => 'Добавить вашу первую запись в журнал',
     'journal_blank_description' => 'В журнал вы можете добавлять записи о событиях в вашей жизни, чтобы сохранить их.',
     'delete_confirmation' => 'Вы уверены что хотите удалить эту запись?',
+    'apply_filter' => 'Apply filter',
+    'start_date' => 'Start Date',
+    'end_date' => 'End Date',
+    'per_page' => 'Per Page',
+    'sort_order' => 'Sort Order',
+    'ascending' => 'Ascending',
+    'descending' => 'Descending',
 ];

--- a/resources/lang/ru/journal.php
+++ b/resources/lang/ru/journal.php
@@ -32,7 +32,7 @@ return [
     'start_date' => 'Start Date',
     'end_date' => 'End Date',
     'per_page' => 'Per Page',
-    'sort_order' => 'Sort Order',
+    'sort_order' => 'Sort By Created At',
     'ascending' => 'Ascending',
     'descending' => 'Descending',
 ];

--- a/resources/lang/sv/journal.php
+++ b/resources/lang/sv/journal.php
@@ -28,4 +28,11 @@ return [
     'journal_blank_cta' => 'Lägg till din första journalpost',
     'journal_blank_description' => 'Tidskriften låter dig skriva händelser som hände dig, och kom ihåg dem.',
     'delete_confirmation' => 'Är du säker på att du vill ta bort denna journalpost?',
+    'apply_filter' => 'Apply filter',
+    'start_date' => 'Start Date',
+    'end_date' => 'End Date',
+    'per_page' => 'Per Page',
+    'sort_order' => 'Sort Order',
+    'ascending' => 'Ascending',
+    'descending' => 'Descending',
 ];

--- a/resources/lang/sv/journal.php
+++ b/resources/lang/sv/journal.php
@@ -32,7 +32,7 @@ return [
     'start_date' => 'Start Date',
     'end_date' => 'End Date',
     'per_page' => 'Per Page',
-    'sort_order' => 'Sort Order',
+    'sort_order' => 'Sort By Created At',
     'ascending' => 'Ascending',
     'descending' => 'Descending',
 ];

--- a/resources/lang/tr/journal.php
+++ b/resources/lang/tr/journal.php
@@ -28,4 +28,11 @@ return [
     'journal_blank_cta' => 'İlk günlük içeriğini yaz',
     'journal_blank_description' => 'Günlük başından geçen olayları yazmanı ve onları tekrar hatırlamanı sağlar.',
     'delete_confirmation' => 'Bu girdiyi silmek istediğinizden emin misiniz?',
+    'apply_filter' => 'Apply filter',
+    'start_date' => 'Start Date',
+    'end_date' => 'End Date',
+    'per_page' => 'Per Page',
+    'sort_order' => 'Sort Order',
+    'ascending' => 'Ascending',
+    'descending' => 'Descending',
 ];

--- a/resources/lang/tr/journal.php
+++ b/resources/lang/tr/journal.php
@@ -32,7 +32,7 @@ return [
     'start_date' => 'Start Date',
     'end_date' => 'End Date',
     'per_page' => 'Per Page',
-    'sort_order' => 'Sort Order',
+    'sort_order' => 'Sort By Created At',
     'ascending' => 'Ascending',
     'descending' => 'Descending',
 ];

--- a/resources/lang/uk/journal.php
+++ b/resources/lang/uk/journal.php
@@ -28,4 +28,11 @@ return [
     'journal_blank_cta' => 'Add your first journal entry',
     'journal_blank_description' => 'The journal lets you write events that happened to you, and remember them.',
     'delete_confirmation' => 'Are you sure you want to delete this journal entry?',
+    'apply_filter' => 'Apply filter',
+    'start_date' => 'Start Date',
+    'end_date' => 'End Date',
+    'per_page' => 'Per Page',
+    'sort_order' => 'Sort Order',
+    'ascending' => 'Ascending',
+    'descending' => 'Descending',
 ];

--- a/resources/lang/uk/journal.php
+++ b/resources/lang/uk/journal.php
@@ -32,7 +32,7 @@ return [
     'start_date' => 'Start Date',
     'end_date' => 'End Date',
     'per_page' => 'Per Page',
-    'sort_order' => 'Sort Order',
+    'sort_order' => 'Sort By Created At',
     'ascending' => 'Ascending',
     'descending' => 'Descending',
 ];

--- a/resources/lang/vi/journal.php
+++ b/resources/lang/vi/journal.php
@@ -28,4 +28,11 @@ return [
     'journal_blank_cta' => 'Thêm mục nhật ký đầu tiên của bạn',
     'journal_blank_description' => 'Nhật ký cho phép bạn viết sự kiện đã xảy ra với bạn, và ghi nhớ chúng.',
     'delete_confirmation' => 'Bạn chắc chắn muốn xóa mục nhật ký này?',
+    'apply_filter' => 'Apply filter',
+    'start_date' => 'Start Date',
+    'end_date' => 'End Date',
+    'per_page' => 'Per Page',
+    'sort_order' => 'Sort Order',
+    'ascending' => 'Ascending',
+    'descending' => 'Descending',
 ];

--- a/resources/lang/vi/journal.php
+++ b/resources/lang/vi/journal.php
@@ -32,7 +32,7 @@ return [
     'start_date' => 'Start Date',
     'end_date' => 'End Date',
     'per_page' => 'Per Page',
-    'sort_order' => 'Sort Order',
+    'sort_order' => 'Sort By Created At',
     'ascending' => 'Ascending',
     'descending' => 'Descending',
 ];

--- a/resources/lang/zh-TW/journal.php
+++ b/resources/lang/zh-TW/journal.php
@@ -28,4 +28,11 @@ return [
     'journal_blank_cta' => '新增您的第一個記錄條目',
     'journal_blank_description' => '記錄允許您編寫發生在您身上的事件, 並記住它們。',
     'delete_confirmation' => '您確定要刪除此條目嗎？',
+    'apply_filter' => 'Apply filter',
+    'start_date' => 'Start Date',
+    'end_date' => 'End Date',
+    'per_page' => 'Per Page',
+    'sort_order' => 'Sort Order',
+    'ascending' => 'Ascending',
+    'descending' => 'Descending',
 ];

--- a/resources/lang/zh-TW/journal.php
+++ b/resources/lang/zh-TW/journal.php
@@ -32,7 +32,7 @@ return [
     'start_date' => 'Start Date',
     'end_date' => 'End Date',
     'per_page' => 'Per Page',
-    'sort_order' => 'Sort Order',
+    'sort_order' => 'Sort By Created At',
     'ascending' => 'Ascending',
     'descending' => 'Descending',
 ];

--- a/resources/lang/zh/journal.php
+++ b/resources/lang/zh/journal.php
@@ -28,4 +28,11 @@ return [
     'journal_blank_cta' => '添加您的第一个记录条目',
     'journal_blank_description' => '记录允许您编写发生在您身上的事件, 并记住它们。',
     'delete_confirmation' => '您确定要删除此条目吗？',
+    'apply_filter' => 'Apply filter',
+    'start_date' => 'Start Date',
+    'end_date' => 'End Date',
+    'per_page' => 'Per Page',
+    'sort_order' => 'Sort Order',
+    'ascending' => 'Ascending',
+    'descending' => 'Descending',
 ];

--- a/resources/lang/zh/journal.php
+++ b/resources/lang/zh/journal.php
@@ -32,7 +32,7 @@ return [
     'start_date' => 'Start Date',
     'end_date' => 'End Date',
     'per_page' => 'Per Page',
-    'sort_order' => 'Sort Order',
+    'sort_order' => 'Sort By Created At',
     'ascending' => 'Ascending',
     'descending' => 'Descending',
 ];


### PR DESCRIPTION
Based on Issue #6445 , it appears that users are facing difficulties accessing older activities in the application.

In my pull request, I have proposed a solution by introducing a filter that allows users to navigate and access older activities in the journal. This enhancement would greatly improve the user experience by providing a means to conveniently access older activities that may have been missed or require modifications.

![Untitled](https://github.com/monicahq/monica/assets/74875624/c4345aa5-e135-4eff-b66f-824a3eaf9b74)

Thanks.

PART OF GTC OPEN SOURCE INTIATIVE