### PR TITLE
fix: fix default timezone can't be empty

### DIFF
--- a/app/Helpers/CountriesHelper.php
+++ b/app/Helpers/CountriesHelper.php
@@ -198,6 +198,6 @@ class CountriesHelper
                 break;
         }
 
-        return $timezone;
+        return $timezone ?? config('app.timezone');
     }
 }


### PR DESCRIPTION
Fix  #6991