### PR TITLE
fix: fix second dummy account not being created

### DIFF
--- a/app/Console/Commands/Local/SetupDummyAccount.php
+++ b/app/Console/Commands/Local/SetupDummyAccount.php
@@ -64,13 +64,14 @@ class SetupDummyAccount extends Command
 
         $this->start();
         $this->wipeAndMigrateDB();
-        $this->createFirstUsers();
+        $this->createFirstUser();
         $this->createVaults();
         $this->createContacts();
         $this->createNotes();
         $this->createTasks();
         $this->createGoals();
         $this->createJournals();
+        $this->createSecondUser();
         $this->stop();
     }
 
@@ -117,7 +118,7 @@ class SetupDummyAccount extends Command
         $this->info('Setup is done. Have fun.');
     }
 
-    private function createFirstUsers(): void
+    private function createFirstUser(): void
     {
         $this->info('☐ Create first user of the account');
 
@@ -297,6 +298,21 @@ class SetupDummyAccount extends Command
                 }
             }
         }
+    }
+
+    private function createSecondUser(): void
+    {
+        $this->info('☐ Create second user of the account');
+
+        $this->secondUser = app(CreateAccount::class)->execute([
+            'email' => 'blank@blank.com',
+            'password' => 'blank123',
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+        ]);
+
+        $this->secondUser->email_verified_at = Carbon::now();
+        $this->secondUser->save();
     }
 
     private function artisan(string $message, string $command, array $arguments = []): void


### PR DESCRIPTION
This pull request includes changes to the `SetupDummyAccount.php` file to improve the setup process by creating an additional user and renaming a method for clarity. The most important changes include renaming the `createFirstUsers` method to `createFirstUser` and adding a new method to create a second user.

Improvements to user creation:

* [`app/Console/Commands/Local/SetupDummyAccount.php`](diffhunk://#diff-10717e118afc5f77ed46d94f0d423cabfeb90c52211713e129754dc15128743bL67-R74): Renamed the `createFirstUsers` method to `createFirstUser` to better reflect its purpose. [[1]](diffhunk://#diff-10717e118afc5f77ed46d94f0d423cabfeb90c52211713e129754dc15128743bL67-R74) [[2]](diffhunk://#diff-10717e118afc5f77ed46d94f0d423cabfeb90c52211713e129754dc15128743bL120-R121)
* [`app/Console/Commands/Local/SetupDummyAccount.php`](diffhunk://#diff-10717e118afc5f77ed46d94f0d423cabfeb90c52211713e129754dc15128743bL67-R74): Added a new method `createSecondUser` to create a second user during the setup process. [[1]](diffhunk://#diff-10717e118afc5f77ed46d94f0d423cabfeb90c52211713e129754dc15128743bL67-R74) [[2]](diffhunk://#diff-10717e118afc5f77ed46d94f0d423cabfeb90c52211713e129754dc15128743bR303-R317)