### PR TITLE
feat: use lucide icon instead of svg

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "laravel-vue-i18n": "^2.7.8",
     "lint-staged": "^15.4.3",
     "lodash": "^4.17.21",
+    "lucide-vue-next": "^0.475.0",
     "mitt": "^3.0.1",
     "prettier": "^3.4.2",
     "prettier-plugin-tailwindcss": "^0.6.11",

--- a/resources/js/Pages/Vault/Calendar/Index.vue
+++ b/resources/js/Pages/Vault/Calendar/Index.vue
@@ -4,7 +4,7 @@ import { Link } from '@inertiajs/vue3';
 import { Tooltip as ATooltip } from 'ant-design-vue';
 import Layout from '@/Shared/Layout.vue';
 import ContactCard from '@/Shared/ContactCard.vue';
-
+import { ChevronLeft, ChevronRight } from 'lucide-vue-next';
 defineProps({
   layoutData: Object,
   data: Object,
@@ -42,57 +42,42 @@ const get = (day) => {
                 <div class="inline-flex rounded-md shadow-xs">
                   <Link
                     :href="data.url.previous"
-                    class="inline-flex items-center rounded-s-lg border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-900 hover:bg-gray-100 hover:text-blue-700 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600 dark:hover:text-white dark:focus:text-white dark:focus:ring-blue-500">
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke-width="1.5"
-                      stroke="currentColor"
-                      class="me-2 h-4 w-4">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
-                    </svg>
+                    class="flex items-center gap-2 rounded-s-lg border border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-900 hover:bg-gray-100 hover:text-blue-700 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600 dark:hover:text-white dark:focus:text-white dark:focus:ring-blue-500">
+                    <ChevronLeft class="h-4 w-4" />
 
                     {{ data.previous_month }}
                   </Link>
 
                   <Link
                     :href="data.url.next"
-                    class="inline-flex items-center rounded-e-md border-y border-e border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-900 hover:bg-gray-100 hover:text-blue-700 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600 dark:hover:text-white dark:focus:text-white dark:focus:ring-blue-500">
+                    class="flex items-center gap-2 rounded-e-md border-y border-e border-gray-200 bg-white px-4 py-2 text-sm font-medium text-gray-900 hover:bg-gray-100 hover:text-blue-700 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:hover:bg-gray-600 dark:hover:text-white dark:focus:text-white dark:focus:ring-blue-500">
                     {{ data.next_month }}
 
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke-width="1.5"
-                      stroke="currentColor"
-                      class="ms-2 h-4 w-4">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
-                    </svg>
+                    <ChevronRight class="h-4 w-4" />
                   </Link>
                 </div>
               </div>
             </div>
 
             <!-- days -->
-            <div class="grid grid-cols-7 rounded-t-lg border-x border-t last:border-b dark:border-gray-700">
-              <div class="border-e p-2 text-center text-xs dark:border-gray-700">
+            <div
+              class="grid grid-cols-7 rounded-t-lg border-x border-t border-gray-200 last:border-b dark:border-gray-700">
+              <div class="border-e border-gray-200 p-2 text-center text-xs dark:border-gray-700">
                 {{ $t('Monday') }}
               </div>
-              <div class="border-e p-2 text-center text-xs dark:border-gray-700">
+              <div class="border-e border-gray-200 p-2 text-center text-xs dark:border-gray-700">
                 {{ $t('Tuesday') }}
               </div>
-              <div class="border-e p-2 text-center text-xs dark:border-gray-700">
+              <div class="border-e border-gray-200 p-2 text-center text-xs dark:border-gray-700">
                 {{ $t('Wednesday') }}
               </div>
-              <div class="border-e p-2 text-center text-xs dark:border-gray-700">
+              <div class="border-e border-gray-200 p-2 text-center text-xs dark:border-gray-700">
                 {{ $t('Thursday') }}
               </div>
-              <div class="border-e p-2 text-center text-xs dark:border-gray-700">
+              <div class="border-e border-gray-200 p-2 text-center text-xs dark:border-gray-700">
                 {{ $t('Friday') }}
               </div>
-              <div class="border-e p-2 text-center text-xs dark:border-gray-700">
+              <div class="border-e border-gray-200 p-2 text-center text-xs dark:border-gray-700">
                 {{ $t('Saturday') }}
               </div>
               <div class="p-2 text-center text-xs">{{ $t('Sunday') }}</div>
@@ -102,12 +87,12 @@ const get = (day) => {
             <div
               v-for="week in data.weeks"
               :key="week.id"
-              class="grid grid-cols-7 border-x border-t last:rounded-b-lg last:border-b dark:border-gray-700">
+              class="grid grid-cols-7 border-x border-t border-gray-200 last:rounded-b-lg last:border-b dark:border-gray-700">
               <div
                 v-for="day in week"
                 :key="day.id"
                 @click="get(day)"
-                class="h-32 border-e p-2 last:border-e-0 dark:border-gray-700"
+                class="h-32 border-e border-gray-200 p-2 last:border-e-0 dark:border-gray-700"
                 :class="day.is_in_month ? 'cursor-pointer' : 'bg-slate-50 dark:bg-slate-900'">
                 <!-- date of the day -->
                 <div class="flex items-center justify-between">

--- a/resources/js/Pages/Vault/Contact/Index.vue
+++ b/resources/js/Pages/Vault/Contact/Index.vue
@@ -34,10 +34,7 @@ const update = () => {
           <div>
             <!-- labels -->
             <div class="mb-8">
-              <div class="mb-3 border-b border-gray-200 dark:border-gray-700">
-                <span class="me-1"> 🏷️ </span>
-                {{ $t('Labels') }}
-              </div>
+              <div class="mb-3 border-b border-gray-200 dark:border-gray-700">{{ $t('Labels') }}</div>
               <ul v-if="data.labels.length > 0">
                 <li class="mb-1">
                   <div v-if="data.current_label">
@@ -72,10 +69,7 @@ const update = () => {
           <div class="p-3 sm:px-3 sm:py-0">
             <!-- title + cta -->
             <div class="mb-3 flex items-center justify-between">
-              <h3>
-                <span class="me-1"> 🥸 </span>
-                {{ $t('All contacts in the vault') }}
-              </h3>
+              <h3>{{ $t('All contacts in the vault') }}</h3>
 
               <div class="flex items-center">
                 <dropdown

--- a/resources/js/Pages/Vault/Contact/Show.vue
+++ b/resources/js/Pages/Vault/Contact/Show.vue
@@ -36,6 +36,7 @@ import Posts from '@/Shared/Modules/Posts.vue';
 import LifeEvent from '@/Shared/Modules/LifeEvent.vue';
 import QuickFacts from '@/Shared/Modules/QuickFacts.vue';
 import Uploadcare from '@/Components/Uploadcare.vue';
+import { ChevronRight } from 'lucide-vue-next';
 
 const props = defineProps({
   layoutData: Object,
@@ -170,37 +171,28 @@ const navigateToSelected = () => {
 <template>
   <Layout :layout-data="layoutData" :inside-vault="true">
     <!-- breadcrumb -->
-    <nav class="bg-white dark:bg-gray-900 sm:mt-20 sm:border-b">
+    <nav class="bg-white dark:bg-gray-900 sm:mt-20 sm:border-b sm:border-gray-300 dark:border-gray-700">
       <div class="max-w-8xl mx-auto hidden px-4 py-2 sm:px-6 md:block">
-        <div class="flex items-baseline justify-between space-x-6">
-          <ul class="text-sm">
-            <li class="me-2 inline text-gray-600 dark:text-gray-400">
-              {{ $t('You are here:') }}
-            </li>
-            <li class="me-2 inline">
-              <Link :href="layoutData.vault.url.contacts" class="text-blue-500 hover:underline">
-                {{ $t('Contacts') }}
-              </Link>
-            </li>
-            <li class="relative me-2 inline">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                class="icon-breadcrumb relative inline h-3 w-3"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-              </svg>
-            </li>
-            <li class="inline">
-              {{ $t('Profile of :name', { name: data.contact_name.name }) }}
-            </li>
-          </ul>
+        <div class="flex items-center gap-1 text-sm">
+          <div class="text-gray-600 dark:text-gray-400">
+            {{ $t('You are here:') }}
+          </div>
+          <div class="inline">
+            <Link :href="layoutData.vault.url.contacts" class="text-blue-500 hover:underline">
+              {{ $t('Contacts') }}
+            </Link>
+          </div>
+          <div class="relative inline">
+            <ChevronRight class="h-3 w-3" />
+          </div>
+          <div class="inline">
+            {{ $t('Profile of :name', { name: data.contact_name.name }) }}
+          </div>
         </div>
       </div>
     </nav>
 
-    <main class="sm:mt-18 relative">
+    <main class="sm:mt-8 relative">
       <div class="mx-auto max-w-6xl px-2 py-2 sm:px-6 sm:py-6 lg:px-8">
         <!-- banner if contact is archived -->
         <!-- this is based on the `listed` boolean on the contact object -->

--- a/resources/js/Pages/Vault/Dashboard/Index.vue
+++ b/resources/js/Pages/Vault/Dashboard/Index.vue
@@ -10,6 +10,7 @@ import LifeMetrics from '@/Pages/Vault/Dashboard/Partials/LifeMetrics.vue';
 import MoodTrackingEvents from '@/Pages/Vault/Dashboard/Partials/MoodTrackingEvents.vue';
 import Feed from '@/Shared/Modules/Feed.vue';
 import LifeEvent from '@/Shared/Modules/LifeEvent.vue';
+import { SquareActivity, Flame, ChartSpline } from 'lucide-vue-next';
 
 const props = defineProps({
   layoutData: Object,
@@ -67,19 +68,8 @@ const changeTab = (tab) => {
                       ? 'bg-gray-100 text-blue-700 dark:bg-gray-900 dark:text-blue-300'
                       : 'bg-white text-gray-900 dark:bg-gray-700 dark:text-white'
                   "
-                  class="inline-flex items-center rounded-s-lg border-y border-s border-gray-200 px-4 py-2 text-sm font-medium hover:bg-gray-100 hover:text-blue-700 dark:border-gray-600 dark:hover:bg-gray-600 dark:hover:text-blue-300 dark:focus:ring-blue-500">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke-width="1.5"
-                    stroke="currentColor"
-                    class="me-2 h-4 w-4 fill-current">
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      d="M21 7.5l-2.25-1.313M21 7.5v2.25m0-2.25l-2.25 1.313M3 7.5l2.25-1.313M3 7.5l2.25 1.313M3 7.5v2.25m9 3l2.25-1.313M12 12.75l-2.25-1.313M12 12.75V15m0 6.75l2.25-1.313M12 21.75V19.5m0 2.25l-2.25-1.313m0-16.875L12 2.25l2.25 1.313M21 14.25v2.25l-2.25 1.313m-13.5 0L3 16.5v-2.25" />
-                  </svg>
+                  class="inline-flex cursor-pointer items-center rounded-s-lg border-y border-s border-gray-200 px-4 py-2 text-sm font-medium hover:bg-gray-100 hover:text-blue-700 dark:border-gray-600 dark:hover:bg-gray-600 dark:hover:text-blue-300 dark:focus:ring-blue-500">
+                  <SquareActivity class="me-2 h-4 w-4" />
                   {{ $t('Activity in this vault') }}
                 </button>
 
@@ -92,23 +82,8 @@ const changeTab = (tab) => {
                       ? 'bg-gray-100 text-blue-700 dark:bg-gray-900 dark:text-blue-300'
                       : 'bg-white text-gray-900 dark:bg-gray-700 dark:text-white'
                   "
-                  class="inline-flex items-center border-y border-e border-gray-200 px-4 py-2 text-sm font-medium hover:bg-gray-100 hover:text-blue-700 dark:border-gray-600 dark:hover:bg-gray-600 dark:hover:text-blue-300 dark:focus:ring-blue-500">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke-width="1.5"
-                    stroke="currentColor"
-                    class="me-2 h-4 w-4">
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      d="M15.362 5.214A8.252 8.252 0 0112 21 8.25 8.25 0 016.038 7.048 8.287 8.287 0 009 9.6a8.983 8.983 0 013.361-6.867 8.21 8.21 0 003 2.48z" />
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      d="M12 18a3.75 3.75 0 00.495-7.467 5.99 5.99 0 00-1.925 3.546 5.974 5.974 0 01-2.133-1A3.75 3.75 0 0012 18z" />
-                  </svg>
+                  class="inline-flex cursor-pointer items-center border-y border-e border-gray-200 px-4 py-2 text-sm font-medium hover:bg-gray-100 hover:text-blue-700 dark:border-gray-600 dark:hover:bg-gray-600 dark:hover:text-blue-300 dark:focus:ring-blue-500">
+                  <Flame class="me-2 h-4 w-4" />
                   {{ $t('Your life events') }}
                 </button>
 
@@ -121,19 +96,8 @@ const changeTab = (tab) => {
                       ? 'bg-gray-100 text-blue-700 dark:bg-gray-900 dark:text-blue-300'
                       : 'bg-white text-gray-900 dark:bg-gray-700 dark:text-white'
                   "
-                  class="inline-flex items-center rounded-e-lg border-y border-e border-gray-200 px-4 py-2 text-sm font-medium hover:bg-gray-100 hover:text-blue-700 dark:border-gray-600 dark:hover:bg-gray-600 dark:hover:text-blue-300 dark:focus:ring-blue-500">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke-width="1.5"
-                    stroke="currentColor"
-                    class="me-2 h-4 w-4">
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      d="M7.5 14.25v2.25m3-4.5v4.5m3-6.75v6.75m3-9v9M6 20.25h12A2.25 2.25 0 0020.25 18V6A2.25 2.25 0 0018 3.75H6A2.25 2.25 0 003.75 6v12A2.25 2.25 0 006 20.25z" />
-                  </svg>
+                  class="inline-flex cursor-pointer items-center rounded-e-lg border-y border-e border-gray-200 px-4 py-2 text-sm font-medium hover:bg-gray-100 hover:text-blue-700 dark:border-gray-600 dark:hover:bg-gray-600 dark:hover:text-blue-300 dark:focus:ring-blue-500">
+                  <ChartSpline class="me-2 h-4 w-4" />
                   {{ $t('Life metrics') }}
                 </button>
               </div>

--- a/resources/js/Pages/Vault/Dashboard/Partials/DueTasks.vue
+++ b/resources/js/Pages/Vault/Dashboard/Partials/DueTasks.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { Link } from '@inertiajs/vue3';
 import Avatar from '@/Shared/Avatar.vue';
-
+import { LayoutList } from 'lucide-vue-next';
 defineProps({
   data: Object,
 });
@@ -15,21 +15,8 @@ const toggle = (task) => {
 
 <template>
   <div class="mb-10">
-    <h3 class="mb-3 border-b border-gray-200 pb-1 font-medium dark:border-gray-800">
-      <span class="relative">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          class="icon-sidebar relative inline h-4 w-4 text-gray-300 hover:text-gray-600 dark:text-gray-700 dark:hover:text-gray-400"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor">
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
-        </svg>
-      </span>
+    <h3 class="mb-3 flex items-center gap-2 border-b border-gray-200 pb-1 font-medium dark:border-gray-800">
+      <LayoutList class="h-4 w-4 text-gray-600" />
 
       {{ $t('Due and upcoming tasks') }}
     </h3>
@@ -114,11 +101,6 @@ const toggle = (task) => {
 </template>
 
 <style lang="scss" scoped>
-.icon-sidebar {
-  color: #737e8d;
-  top: -2px;
-}
-
 input[type='checkbox'] {
   top: 4px;
 }

--- a/resources/js/Pages/Vault/Dashboard/Partials/LastUpdated.vue
+++ b/resources/js/Pages/Vault/Dashboard/Partials/LastUpdated.vue
@@ -2,15 +2,7 @@
   <div>
     <h3 class="mb-3 flex border-b border-gray-200 pb-1 font-medium dark:border-gray-700">
       <span class="relative me-2">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          class="icon-sidebar relative inline h-4 w-4 text-gray-300 hover:text-gray-600 dark:text-gray-400"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth="{2}">
-          <path strokeLinecap="round" strokeLinejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-        </svg>
+        <History class="icon-sidebar relative inline h-4 w-4 text-gray-300 hover:text-gray-600 dark:text-gray-400" />
       </span>
 
       <span class="me-2 inline">
@@ -33,12 +25,14 @@
 import { Link } from '@inertiajs/vue3';
 import Help from '@/Shared/Help.vue';
 import Avatar from '@/Shared/Avatar.vue';
+import { History } from 'lucide-vue-next';
 
 export default {
   components: {
     InertiaLink: Link,
     Help,
     Avatar,
+    History,
   },
 
   props: {

--- a/resources/js/Pages/Vault/Dashboard/Partials/LifeMetrics.vue
+++ b/resources/js/Pages/Vault/Dashboard/Partials/LifeMetrics.vue
@@ -9,6 +9,7 @@ import PrettyButton from '@/Shared/Form/PrettyButton.vue';
 import TextInput from '@/Shared/Form/TextInput.vue';
 import PrettySpan from '@/Shared/Form/PrettySpan.vue';
 import HoverMenu from '@/Shared/HoverMenu.vue';
+import { ChartSpline } from 'lucide-vue-next';
 
 const props = defineProps({
   data: Object,
@@ -111,21 +112,8 @@ const destroy = (lifeMetric) => {
   <div class="mb-10">
     <!-- title + cta -->
     <div class="mb-3 items-center justify-between border-b border-gray-200 pb-2 dark:border-gray-700 sm:flex">
-      <div class="mb-2 sm:mb-0">
-        <span class="relative me-1">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke-width="1.5"
-            stroke="currentColor"
-            class="relative inline h-4 w-4">
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              d="M7.5 14.25v2.25m3-4.5v4.5m3-6.75v6.75m3-9v9M6 20.25h12A2.25 2.25 0 0020.25 18V6A2.25 2.25 0 0018 3.75H6A2.25 2.25 0 003.75 6v12A2.25 2.25 0 006 20.25z" />
-          </svg>
-        </span>
+      <div class="mb-2 sm:mb-0 flex items-center gap-2">
+        <ChartSpline class="h-4 w-4" />
 
         <span class="font-semibold"> {{ $t('Life metrics') }} </span>
       </div>

--- a/resources/js/Pages/Vault/Dashboard/Partials/MoodTrackingEvents.vue
+++ b/resources/js/Pages/Vault/Dashboard/Partials/MoodTrackingEvents.vue
@@ -8,6 +8,7 @@ import TextArea from '@/Shared/Form/TextArea.vue';
 import PrettyButton from '@/Shared/Form/PrettyButton.vue';
 import TextInput from '@/Shared/Form/TextInput.vue';
 import Errors from '@/Shared/Form/Errors.vue';
+import { CloudSun } from 'lucide-vue-next';
 
 const props = defineProps({
   data: Object,
@@ -71,21 +72,8 @@ const submit = () => {
 
 <template>
   <div class="mb-10">
-    <h3 class="mb-3 border-b border-gray-200 pb-1 font-medium dark:border-gray-700">
-      <span class="relative">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke-width="1.5"
-          stroke="currentColor"
-          class="icon-sidebar relative inline h-4 w-4 text-gray-300 hover:text-gray-600 dark:text-gray-400 dark:hover:text-gray-400">
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            d="M15.042 21.672L13.684 16.6m0 0l-2.51 2.225.569-9.47 5.227 7.917-3.286-.672zM12 2.25V4.5m5.834.166l-1.591 1.591M20.25 10.5H18M7.757 14.743l-1.59 1.59M6 10.5H3.75m4.007-4.243l-1.59-1.59" />
-        </svg>
-      </span>
+    <h3 class="mb-3 flex items-center gap-2 border-b border-gray-200 pb-1 font-medium dark:border-gray-700">
+      <CloudSun class="h-4 w-4" />
 
       {{ $t('Record your mood') }}
     </h3>

--- a/resources/js/Pages/Vault/Dashboard/Task/Index.vue
+++ b/resources/js/Pages/Vault/Dashboard/Task/Index.vue
@@ -4,21 +4,8 @@
       <div class="mx-auto max-w-3xl px-2 py-2 sm:px-6 sm:py-6 lg:px-8">
         <!-- title -->
         <div class="mb-5 items-center justify-between border-b border-gray-200 pb-2 dark:border-gray-700 sm:flex">
-          <div class="mb-2 sm:mb-0">
-            <span class="relative">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                class="icon-sidebar relative inline h-4 w-4 text-gray-300 hover:text-gray-600 dark:text-gray-700 dark:hover:text-gray-400"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor">
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" />
-              </svg>
-            </span>
+          <div class="mb-2 sm:mb-0 flex items-center gap-2">
+            <LayoutList class="h-4 w-4 text-gray-600" />
 
             {{ $t('Due and upcoming tasks') }}
           </div>
@@ -100,12 +87,14 @@
 import { Link } from '@inertiajs/vue3';
 import Layout from '@/Shared/Layout.vue';
 import Avatar from '@/Shared/Avatar.vue';
+import { LayoutList } from 'lucide-vue-next';
 
 export default {
   components: {
     InertiaLink: Link,
     Layout,
     Avatar,
+    LayoutList,
   },
 
   props: {

--- a/resources/js/Pages/Vault/Journal/Index.vue
+++ b/resources/js/Pages/Vault/Journal/Index.vue
@@ -2,7 +2,7 @@
 import { Link } from '@inertiajs/vue3';
 import Layout from '@/Shared/Layout.vue';
 import PrettyLink from '@/Shared/Form/PrettyLink.vue';
-
+import { CalendarDays } from 'lucide-vue-next';
 defineProps({
   layoutData: Object,
   data: Object,
@@ -40,21 +40,8 @@ defineProps({
                   journal.name
                 }}</Link>
 
-                <div v-if="journal.last_updated" class="mb-2 flex items-center text-sm sm:mb-0">
-                  <span class="me-1">
-                    <svg
-                      class="h-4 w-4 text-gray-500"
-                      xmlns="http://www.w3.org/2000/svg"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke-width="1.5"
-                      stroke="currentColor">
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        d="M12 6v6h4.5m4.5 0a9 9 0 11-18 0 9 9 0 0118 0z" />
-                    </svg>
-                  </span>
+                <div v-if="journal.last_updated" class="mb-2 flex items-center gap-2 text-sm sm:mb-0">
+                  <CalendarDays class="h-4 w-4 text-gray-400" />
 
                   {{ $t('Updated on :date', { date: journal.last_updated }) }}
                 </div>

--- a/resources/js/Pages/Vault/Journal/Show.vue
+++ b/resources/js/Pages/Vault/Journal/Show.vue
@@ -3,7 +3,7 @@ import { Link, useForm } from '@inertiajs/vue3';
 import Layout from '@/Shared/Layout.vue';
 import PrettyLink from '@/Shared/Form/PrettyLink.vue';
 import { trans } from 'laravel-vue-i18n';
-
+import { ChevronRight } from 'lucide-vue-next';
 const props = defineProps({
   layoutData: Object,
   data: Object,
@@ -25,37 +25,28 @@ const destroy = () => {
 <template>
   <layout :layout-data="layoutData" :inside-vault="true">
     <!-- breadcrumb -->
-    <nav class="bg-white dark:bg-gray-900 sm:mt-20 sm:border-b">
+    <nav class="bg-white dark:bg-gray-900 sm:mt-20 sm:border-b sm:border-gray-300 dark:border-gray-700">
       <div class="max-w-8xl mx-auto hidden px-4 py-2 sm:px-6 md:block">
-        <div class="flex items-baseline justify-between space-x-6">
-          <ul class="text-sm">
-            <li class="me-2 inline text-gray-600 dark:text-gray-400">
-              {{ $t('You are here:') }}
-            </li>
-            <li class="me-2 inline">
-              <Link :href="layoutData.vault.url.journals" class="text-blue-500 hover:underline">
-                {{ $t('Journals') }}
-              </Link>
-            </li>
-            <li class="relative me-2 inline">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                class="icon-breadcrumb relative inline h-3 w-3"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-              </svg>
-            </li>
-            <li class="inline">
-              {{ data.name }}
-            </li>
-          </ul>
+        <div class="flex items-center gap-1 text-sm">
+          <div class="text-gray-600 dark:text-gray-400">
+            {{ $t('You are here:') }}
+          </div>
+          <div class="inline">
+            <Link :href="layoutData.vault.url.journals" class="text-blue-500 hover:underline">
+              {{ $t('Journals') }}
+            </Link>
+          </div>
+          <div class="relative inline">
+            <ChevronRight class="h-3 w-3" />
+          </div>
+          <div class="inline">
+            {{ data.name }}
+          </div>
         </div>
       </div>
     </nav>
 
-    <main class="sm:mt-18 relative">
+    <main class="sm:mt-10 relative">
       <div class="mx-auto max-w-6xl px-2 py-2 sm:px-6 sm:py-6 lg:px-8">
         <h1 class="text-2xl" :class="data.description ? 'mb-4' : 'mb-8'">{{ data.name }}</h1>
 
@@ -179,11 +170,9 @@ const destroy = () => {
                       <div class="flex w-full items-center justify-between">
                         <!-- title and excerpt -->
                         <div>
-                          <span
-                            ><Link :href="post.url.show" class="text-blue-500 hover:underline">{{
-                              post.title
-                            }}</Link></span
-                          >
+                          <span>
+                            <Link :href="post.url.show" class="text-blue-500 hover:underline">{{ post.title }}</Link>
+                          </span>
                           <p v-if="post.excerpt">{{ post.excerpt }}</p>
                         </div>
 

--- a/resources/js/Shared/Form/ContactSelector.vue
+++ b/resources/js/Shared/Form/ContactSelector.vue
@@ -3,7 +3,7 @@ import { computed, nextTick, onMounted, ref, watch } from 'vue';
 import { Link, useForm } from '@inertiajs/vue3';
 import { trans } from 'laravel-vue-i18n';
 import Errors from '@/Shared/Form/Errors.vue';
-import SearchIcon from '@/Shared/Icons/SearchIcon.vue';
+import { ScanSearch } from 'lucide-vue-next';
 
 const props = defineProps({
   modelValue: {
@@ -175,7 +175,7 @@ const search = _.debounce(() => {
     <!-- mode to add a contact -->
     <div v-if="addContactMode">
       <div class="relative mb-3">
-        <SearchIcon />
+        <ScanSearch class="absolute start-2 top-2 h-4 w-4 text-gray-400" />
 
         <input
           ref="searchInput"

--- a/resources/js/Shared/Form/PrettyLink.vue
+++ b/resources/js/Shared/Form/PrettyLink.vue
@@ -1,13 +1,13 @@
 <template>
   <InertiaLink
-    :class="'dark:box-s relative border-zinc-900 bg-white text-sm dark:border-zinc-100 dark:bg-gray-800 dark:text-gray-100'"
+    :class="'flex items-center gap-1 dark:box-s relative border-zinc-900 bg-white text-sm dark:border-zinc-100 dark:bg-gray-800 dark:text-gray-100'"
     :href="href"
     preserve-scroll>
-    <PlusIcon v-if="icon === 'plus'" />
+    <Plus class="h-4 w-4" v-if="icon === 'plus'" />
 
-    <CheckedIcon v-else-if="icon === 'check'" />
+    <Check class="h-4 w-4" v-else-if="icon === 'check'" />
 
-    <DoorIcon :type="'entry'" v-else-if="icon === 'exit'" />
+    <DoorOpen class="h-4 w-4" v-else-if="icon === 'exit'" />
 
     <span>
       {{ text }}
@@ -17,16 +17,14 @@
 
 <script>
 import { Link } from '@inertiajs/vue3';
-import PlusIcon from '@/Shared/Icons/PlusIcon.vue';
-import CheckedIcon from '@/Shared/Icons/CheckedIcon.vue';
-import DoorIcon from '@/Shared/Icons/DoorIcon.vue';
+import { Plus, Check, DoorOpen } from 'lucide-vue-next';
 
 export default {
   components: {
     InertiaLink: Link,
-    PlusIcon,
-    CheckedIcon,
-    DoorIcon,
+    Plus,
+    Check,
+    DoorOpen,
   },
 
   props: {
@@ -56,8 +54,6 @@ a {
   border-radius: 0.25rem !important;
   border-width: 1px !important;
   box-shadow: var(--tw-ring-offset-shadow, 0 0 transparent), var(--tw-ring-shadow, 0 0 transparent), var(--tw-shadow) !important;
-  display: inline-block !important;
-  position: relative !important;
   text-decoration: none !important;
   transition-duration: 0.15s !important;
   transition-property:

--- a/resources/js/Shared/Form/TextArea.vue
+++ b/resources/js/Shared/Form/TextArea.vue
@@ -102,7 +102,7 @@ defineExpose({
 </script>
 
 <template>
-  <div class="mb-3">
+  <div>
     <label v-if="label" class="mb-2 block relative text-sm dark:text-gray-100" :for="id">
       {{ label }}
       <span v-if="!required" class="optional-badge rounded-sm px-[3px] py-px text-xs">

--- a/resources/js/Shared/Help.vue
+++ b/resources/js/Shared/Help.vue
@@ -2,7 +2,7 @@
 import { usePage } from '@inertiajs/vue3';
 import { Tooltip } from 'ant-design-vue';
 import { computed } from 'vue';
-import FaceIcon from '@/Shared/Icons/FaceIcon.vue';
+import { MessageCircleQuestion } from 'lucide-vue-next';
 
 const props = defineProps({
   url: String,
@@ -27,7 +27,8 @@ const finalURL = computed(() => {
     lang="en"
     rel="noopener noreferrer">
     <Tooltip placement="topLeft" :title="$t('This link will open in a new tab')" arrow-point-at-center>
-      <FaceIcon :type="'question'" />
+      <MessageCircleQuestion
+        class="h-4 w-4 text-gray-400 hover:text-gray-600 dark:text-gray-400 dark:hover:text-gray-600" />
     </Tooltip>
   </a>
 </template>

--- a/resources/js/Shared/Layout.vue
+++ b/resources/js/Shared/Layout.vue
@@ -21,7 +21,7 @@
 
         <!-- search box -->
         <div v-if="insideVault" class="flew-grow relative">
-          <SearchIcon />
+          <ScanSearch class="absolute start-2 top-2 h-4 w-4 text-gray-400" />
           <input
             type="text"
             class="dark:highlight-white/5 block w-64 rounded-md border border-gray-300 px-2 py-1 text-center placeholder:text-gray-600 hover:cursor-pointer focus:border-indigo-500 focus:ring-indigo-500 dark:border-0 dark:border-gray-700 dark:bg-slate-900 dark:placeholder:text-gray-400 dark:hover:bg-slate-700 sm:text-sm"
@@ -30,36 +30,36 @@
         </div>
 
         <!-- icons -->
-        <div class="flew-grow">
-          <ul class="relative">
-            <li class="relative top-[3px] me-4 inline">
-              <label for="dark-mode-toggle" class="relative inline-flex cursor-pointer">
-                <input
-                  id="dark-mode-toggle"
-                  v-model="style.checked"
-                  type="checkbox"
-                  class="peer hidden"
-                  @click="toggleStyle" />
-                <div
-                  class="peer me-2 h-4 w-7 rounded-full bg-gray-200 after:absolute after:left-[2px] after:right-[14px] after:top-[2px] after:h-3 after:w-3 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:bg-blue-600 peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-hidden peer-focus:ring-4 peer-focus:ring-blue-300 dark:border-gray-600 dark:bg-gray-800 dark:peer-focus:ring-blue-800" />
-                <DarkModeIcon :checked="style.checked" />
-              </label>
-            </li>
-            <li class="me-4 inline">
-              <InertiaLink :href="layoutData.url.settings" class="relative inline">
-                <SettingIcon />
+        <div class="flex items-center justify-end gap-4">
+          <div class="relative top-[3px] me-4 inline">
+            <label for="dark-mode-toggle" class="relative inline-flex cursor-pointer">
+              <input
+                id="dark-mode-toggle"
+                v-model="style.checked"
+                type="checkbox"
+                class="peer hidden"
+                @click="toggleStyle" />
+              <div
+                class="peer me-2 h-4 w-7 rounded-full bg-gray-200 after:absolute after:left-[2px] after:right-[14px] after:top-[2px] after:h-3 after:w-3 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:bg-blue-600 peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-hidden peer-focus:ring-4 peer-focus:ring-blue-300 dark:border-gray-600 dark:bg-gray-800 dark:peer-focus:ring-blue-800" />
+              <DarkModeIcon :checked="style.checked" />
+            </label>
+          </div>
+          <InertiaLink :href="layoutData.url.settings" class="relative flex items-center gap-1">
+            <Settings
+              class="h-4 w-4 cursor-pointer text-gray-600 hover:text-gray-900 dark:text-gray-600 dark:hover:text-gray-100" />
 
-                <span class="text-sm dark:text-sky-400">{{ $t('Settings') }}</span>
-              </InertiaLink>
-            </li>
-            <li class="inline">
-              <InertiaLink class="inline" method="post" :href="route('logout')" as="button">
-                <DoorIcon />
+            <span class="text-sm dark:text-sky-400">{{ $t('Settings') }}</span>
+          </InertiaLink>
+          <InertiaLink
+            class="relative flex items-center gap-1 cursor-pointer"
+            method="post"
+            :href="route('logout')"
+            as="button">
+            <LogOut
+              class="h-4 w-4 cursor-pointer text-gray-600 hover:text-gray-900 dark:text-gray-600 dark:hover:text-gray-100" />
 
-                <span class="text-sm dark:text-sky-400">{{ $t('Logout') }}</span>
-              </InertiaLink>
-            </li>
-          </ul>
+            <span class="text-sm dark:text-sky-400">{{ $t('Logout') }}</span>
+          </InertiaLink>
         </div>
       </nav>
 
@@ -356,10 +356,8 @@ import { Link } from '@inertiajs/vue3';
 import Toaster from '@/Shared/Toaster.vue';
 import FooterLayout from '@/Layouts/FooterLayout.vue';
 import ChevronIcon from '@/Shared/Icons/ChevronIcon.vue';
-import SearchIcon from '@/Shared/Icons/SearchIcon.vue';
 import DarkModeIcon from '@/Shared/Icons/DarkModeIcon.vue';
-import SettingIcon from '@/Shared/Icons/SettingIcon.vue';
-import DoorIcon from '@/Shared/Icons/DoorIcon.vue';
+import { Settings, LogOut, ScanSearch } from 'lucide-vue-next';
 
 export default {
   components: {
@@ -367,10 +365,10 @@ export default {
     Toaster,
     FooterLayout,
     ChevronIcon,
-    SearchIcon,
+    ScanSearch,
     DarkModeIcon,
-    SettingIcon,
-    DoorIcon,
+    Settings,
+    LogOut,
   },
 
   props: {

--- a/resources/js/Shared/Modules/Addresses.vue
+++ b/resources/js/Shared/Modules/Addresses.vue
@@ -9,7 +9,7 @@ import Dropdown from '@/Shared/Form/Dropdown.vue';
 import JetConfirmationModal from '@/Components/Jetstream/ConfirmationModal.vue';
 import JetDangerButton from '@/Components/Jetstream/DangerButton.vue';
 import JetSecondaryButton from '@/Components/Jetstream/SecondaryButton.vue';
-import MapPointerIcon from '@/Shared/Icons/MapPointerIcon.vue';
+import { MapPinHouse } from 'lucide-vue-next';
 
 const props = defineProps({
   layoutData: Object,
@@ -149,10 +149,8 @@ const destroy = () => {
   <div class="mb-10">
     <!-- title + cta -->
     <div class="mb-3 items-center justify-between border-b border-gray-200 pb-2 dark:border-gray-700 sm:flex">
-      <div class="mb-2 sm:mb-0">
-        <span class="relative me-1">
-          <MapPointerIcon />
-        </span>
+      <div class="mb-2 sm:mb-0 flex items-center gap-2">
+        <MapPinHouse class="h-4 w-4 text-gray-600" />
 
         <span class="font-semibold">
           {{ $t('Addresses') }}

--- a/resources/js/Shared/Modules/Calls.vue
+++ b/resources/js/Shared/Modules/Calls.vue
@@ -10,7 +10,7 @@ import PrettyButton from '@/Shared/Form/PrettyButton.vue';
 import PrettySpan from '@/Shared/Form/PrettySpan.vue';
 import TextArea from '@/Shared/Form/TextArea.vue';
 import Errors from '@/Shared/Form/Errors.vue';
-import CallIcon from '@/Shared/Icons/CallIcon.vue';
+import { PhoneCall } from 'lucide-vue-next';
 
 const props = defineProps({
   data: Object,
@@ -152,10 +152,8 @@ const destroy = (call) => {
   <div class="mb-10">
     <!-- title + cta -->
     <div class="mb-3 items-center justify-between border-b border-gray-200 pb-2 dark:border-gray-700 sm:flex">
-      <div class="mb-2 sm:mb-0">
-        <span class="relative me-1">
-          <CallIcon :is-normal="true" />
-        </span>
+      <div class="mb-2 sm:mb-0 flex items-center gap-2">
+        <PhoneCall class="h-4 w-4 text-gray-600" />
 
         <span class="font-semibold"> {{ $t('Calls') }} </span>
       </div>

--- a/resources/js/Shared/Modules/ContactInformation.vue
+++ b/resources/js/Shared/Modules/ContactInformation.vue
@@ -2,10 +2,8 @@
   <div class="mb-10">
     <!-- title + cta -->
     <div class="mb-3 items-center justify-between border-b border-gray-200 pb-2 dark:border-gray-700 sm:flex">
-      <div class="mb-2 sm:mb-0">
-        <span class="relative me-1">
-          <WorldIcon />
-        </span>
+      <div class="mb-2 sm:mb-0 flex items-center gap-2">
+        <Headset class="h-4 w-4 text-gray-600" />
 
         <span class="font-semibold">
           {{ $t('Contact information') }}
@@ -152,7 +150,7 @@ import PrettySpan from '@/Shared/Form/PrettySpan.vue';
 import TextInput from '@/Shared/Form/TextInput.vue';
 import Dropdown from '@/Shared/Form/Dropdown.vue';
 import Errors from '@/Shared/Form/Errors.vue';
-import WorldIcon from '@/Shared/Icons/WorldIcon.vue';
+import { Headset } from 'lucide-vue-next';
 
 export default {
   components: {
@@ -161,7 +159,7 @@ export default {
     TextInput,
     Dropdown,
     Errors,
-    WorldIcon,
+    Headset,
   },
 
   props: {

--- a/resources/js/Shared/Modules/ContactName.vue
+++ b/resources/js/Shared/Modules/ContactName.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="mb-4">
-    <div class="mb-1 items-center justify-between border-b border-gray-200 dark:border-gray-700 flex">
-      <div class="mb-2 text-xs sm:mb-0">{{ $t('Name') }}</div>
+    <div class="pb-1 mb-2 items-center justify-between border-b border-gray-200 dark:border-gray-700 flex">
+      <div class="text-xs">{{ $t('Name') }}</div>
       <InertiaLink :href="data.url.edit" class="relative">
-        <EditIcon />
+        <Pencil class="h-3 w-3 text-gray-400" />
       </InertiaLink>
     </div>
 
@@ -27,15 +27,15 @@
 <script>
 import { Link } from '@inertiajs/vue3';
 import { Tooltip as ATooltip } from 'ant-design-vue';
-import EditIcon from '@/Shared/Icons/EditIcon.vue';
 import StarIcon from '@/Shared/Icons/StarIcon.vue';
+import { Pencil } from 'lucide-vue-next';
 
 export default {
   components: {
     InertiaLink: Link,
     ATooltip,
-    EditIcon,
     StarIcon,
+    Pencil,
   },
 
   props: {
@@ -70,9 +70,3 @@ export default {
   },
 };
 </script>
-
-<style lang="scss" scoped>
-.icon-sidebar {
-  top: -2px;
-}
-</style>

--- a/resources/js/Shared/Modules/Documents.vue
+++ b/resources/js/Shared/Modules/Documents.vue
@@ -2,10 +2,8 @@
   <div class="mb-10">
     <!-- title + cta -->
     <div class="mb-3 items-center justify-between border-b border-gray-200 pb-2 dark:border-gray-700 sm:flex">
-      <div class="mb-2 sm:mb-0">
-        <span class="relative me-1">
-          <DatabaseIcon />
-        </span>
+      <div class="mb-2 sm:mb-0 flex items-center gap-2">
+        <CloudUpload class="h-4 w-4 text-gray-600" />
 
         <span class="font-semibold">
           {{ $t('Documents') }}
@@ -89,13 +87,13 @@
 <script>
 import PrettyButton from '@/Shared/Form/PrettyButton.vue';
 import Uploadcare from '@/Components/Uploadcare.vue';
-import DatabaseIcon from '@/Shared/Icons/DatabaseIcon.vue';
+import { CloudUpload } from 'lucide-vue-next';
 
 export default {
   components: {
     PrettyButton,
     Uploadcare,
-    DatabaseIcon,
+    CloudUpload,
   },
 
   props: {

--- a/resources/js/Shared/Modules/Feed.vue
+++ b/resources/js/Shared/Modules/Feed.vue
@@ -27,10 +27,10 @@
             </p>
 
             <!-- date of the action -->
-            <p class="mb-1 md:mb-0 flex items-center text-sm text-gray-400">
+            <p class="mb-1 md:mb-0 flex items-center gap-1 text-sm text-gray-400">
               <span>{{ feedItem.created_at }}</span>
 
-              <CalendarIcon :type="'empty'" />
+              <CalendarDays class="h-3 w-3" />
             </p>
           </div>
         </div>
@@ -187,7 +187,7 @@ import Pet from '@/Shared/Modules/FeedItems/Pet.vue';
 import Goal from '@/Shared/Modules/FeedItems/Goal.vue';
 import MoodTrackingEvent from '@/Shared/Modules/FeedItems/MoodTrackingEvent.vue';
 import Note from '@/Shared/Modules/FeedItems/Note.vue';
-import CalendarIcon from '@/Shared/Icons/CalendarIcon.vue';
+import { CalendarDays } from 'lucide-vue-next';
 
 export default {
   components: {
@@ -202,7 +202,7 @@ export default {
     Goal,
     MoodTrackingEvent,
     Note,
-    CalendarIcon,
+    CalendarDays,
   },
 
   props: {

--- a/resources/js/Shared/Modules/GenderPronoun.vue
+++ b/resources/js/Shared/Modules/GenderPronoun.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { Link } from '@inertiajs/vue3';
-import EditIcon from '@/Shared/Icons/EditIcon.vue';
+import { Pencil } from 'lucide-vue-next';
 
 defineProps({
   data: Object,
@@ -11,10 +11,10 @@ defineProps({
   <div class="mb-4 grid grid-cols-2 gap-4">
     <!-- gender -->
     <div>
-      <div class="mb-3 items-center justify-between border-b border-gray-200 dark:border-gray-700 flex">
-        <div class="mb-2 text-xs sm:mb-0">{{ $t('Gender') }}</div>
+      <div class="pb-1 mb-2 items-center justify-between border-b border-gray-200 dark:border-gray-700 flex">
+        <div class="text-xs">{{ $t('Gender') }}</div>
         <Link :href="data.url.edit" class="relative">
-          <EditIcon />
+          <Pencil class="h-3 w-3 text-gray-400" />
         </Link>
       </div>
 
@@ -26,10 +26,10 @@ defineProps({
 
     <!-- pronoun -->
     <div>
-      <div class="mb-3 items-center justify-between border-b border-gray-200 dark:border-gray-700 flex">
-        <div class="mb-2 text-xs sm:mb-0">{{ $t('Pronoun') }}</div>
+      <div class="pb-1 mb-2 items-center justify-between border-b border-gray-200 dark:border-gray-700 flex">
+        <div class="text-xs">{{ $t('Pronoun') }}</div>
         <Link :href="data.url.edit" class="relative">
-          <EditIcon />
+          <Pencil class="h-3 w-3 text-gray-400" />
         </Link>
       </div>
 

--- a/resources/js/Shared/Modules/Goals.vue
+++ b/resources/js/Shared/Modules/Goals.vue
@@ -2,10 +2,8 @@
   <div class="mb-10">
     <!-- title + cta -->
     <div class="mb-3 items-center justify-between border-b border-gray-200 pb-2 dark:border-gray-700 sm:flex">
-      <div class="mb-2 sm:mb-0">
-        <span class="relative me-1">
-          <BallIcon />
-        </span>
+      <div class="mb-2 sm:mb-0 flex items-center gap-2">
+        <Crosshair class="h-4 w-4 text-gray-600" />
 
         <span class="font-semibold"> {{ $t('Goals') }} </span>
       </div>
@@ -131,8 +129,7 @@ import PrettyButton from '@/Shared/Form/PrettyButton.vue';
 import PrettySpan from '@/Shared/Form/PrettySpan.vue';
 import TextInput from '@/Shared/Form/TextInput.vue';
 import Errors from '@/Shared/Form/Errors.vue';
-import BallIcon from '@/Shared/Icons/BallIcon.vue';
-import FaceIcon from '@/Shared/Icons/FaceIcon.vue';
+import { Crosshair } from 'lucide-vue-next';
 
 export default {
   components: {
@@ -141,8 +138,7 @@ export default {
     PrettySpan,
     TextInput,
     Errors,
-    BallIcon,
-    FaceIcon,
+    Crosshair,
   },
 
   props: {

--- a/resources/js/Shared/Modules/Groups.vue
+++ b/resources/js/Shared/Modules/Groups.vue
@@ -2,10 +2,8 @@
   <div class="mb-10">
     <!-- title + cta -->
     <div class="mb-3 items-center justify-between border-b border-gray-200 pb-2 dark:border-gray-700 sm:flex">
-      <div class="mb-2 sm:mb-0">
-        <span class="relative me-1">
-          <BadgeIcon />
-        </span>
+      <div class="mb-2 sm:mb-0 flex items-center gap-2">
+        <Handshake class="h-4 w-4 text-gray-600" />
 
         <span class="font-semibold"> {{ $t('Groups') }} </span>
       </div>
@@ -129,7 +127,7 @@ import TextInput from '@/Shared/Form/TextInput.vue';
 import Dropdown from '@/Shared/Form/Dropdown.vue';
 import Errors from '@/Shared/Form/Errors.vue';
 import Avatar from '@/Shared/Avatar.vue';
-import BadgeIcon from '@/Shared/Icons/BadgeIcon.vue';
+import { Handshake } from 'lucide-vue-next';
 
 export default {
   components: {
@@ -140,7 +138,7 @@ export default {
     Dropdown,
     Errors,
     Avatar,
-    BadgeIcon,
+    Handshake,
   },
 
   props: {

--- a/resources/js/Shared/Modules/ImportantDates.vue
+++ b/resources/js/Shared/Modules/ImportantDates.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { Link } from '@inertiajs/vue3';
-import EditIcon from '@/Shared/Icons/EditIcon.vue';
+import { Pencil } from 'lucide-vue-next';
 
 defineProps({
   data: Object,
@@ -9,10 +9,10 @@ defineProps({
 
 <template>
   <div class="mb-4">
-    <div class="mb-3 items-center justify-between border-b border-gray-200 dark:border-gray-700 flex">
-      <div class="mb-2 text-xs sm:mb-0">{{ $t('Important dates') }}</div>
+    <div class="pb-1 mb-2 items-center justify-between border-b border-gray-200 dark:border-gray-700 flex">
+      <div class="text-xs">{{ $t('Important dates') }}</div>
       <Link :href="data.url.edit" class="relative">
-        <EditIcon />
+        <Pencil class="h-3 w-3 text-gray-400" />
       </Link>
     </div>
 

--- a/resources/js/Shared/Modules/JobInformation.vue
+++ b/resources/js/Shared/Modules/JobInformation.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="mb-4">
-    <div class="mb-3 items-center justify-between border-b border-gray-200 dark:border-gray-700 flex">
-      <div class="mb-2 text-xs sm:mb-0">{{ $t('Job information') }}</div>
+    <div class="pb-1 mb-2 items-center justify-between border-b border-gray-200 dark:border-gray-700 flex">
+      <div class="text-xs">{{ $t('Job information') }}</div>
       <span v-if="!editJobInformation" class="relative cursor-pointer" @click="showEditModal">
-        <EditIcon />
+        <Pencil class="h-3 w-3 text-gray-400" />
       </span>
 
       <!-- close button -->
@@ -107,7 +107,7 @@ import Dropdown from '@/Shared/Form/Dropdown.vue';
 import PrettySpan from '@/Shared/Form/PrettySpan.vue';
 import PrettyButton from '@/Shared/Form/PrettyButton.vue';
 import Errors from '@/Shared/Form/Errors.vue';
-import EditIcon from '@/Shared/Icons/EditIcon.vue';
+import { Pencil } from 'lucide-vue-next';
 
 export default {
   components: {
@@ -116,7 +116,7 @@ export default {
     Dropdown,
     PrettySpan,
     PrettyButton,
-    EditIcon,
+    Pencil,
   },
 
   props: {

--- a/resources/js/Shared/Modules/Labels.vue
+++ b/resources/js/Shared/Modules/Labels.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="mb-4">
-    <div class="mb-3 items-center justify-between border-b border-gray-200 dark:border-gray-700 flex">
-      <div class="mb-2 text-xs sm:mb-0">{{ $t('Labels') }}</div>
+    <div class="pb-1 mb-2 items-center justify-between border-b border-gray-200 dark:border-gray-700 flex">
+      <div class="text-xs">{{ $t('Labels') }}</div>
       <span v-if="!editLabelModalShown" class="relative cursor-pointer" @click="showEditModal">
-        <EditIcon />
+        <Pencil class="h-3 w-3 text-gray-400" />
       </span>
 
       <!-- close button -->
@@ -87,15 +87,15 @@
 import { Link } from '@inertiajs/vue3';
 import TextInput from '@/Shared/Form/TextInput.vue';
 import Errors from '@/Shared/Form/Errors.vue';
-import EditIcon from '@/Shared/Icons/EditIcon.vue';
 import CheckedIcon from '@/Shared/Icons/CheckedIcon.vue';
+import { Pencil } from 'lucide-vue-next';
 
 export default {
   components: {
     InertiaLink: Link,
     TextInput,
     Errors,
-    EditIcon,
+    Pencil,
     CheckedIcon,
   },
 

--- a/resources/js/Shared/Modules/LifeEvent.vue
+++ b/resources/js/Shared/Modules/LifeEvent.vue
@@ -6,10 +6,10 @@ import PrettyButton from '@/Shared/Form/PrettyButton.vue';
 import ContactCard from '@/Shared/ContactCard.vue';
 import HoverMenu from '@/Shared/HoverMenu.vue';
 import CreateLifeEvent from '@/Shared/Modules/CreateLifeEvent.vue';
-import FireIcon from '@/Shared/Icons/FireIcon.vue';
 import ChevronIcon from '@/Shared/Icons/ChevronIcon.vue';
 import ClockIcon from '@/Shared/Icons/ClockIcon.vue';
 import TwoPinMapIcon from '@/Shared/Icons/TwoPinMapIcon.vue';
+import { Flame } from 'lucide-vue-next';
 
 const props = defineProps({
   layoutData: Object,
@@ -109,10 +109,8 @@ const toggleLifeEventVisibility = (lifeEvent) => {
   <div class="mb-10">
     <!-- title + cta -->
     <div class="mb-3 items-center justify-between border-b border-gray-200 pb-2 dark:border-gray-700 sm:flex">
-      <div class="mb-2 sm:mb-0">
-        <span class="relative me-1">
-          <FireIcon />
-        </span>
+      <div class="mb-2 sm:mb-0 flex items-center gap-2">
+        <Flame class="h-4 w-4" />
 
         <span class="font-semibold"> {{ $t('Life events') }} </span>
       </div>

--- a/resources/js/Shared/Modules/Loans.vue
+++ b/resources/js/Shared/Modules/Loans.vue
@@ -13,8 +13,8 @@ import Errors from '@/Shared/Form/Errors.vue';
 import ContactSelector from '@/Shared/Form/ContactSelector.vue';
 import Dropdown from '@/Shared/Form/Dropdown.vue';
 import ContactCard from '@/Shared/ContactCard.vue';
-import DollarIcon from '@/Shared/Icons/DollarIcon.vue';
 import ArrowIcon from '@/Shared/Icons/ArrowIcon.vue';
+import { HandCoins } from 'lucide-vue-next';
 
 const props = defineProps({
   layoutData: Object,
@@ -150,10 +150,8 @@ const toggle = (loan) => {
   <div class="mb-10">
     <!-- title + cta -->
     <div class="mb-3 items-center justify-between border-b border-gray-200 pb-2 dark:border-gray-700 sm:flex">
-      <div class="mb-2 sm:mb-0">
-        <span class="relative me-1">
-          <DollarIcon />
-        </span>
+      <div class="mb-2 sm:mb-0 flex items-center gap-2">
+        <HandCoins class="h-4 w-4 text-gray-600" />
 
         <span class="font-semibold"> {{ $t('Loans') }} </span>
       </div>

--- a/resources/js/Shared/Modules/Notes.vue
+++ b/resources/js/Shared/Modules/Notes.vue
@@ -2,10 +2,8 @@
   <div class="mb-10">
     <!-- title + cta -->
     <div class="mb-3 items-center justify-between border-b border-gray-200 pb-2 dark:border-gray-700 sm:flex">
-      <div class="mb-2 sm:mb-0">
-        <span class="relative me-1">
-          <NoteIcon />
-        </span>
+      <div class="mb-2 sm:mb-0 flex items-center gap-2">
+        <NotebookPen class="h-4 w-4 text-gray-600" />
 
         <span class="font-semibold"> {{ $t('Notes') }} </span>
       </div>
@@ -111,22 +109,22 @@
           <!-- details -->
           <div
             class="flex justify-between border-t border-gray-200 px-3 py-1 text-xs text-gray-600 hover:rounded-b hover:bg-slate-50 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-slate-900">
-            <div class="flex items-center">
+            <div class="flex items-center gap-4">
               <!-- emotion -->
               <div v-if="note.emotion" class="relative me-3 inline">
                 {{ note.emotion.name }}
               </div>
 
               <!-- date -->
-              <div class="relative me-3 inline">
-                <ClockIcon :time="'four'" />
+              <div class="relative flex items-center gap-1">
+                <CalendarDays class="h-3 w-3" />
                 {{ note.written_at }}
               </div>
 
               <!-- author -->
               <div v-if="note.author" class="relative me-3 inline">
-                <div class="icon-avatar relative flex">
-                  <avatar :data="note.author.avatar" :class="'relative me-1 h-3 w-3 rounded-full'" />
+                <div class="icon-avatar flex items-center gap-1">
+                  <avatar :data="note.author.avatar" :class="'h-3 w-3 rounded-full'" />
                   <span>{{ note.author.name }}</span>
                 </div>
               </div>
@@ -225,8 +223,7 @@ import TextArea from '@/Shared/Form/TextArea.vue';
 import Errors from '@/Shared/Form/Errors.vue';
 import Avatar from '@/Shared/Avatar.vue';
 import Pagination from '@/Components/Pagination.vue';
-import NoteIcon from '@/Shared/Icons/NoteIcon.vue';
-import ClockIcon from '@/Shared/Icons/ClockIcon.vue';
+import { NotebookPen, CalendarDays } from 'lucide-vue-next';
 
 export default {
   components: {
@@ -239,8 +236,8 @@ export default {
     Errors,
     Avatar,
     Pagination,
-    NoteIcon,
-    ClockIcon,
+    NotebookPen,
+    CalendarDays,
   },
 
   props: {

--- a/resources/js/Shared/Modules/Pets.vue
+++ b/resources/js/Shared/Modules/Pets.vue
@@ -2,12 +2,8 @@
   <div class="mb-10">
     <!-- title + cta -->
     <div class="mb-3 items-center justify-between border-b border-gray-200 pb-2 dark:border-gray-700 flex">
-      <div class="mb-2 sm:mb-0">
-        <span class="relative me-1">
-          <span class="relative me-1">
-            <FaceIcon :type="'dog'" />
-          </span>
-        </span>
+      <div class="mb-2 sm:mb-0 flex items-center gap-2">
+        <Dog class="h-4 w-4 text-gray-600" />
 
         <span class="font-semibold"> {{ $t('Pets') }} </span>
       </div>
@@ -141,7 +137,7 @@ import PrettySpan from '@/Shared/Form/PrettySpan.vue';
 import TextInput from '@/Shared/Form/TextInput.vue';
 import Dropdown from '@/Shared/Form/Dropdown.vue';
 import Errors from '@/Shared/Form/Errors.vue';
-import FaceIcon from '@/Shared/Icons/FaceIcon.vue';
+import { Dog } from 'lucide-vue-next';
 
 export default {
   components: {
@@ -150,7 +146,7 @@ export default {
     TextInput,
     Dropdown,
     Errors,
-    FaceIcon,
+    Dog,
   },
 
   props: {

--- a/resources/js/Shared/Modules/Photos.vue
+++ b/resources/js/Shared/Modules/Photos.vue
@@ -2,10 +2,8 @@
   <div class="mb-10">
     <!-- title + cta -->
     <div class="mb-3 items-center justify-between border-b border-gray-200 pb-2 dark:border-gray-700 sm:flex">
-      <div class="mb-2 sm:mb-0">
-        <span class="relative me-1">
-          <PhotoIcon />
-        </span>
+      <div class="mb-2 sm:mb-0 flex items-center gap-2">
+        <FileImage class="h-4 w-4 text-gray-600" />
 
         <span class="font-semibold">
           {{ $t('Photos') }}
@@ -79,14 +77,14 @@
 import { Link } from '@inertiajs/vue3';
 import PrettyButton from '@/Shared/Form/PrettyButton.vue';
 import Uploadcare from '@/Components/Uploadcare.vue';
-import PhotoIcon from '@/Shared/Icons/PhotoIcon.vue';
+import { FileImage } from 'lucide-vue-next';
 
 export default {
   components: {
     InertiaLink: Link,
     PrettyButton,
     Uploadcare,
-    PhotoIcon,
+    FileImage,
   },
 
   props: {

--- a/resources/js/Shared/Modules/Posts.vue
+++ b/resources/js/Shared/Modules/Posts.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { Link } from '@inertiajs/vue3';
-import TagIcon from '@/Shared/Icons/TagIcon.vue';
 import ClockIcon from '@/Shared/Icons/ClockIcon.vue';
+import { PenTool } from 'lucide-vue-next';
 
 defineProps({
   data: Object,
@@ -12,10 +12,8 @@ defineProps({
   <div class="mb-10">
     <!-- title + cta -->
     <div class="mb-3 items-center justify-between border-b border-gray-200 pb-2 dark:border-gray-700 sm:flex">
-      <div class="mb-2 sm:mb-0">
-        <span class="relative me-1">
-          <TagIcon />
-        </span>
+      <div class="mb-2 sm:mb-0 flex items-center gap-2">
+        <PenTool class="h-4 w-4 text-gray-600" />
 
         <span class="font-semibold"> {{ $t('Posts') }} </span>
       </div>

--- a/resources/js/Shared/Modules/QuickFacts.vue
+++ b/resources/js/Shared/Modules/QuickFacts.vue
@@ -7,9 +7,9 @@ import Errors from '@/Shared/Form/Errors.vue';
 import PrettyButton from '@/Shared/Form/PrettyButton.vue';
 import TextInput from '@/Shared/Form/TextInput.vue';
 import PrettySpan from '@/Shared/Form/PrettySpan.vue';
-import LampIcon from '@/Shared/Icons/LampIcon.vue';
 import ChevronIcon from '@/Shared/Icons/ChevronIcon.vue';
 import ValideIcon from '@/Shared/Icons/ValideIcon.vue';
+import { Lightbulb } from 'lucide-vue-next';
 
 const props = defineProps({
   data: Object,
@@ -99,9 +99,8 @@ const destroy = (quickFact) => {
 <template>
   <div class="mb-8 rounded-lg border border-gray-200 bg-gray-50 p-3 shadow-xs dark:border-gray-700 dark:bg-gray-900">
     <div @click="toggle()" class="flex cursor-pointer items-center justify-between" :class="openState ? ' mb-4' : ''">
-      <div class="me-1 flex items-center">
-        <LampIcon />
-
+      <div class="flex items-center gap-2">
+        <Lightbulb class="h-4 w-4 text-gray-600" />
         <p class="text-sm font-bold">{{ $t('Quick facts') }}</p>
       </div>
 

--- a/resources/js/Shared/Modules/Relationships.vue
+++ b/resources/js/Shared/Modules/Relationships.vue
@@ -2,10 +2,8 @@
   <div class="mb-10">
     <!-- title + cta -->
     <div class="mb-3 items-center justify-between border-b border-gray-200 pb-2 dark:border-gray-700 sm:flex">
-      <div class="mb-2 sm:mb-0">
-        <span class="relative me-1">
-          <PeopleIcon />
-        </span>
+      <div class="mb-2 sm:mb-0 flex items-center gap-2">
+        <UsersRound class="h-4 w-4 text-gray-600" />
 
         <span class="font-semibold"> {{ $t('Relationships') }} </span>
       </div>
@@ -76,14 +74,14 @@
 import { Link } from '@inertiajs/vue3';
 import PrettyLink from '@/Shared/Form/PrettyLink.vue';
 import Avatar from '@/Shared/Avatar.vue';
-import PeopleIcon from '@/Shared/Icons/PeopleIcon.vue';
+import { UsersRound } from 'lucide-vue-next';
 
 export default {
   components: {
     InertiaLink: Link,
     PrettyLink,
     Avatar,
-    PeopleIcon,
+    UsersRound,
   },
 
   props: {
@@ -122,11 +120,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.icon-sidebar {
-  color: #737e8d;
-  top: -2px;
-}
-
 .item-list {
   &:hover:first-child {
     border-top-left-radius: 8px;

--- a/resources/js/Shared/Modules/Religion.vue
+++ b/resources/js/Shared/Modules/Religion.vue
@@ -5,7 +5,7 @@ import Errors from '@/Shared/Form/Errors.vue';
 import PrettyButton from '@/Shared/Form/PrettyButton.vue';
 import PrettySpan from '@/Shared/Form/PrettySpan.vue';
 import Dropdown from '@/Shared/Form/Dropdown.vue';
-import EditIcon from '@/Shared/Icons/EditIcon.vue';
+import { Pencil } from 'lucide-vue-next';
 
 const props = defineProps({
   data: Object,
@@ -42,12 +42,12 @@ const showEditModal = () => {
 
 <template>
   <div class="mb-4">
-    <div class="mb-3 items-center justify-between border-b border-gray-200 dark:border-gray-700 flex">
+    <div class="pb-1 mb-2 items-center justify-between border-b border-gray-200 dark:border-gray-700 flex">
       <!-- title -->
-      <div class="mb-2 text-xs sm:mb-0">{{ $t('Religion') }}</div>
+      <div class="text-xs">{{ $t('Religion') }}</div>
 
       <span v-if="!editReligion" class="relative cursor-pointer" @click="showEditModal()">
-        <EditIcon />
+        <Pencil class="h-3 w-3 text-gray-400" />
       </span>
 
       <!-- close button -->

--- a/resources/js/Shared/Modules/Reminders.vue
+++ b/resources/js/Shared/Modules/Reminders.vue
@@ -11,8 +11,7 @@ import PrettySpan from '@/Shared/Form/PrettySpan.vue';
 import TextInput from '@/Shared/Form/TextInput.vue';
 import Dropdown from '@/Shared/Form/Dropdown.vue';
 import Errors from '@/Shared/Form/Errors.vue';
-import ReminderIcon from '@/Shared/Icons/ReminderIcon.vue';
-import RefreshIcon from '@/Shared/Icons/RefreshIcon.vue';
+import { Bell } from 'lucide-vue-next';
 
 const props = defineProps({
   data: Object,
@@ -124,11 +123,8 @@ const destroy = (reminder) => {
   <div class="mb-10">
     <!-- title + cta -->
     <div class="mb-3 items-center justify-between border-b border-gray-200 pb-2 dark:border-gray-700 sm:flex">
-      <div class="mb-2 sm:mb-0">
-        <span class="relative me-1">
-          <ReminderIcon />
-        </span>
-
+      <div class="mb-2 sm:mb-0 flex items-center gap-2">
+        <Bell class="h-4 w-4 text-gray-600" />
         <span class="font-semibold"> {{ $t('Reminders') }} </span>
       </div>
       <pretty-button

--- a/resources/js/Shared/Modules/Tasks.vue
+++ b/resources/js/Shared/Modules/Tasks.vue
@@ -5,8 +5,8 @@ import { trans } from 'laravel-vue-i18n';
 import HoverMenu from '@/Shared/HoverMenu.vue';
 import PrettyButton from '@/Shared/Form/PrettyButton.vue';
 import CreateOrEditTask from '@/Shared/Modules/TaskItems/CreateOrEditTask.vue';
-import TaskIcon from '@/Shared/Icons/TaskIcon.vue';
 import DateIcon from '@/Shared/Icons/DateIcon.vue';
+import { LayoutList } from 'lucide-vue-next';
 
 const props = defineProps({
   data: Object,
@@ -91,10 +91,8 @@ const destroy = (task) => {
   <div class="mb-10">
     <!-- title + cta -->
     <div class="mb-3 items-center justify-between border-b border-gray-200 pb-2 dark:border-gray-700 sm:flex">
-      <div class="mb-2 sm:mb-0">
-        <span class="relative me-1">
-          <TaskIcon />
-        </span>
+      <div class="mb-2 sm:mb-0 flex items-center gap-2">
+        <LayoutList class="h-4 w-4 text-gray-600" />
 
         <span class="font-semibold"> {{ $t('Tasks') }} </span>
       </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3188,6 +3188,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lucide-vue-next@npm:^0.475.0":
+  version: 0.475.0
+  resolution: "lucide-vue-next@npm:0.475.0"
+  peerDependencies:
+    vue: ">=3.0.1"
+  checksum: 10c0/cf3038b67872e782ed41c9480203f26d557caa39b3082cb1ba3315f0102222e603370ac15401834bd586480b395e6efbe09edf48a8b84b22807dbae359abe94c
+  languageName: node
+  linkType: hard
+
 "magic-string@npm:^0.30.10":
   version: 0.30.10
   resolution: "magic-string@npm:0.30.10"
@@ -3983,6 +3992,7 @@ __metadata:
     laravel-vue-i18n: "npm:^2.7.8"
     lint-staged: "npm:^15.4.3"
     lodash: "npm:^4.17.21"
+    lucide-vue-next: "npm:^0.475.0"
     mitt: "npm:^3.0.1"
     prettier: "npm:^3.4.2"
     prettier-plugin-tailwindcss: "npm:^0.6.11"


### PR DESCRIPTION
While I'm quite reluctant to use dependencies in the project, I believe that using inline SVGs is not ideal for the codebase because it can be messy. Additionally, using custom icons creates inconsistency.

I've been using on other projects https://lucide.dev icons and they are just great.

So we are moving from custom SVG icons to a library of icons.

In terms of performance there are no impact since they are using tree-shaking to make sure we only load what we need.

I haven't replaced the icons everywhere, I need further testing for some pages, but the most has been done here.