### PR TITLE
refactor: Update MultiAvatar.php, solving a SonarCloud bug

### DIFF
--- a/app/Models/MultiAvatar.php
+++ b/app/Models/MultiAvatar.php
@@ -25,9 +25,8 @@ class MultiAvatar
 
     public function __invoke($avatarId, $sansEnv, $ver)
     {
-        $svgCode = $this->generate(strval($avatarId), $sansEnv, $ver);
 
-        return $svgCode;
+        return $this->generate(strval($avatarId), $sansEnv, $ver);
     }
 
     public function getFinal($part, $partV, $theme, $themes, $sP)


### PR DESCRIPTION
I've changed the return in line 29, of function  __invoke($avatarId, $sansEnv, $ver), which returned a variable that had been assigned to a value on the previous line, so that the returns gives the value directly

