### PR TITLE
fix: prevented radio from needing to be clicked twice

### DIFF
--- a/resources/js/Pages/Vault/Contact/Relationships/Create.vue
+++ b/resources/js/Pages/Vault/Contact/Relationships/Create.vue
@@ -204,7 +204,7 @@
                       name="name-order"
                       type="radio"
                       class="h-4 w-4 border-gray-300 text-sky-500 dark:border-gray-700"
-                      @click="displayContactSelector" />
+                      @input="displayContactSelector" />
                     <label
                       for="contact"
                       class="ms-3 block cursor-pointer text-sm font-medium text-gray-700 dark:text-gray-300">


### PR DESCRIPTION
Changed event listener from 'click' to 'input' which fixes the bug that caused users to need to click the button more than once for the radio to be selected.