### PR TITLE
chore: fix issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,9 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
 ## Bug description
 
 *Please describe.*


### PR DESCRIPTION
Currently the issue template is not used and the template chooser does not work.
https://github.com/monicahq/monica/issues/new/choose

Docs: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository