### PR TITLE
refactor: remove useless condition

### DIFF
--- a/app/Services/BaseService.php
+++ b/app/Services/BaseService.php
@@ -274,6 +274,6 @@ abstract class BaseService
             return;
         }
 
-        return $data[$index] == '' ? null : $data[$index];
+        return $data[$index];
     }
 }


### PR DESCRIPTION
When value is empty string, it's caught in empty check condition and return null.
So suggest removing useless condition.

```
$val = '';
var_dump(empty($val)); // true
var_dump($val == '');  // true
```