### PR TITLE
feat(journal): add date support to API

### DIFF
--- a/app/Http/Controllers/Api/ApiJournalController.php
+++ b/app/Http/Controllers/Api/ApiJournalController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api;
 use App\Http\Resources\Journal\Entry as JournalResource;
 use App\Models\Journal\Entry;
 use App\Services\Journal\CreateEntry;
+use App\Services\Journal\DestroyEntry;
 use App\Services\Journal\UpdateEntry;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Database\QueryException;
@@ -115,15 +116,16 @@ class ApiJournalController extends ApiController
     public function destroy(Request $request, $entryId)
     {
         try {
-            $entry = Entry::where('account_id', auth()->user()->account_id)
-                ->where('id', $entryId)
-                ->firstOrFail();
+            app(DestroyEntry::class)->execute([
+                'account_id' => auth()->user()->account_id,
+                'id' => $entryId,
+            ]);
         } catch (ModelNotFoundException $e) {
             return $this->respondNotFound();
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         }
 
-        $entry->delete();
-
-        return $this->respondObjectDeleted($entry->id);
+        return $this->respondObjectDeleted($entryId);
     }
 }

--- a/app/Http/Controllers/Api/ApiJournalController.php
+++ b/app/Http/Controllers/Api/ApiJournalController.php
@@ -2,12 +2,14 @@
 
 namespace App\Http\Controllers\Api;
 
-use Illuminate\Http\Request;
-use App\Models\Journal\Entry;
-use Illuminate\Database\QueryException;
-use Illuminate\Support\Facades\Validator;
 use App\Http\Resources\Journal\Entry as JournalResource;
+use App\Models\Journal\Entry;
+use App\Services\Journal\CreateEntry;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\QueryException;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
 
 class ApiJournalController extends ApiController
 {
@@ -49,32 +51,34 @@ class ApiJournalController extends ApiController
     }
 
     /**
-     * Store the call.
+     * Store the entry.
      *
      * @param  Request  $request
      * @return JournalResource|\Illuminate\Http\JsonResponse
      */
     public function store(Request $request)
     {
-        $isvalid = $this->validateUpdate($request);
-        if ($isvalid !== true) {
-            return $isvalid;
-        }
-
         try {
-            $entry = Entry::create(
+            $entry = app(CreateEntry::class)->execute(
                 $request->except(['account_id'])
-                + ['account_id' => auth()->user()->account_id]
+                +
+                [
+                    'account_id' => auth()->user()->account_id,
+                ]
             );
+        } catch (ModelNotFoundException $e) {
+            return $this->respondNotFound();
+        } catch (ValidationException $e) {
+            return $this->respondValidatorFailed($e->validator);
         } catch (QueryException $e) {
-            return $this->respondNotTheRightParameters();
+            return $this->respondInvalidQuery();
         }
 
         return new JournalResource($entry);
     }
 
     /**
-     * Update the note.
+     * Update the entry.
      *
      * @param  Request  $request
      * @param  int  $entryId

--- a/app/Http/Controllers/JournalController.php
+++ b/app/Http/Controllers/JournalController.php
@@ -3,13 +3,16 @@
 namespace App\Http\Controllers;
 
 use App\Helpers\DateHelper;
-use App\Models\Journal\Day;
-use Illuminate\Http\Request;
-use App\Models\Journal\Entry;
 use App\Helpers\JournalHelper;
-use App\Models\Journal\JournalEntry;
-use Illuminate\Support\Facades\Validator;
 use App\Http\Requests\Journal\DaysRequest;
+use App\Models\Journal\Day;
+use App\Models\Journal\Entry;
+use App\Models\Journal\JournalEntry;
+use App\Services\Journal\CreateEntry;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
+use Throwable;
 
 class JournalController extends Controller
 {
@@ -33,12 +36,12 @@ class JournalController extends Controller
 
         $startDate = $request->input('start_date');
         $endDate = $request->input('end_date');
-        $sortBy = $request->input('sort_by', 'created_at'); 
-        $sortOrder = $request->input('sort_order', 'desc'); 
+        $sortBy = $request->input('sort_by', 'created_at');
+        $sortOrder = $request->input('sort_order', 'desc');
         $perPage = $request->input('per_page', 30);
 
         $entries = collect([]);
-        
+
         $journalEntriesQuery = auth()->user()->account->journalEntries();
 
         if ($startDate && $endDate) {
@@ -46,7 +49,7 @@ class JournalController extends Controller
                 ->whereDate('date', '<=', $endDate);
         }
         $journalEntries = $journalEntriesQuery->orderBy($sortBy, $sortOrder)
-        ->paginate($perPage);
+            ->paginate($perPage);
 
 
         // this is needed to determine if we need to display the calendar
@@ -90,7 +93,7 @@ class JournalController extends Controller
     /**
      * Gets the details of a single Journal Entry.
      *
-     * @param  JournalEntry  $journalEntry
+     * @param JournalEntry $journalEntry
      * @return array
      */
     public function get(JournalEntry $journalEntry)
@@ -160,35 +163,28 @@ class JournalController extends Controller
     /**
      * Saves the journal entry.
      *
-     * @param  Request  $request
+     * @param Request $request
      * @return \Illuminate\Http\RedirectResponse
      */
     public function save(Request $request)
     {
-        $validator = Validator::make($request->all(), [
-            'entry' => 'required|string',
-            'date' => 'required|date',
-        ]);
-
-        if ($validator->fails()) {
+        try {
+            app(CreateEntry::class)->execute(
+                $request->except(['account_id'])
+                +
+                [
+                    'account_id' => $request->user()->account_id,
+                    'post' => $request->input('entry'),
+                ]
+            );
+        } catch (ValidationException $e) {
             return back()
                 ->withInput()
-                ->withErrors($validator);
+                ->withErrors($e->validator);
+        } catch (Throwable $e) {
+            return back()
+                ->withInput();
         }
-
-        $entry = new Entry;
-        $entry->account_id = $request->user()->account_id;
-        $entry->post = $request->input('entry');
-
-        if ($request->input('title') != '') {
-            $entry->title = $request->input('title');
-        }
-
-        $entry->save();
-
-        $entry->date = $request->input('date');
-        // Log a journal entry
-        JournalEntry::add($entry);
 
         return redirect()->route('journal.index');
     }
@@ -196,7 +192,7 @@ class JournalController extends Controller
     /**
      * Display the Edit journal entry screen.
      *
-     * @param  Entry  $entry
+     * @param Entry $entry
      * @return \Illuminate\View\View
      */
     public function edit(Entry $entry)
@@ -204,12 +200,12 @@ class JournalController extends Controller
         return view('journal.edit')
             ->withEntry($entry);
     }
-    
+
     /**
      * Method updateDay
      *
      * @param Request $request
-     * @param Day $day 
+     * @param Day $day
      *
      */
     public function updateDay(Request $request, Day $day)
@@ -226,7 +222,7 @@ class JournalController extends Controller
     /**
      * Update a journal entry.
      *
-     * @param  Request  $request
+     * @param Request $request
      * @return \Illuminate\Http\RedirectResponse
      */
     public function update(Request $request, Entry $entry)

--- a/app/Http/Controllers/JournalController.php
+++ b/app/Http/Controllers/JournalController.php
@@ -9,6 +9,7 @@ use App\Models\Journal\Day;
 use App\Models\Journal\Entry;
 use App\Models\Journal\JournalEntry;
 use App\Services\Journal\CreateEntry;
+use App\Services\Journal\DestroyEntry;
 use App\Services\Journal\UpdateEntry;
 use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
@@ -250,13 +251,18 @@ class JournalController extends Controller
     }
 
     /**
-     * Delete the reminder.
+     * Delete the journal entry.
      */
     public function deleteEntry(Request $request, Entry $entry)
     {
-        $entry->deleteJournalEntry();
-        $entry->delete();
-
-        return ['true'];
+        try {
+            app(DestroyEntry::class)->execute([
+                'account_id' => $request->user()->account_id,
+                'id' => $entry->id,
+            ]);
+            return ['true'];
+        } catch (Throwable $e) {
+            return ['false'];
+        }
     }
 }

--- a/app/Models/Journal/Entry.php
+++ b/app/Models/Journal/Entry.php
@@ -35,7 +35,15 @@ class Entry extends Model implements IsJournalableInterface
         'account_id',
         'title',
         'post',
+        'date',
     ];
+
+    /**
+     * The attributes that should be mutated to dates.
+     *
+     * @var array<string>
+     */
+    protected $dates = ['date'];
 
     /**
      * Get the account record associated with the entry.
@@ -45,18 +53,6 @@ class Entry extends Model implements IsJournalableInterface
     public function account()
     {
         return $this->belongsTo(Account::class);
-    }
-
-    /**
-     * Get the Entry date.
-     *
-     * @param  string  $value
-     * @return \Carbon\Carbon
-     */
-    public function getDateAttribute($value)
-    {
-        // Default to created_at, but show journalEntry->date if the entry type is JournalEntry
-        return $this->journalEntry ? $this->journalEntry->date : $this->created_at;
     }
 
     /**

--- a/app/Models/Journal/JournalEntry.php
+++ b/app/Models/Journal/JournalEntry.php
@@ -76,7 +76,7 @@ class JournalEntry extends Model
         if ($resourceToLog instanceof \App\Models\Account\Activity) {
             $journal->date = $resourceToLog->happened_at;
         } elseif ($resourceToLog instanceof \App\Models\Journal\Entry) {
-            $journal->date = $resourceToLog->attributes['date'];
+            $journal->date = $resourceToLog->date;
         }
         $journal->save();
         $resourceToLog->journalEntries()->save($journal);

--- a/app/Services/Journal/CreateEntry.php
+++ b/app/Services/Journal/CreateEntry.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Services\Journal;
+
+use App\Models\Journal\Entry;
+use App\Models\Journal\JournalEntry;
+use App\Services\BaseService;
+
+class CreateEntry extends BaseService
+{
+    /**
+     * Get the validation rules that apply to the service.
+     *
+     * @return array
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => 'nullable|max:255',
+            'post' => 'required|max:1000000',
+            'date' => 'required|date|date_format:Y-m-d',
+        ];
+    }
+
+    /**
+     * Create an entry.
+     *
+     * @param  array  $data
+     * @return Entry
+     */
+    public function execute(array $data): Entry
+    {
+        $this->validate($data);
+
+        $entry = $this->create($data);
+
+        // Log a journal entry
+        JournalEntry::add($entry);
+
+        return $entry;
+    }
+
+    /**
+     * Create the entry.
+     *
+     * @param  array  $data
+     * @return Entry
+     */
+    private function create(array $data): Entry
+    {
+        return Entry::create([
+            'account_id' => $data['account_id'],
+            'title' => $this->nullOrValue($data, 'title'),
+            'post' => $data['post'],
+            'date' => $data['date'],
+        ]);
+    }
+}

--- a/app/Services/Journal/DestroyEntry.php
+++ b/app/Services/Journal/DestroyEntry.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Services\Journal;
+
+use App\Models\Journal\Entry;
+use App\Services\BaseService;
+
+class DestroyEntry extends BaseService
+{
+    /**
+     * Get the validation rules that apply to the service.
+     *
+     * @return array
+     */
+    public function rules(): array
+    {
+        return [
+            'account_id' => 'required|integer|exists:accounts,id',
+            'id' => 'required|integer|exists:entries,id',
+        ];
+    }
+
+    /**
+     * Destroy an entry.
+     *
+     * @param array $data
+     * @return bool
+     */
+    public function execute(array $data): bool
+    {
+        $this->validate($data);
+
+        $entry = Entry::where('account_id', $data['account_id'])
+            ->where('id', $data['id'])
+            ->firstOrFail();
+
+        $entry->deleteJournalEntry();
+
+        $entry->delete();
+
+        return true;
+    }
+
+    /**
+     * Validate all datas to execute the service.
+     *
+     * @param array $data
+     * @return bool
+     */
+    public function validate(array $data): bool
+    {
+        parent::validate($data);
+
+        Entry::where('account_id', $data['account_id'])
+            ->findOrFail($data['id']);
+
+        return true;
+    }
+}

--- a/app/Services/Journal/UpdateEntry.php
+++ b/app/Services/Journal/UpdateEntry.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Services\Journal;
+
+use App\Models\Journal\Entry;
+use App\Models\Journal\JournalEntry;
+use App\Services\BaseService;
+
+class UpdateEntry extends BaseService
+{
+    /**
+     * Get the validation rules that apply to the service.
+     *
+     * @return array
+     */
+    public function rules(): array
+    {
+        return [
+            'account_id' => 'required|integer|exists:accounts,id',
+            'id' => 'required|integer|exists:entries,id',
+            'title' => 'nullable|max:255',
+            'post' => 'required|max:1000000',
+            'date' => 'required|date|date_format:Y-m-d',
+        ];
+    }
+
+    /**
+     * Update an entry.
+     */
+    public function execute(array $data): Entry
+    {
+        $this->validate($data);
+
+        $entry = Entry::where('account_id', $data['account_id'])
+            ->where('id', $data['id'])
+            ->firstOrFail();
+
+        $this->update($data, $entry);
+
+        // Log a journal entry but need to delete the previous one first
+        $entry->deleteJournalEntry();
+        JournalEntry::add($entry);
+
+        return $entry->refresh();
+    }
+
+    /**
+     * Validate the update.
+     */
+    public function validate(array $data): bool
+    {
+        parent::validate($data);
+
+        Entry::where('account_id', $data['account_id'])
+            ->findOrFail($data['id']);
+
+        return true;
+    }
+
+    /**
+     * Update the entry.
+     */
+    private function update(array $data, Entry $entry): void
+    {
+        $entry->update([
+            'title' => $this->nullOrValue($data, 'title'),
+            'post' => $data['post'],
+            'date' => $data['date'],
+        ]);
+
+    }
+}

--- a/database/migrations/2024_05_09_215722_add_date_to_entries.php
+++ b/database/migrations/2024_05_09_215722_add_date_to_entries.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('entries', function (Blueprint $table) {
+            // Add the new date column
+            $table->date('date')->after('account_id');
+        });
+
+        // Copy the date from journal_entries table and populate the new column
+        DB::table('entries')
+            ->join('journal_entries', function ($join) {
+                $join->on('entries.id', '=', 'journal_entries.journalable_id')
+                    ->where('journal_entries.journalable_type', '=', 'App\Models\Journal\Entry');
+            })
+            ->update(['entries.date' => DB::raw('journal_entries.date')]);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('entries', function (Blueprint $table) {
+            $table->dropColumn('date');
+        });
+    }
+};

--- a/tests/Api/ApiJournalTest.php
+++ b/tests/Api/ApiJournalTest.php
@@ -15,6 +15,7 @@ class ApiJournalTest extends ApiTestCase
         'object',
         'title',
         'post',
+        'date',
         'account' => [
             'id',
         ],
@@ -94,6 +95,7 @@ class ApiJournalTest extends ApiTestCase
         $response = $this->json('POST', '/api/journal', [
             'title' => 'my title',
             'post' => 'content post',
+            'date' => '2024-01-01',
         ]);
 
         $response->assertStatus(201);
@@ -106,6 +108,7 @@ class ApiJournalTest extends ApiTestCase
             'id' => $entryId,
             'title' => 'my title',
             'post' => 'content post',
+            'date' => '2024-01-01T00:00:00.000000Z',
         ]);
 
         $this->assertGreaterThan(0, $entryId);
@@ -114,6 +117,7 @@ class ApiJournalTest extends ApiTestCase
             'id' => $entryId,
             'title' => 'my title',
             'post' => 'content post',
+            'date' => '2024-01-01',
         ]);
     }
 
@@ -125,8 +129,8 @@ class ApiJournalTest extends ApiTestCase
         $response = $this->json('POST', '/api/journal', []);
 
         $this->expectDataError($response, [
-            'The title field is required.',
             'The post field is required.',
+            'The date field is required.',
         ]);
     }
 
@@ -136,12 +140,14 @@ class ApiJournalTest extends ApiTestCase
         $user = $this->signin();
         $entry = factory(Entry::class)->create([
             'account_id' => $user->account_id,
-            'title' => 'xxx',
+            'post' => 'xxx',
+            'date' => '2024-01-01',
         ]);
 
         $response = $this->json('PUT', '/api/journal/'.$entry->id, [
             'title' => 'my title',
             'post' => 'content post',
+            'date' => '2024-01-02',
         ]);
 
         $response->assertStatus(200);
@@ -155,6 +161,7 @@ class ApiJournalTest extends ApiTestCase
             'id' => $entryId,
             'title' => 'my title',
             'post' => 'content post',
+            'date' => '2024-01-02T00:00:00.000000Z',
         ]);
 
         $this->assertGreaterThan(0, $entryId);
@@ -163,6 +170,7 @@ class ApiJournalTest extends ApiTestCase
             'id' => $entryId,
             'title' => 'my title',
             'post' => 'content post',
+            'date' => '2024-01-02',
         ]);
     }
 
@@ -177,8 +185,8 @@ class ApiJournalTest extends ApiTestCase
         $response = $this->json('PUT', '/api/journal/'.$entry->id, []);
 
         $this->expectDataError($response, [
-            'The title field is required.',
             'The post field is required.',
+            'The date field is required.',
         ]);
     }
 
@@ -210,6 +218,8 @@ class ApiJournalTest extends ApiTestCase
 
         $response = $this->json('DELETE', '/api/journal/0');
 
-        $this->expectNotFound($response);
+        $this->expectDataError($response, [
+            'The selected id is invalid.',
+        ]);
     }
 }

--- a/tests/Feature/JournalEntryTest.php
+++ b/tests/Feature/JournalEntryTest.php
@@ -43,9 +43,9 @@ class JournalEntryTest extends FeatureTestCase
             'account_id' => $user->account_id,
             'title' => 'This is the title',
             'post' => 'this is a post',
+            'date' => '2017-01-01',
         ]);
-        $entry->date = '2017-01-01';
-        $journalEntry = JournalEntry::add($entry);
+        JournalEntry::add($entry);
 
         $params = [
             'entry' => 'Good day',

--- a/tests/Unit/Models/EntryTest.php
+++ b/tests/Unit/Models/EntryTest.php
@@ -17,7 +17,8 @@ class EntryTest extends TestCase
             'id' => 1,
             'title' => 'This is the title',
             'post' => 'this is a post',
-            'created_at' => '2017-01-01 00:00:00',
+            'date' => '2017-01-01',
+            'created_at' => '2024-01-01 00:00:00',
         ]);
 
         $data = [
@@ -31,7 +32,7 @@ class EntryTest extends TestCase
             'month_name' => 'JAN',
             'year' => 2017,
             'date' => '2017-01-01 00:00:00',
-            'created_at' => 'Jan 01, 2017 00:00',
+            'created_at' => 'Jan 01, 2024 00:00',
         ];
 
         $this->assertEquals(


### PR DESCRIPTION
These changes add the ability to specify a date when creating a journal entry through the API, or more accurately require it. The functionality is there when using the web but it was missing from the API. The title is now also optional through the API to match the web functionality.

Additionally, I've also standardised creating, updating, and deleting of entries across the web and API controllers. This follows the pattern that is used for activities.

A migration was added that copies the date from the `journal_entries.date` into the newly added `entries.date` field, which should be equivalent from what I understand.

For more context, I'm a big fan of Monica and I found this missing functionality when trying to use the API to build an Android client. I've never worked with PHP or done web dev before but this was essential functionality for the app so thought I'd give this a shot 👀  Because of that please let me know if anything is missing or inconsistent!