### PR TITLE
fix: fix job information cant be saved

### DIFF
--- a/app/Domains/Contact/ManageJobInformation/Services/UpdateJobInformation.php
+++ b/app/Domains/Contact/ManageJobInformation/Services/UpdateJobInformation.php
@@ -23,7 +23,7 @@ class UpdateJobInformation extends BaseService implements ServiceInterface
             'vault_id' => 'required|uuid|exists:vaults,id',
             'author_id' => 'required|uuid|exists:users,id',
             'contact_id' => 'required|uuid|exists:contacts,id',
-            'company_id' => 'nullable|integer|exists:companies,id',
+            'company_id' => 'nullable|integer',
             'job_position' => 'nullable|string|max:255',
         ];
     }


### PR DESCRIPTION
If the company id is not provided, the job information can't be saved, even though the information is optional.

We should get rid off this bug.

