### PR TITLE
fix: update is past address for contact address

### DIFF
--- a/app/Domains/Contact/ManageContactAddresses/Web/Controllers/ContactModuleAddressController.php
+++ b/app/Domains/Contact/ManageContactAddresses/Web/Controllers/ContactModuleAddressController.php
@@ -77,7 +77,7 @@ class ContactModuleAddressController extends Controller
         $contact = Contact::find($contactId);
 
         // update pivot table
-        $contact->addresses()->where('address_id', $addressId)->update([
+        $contact->addresses()->updateExistingPivot($addressId, [
             'is_past_address' => $request->input('is_past_address'),
         ]);
 


### PR DESCRIPTION
`is_past_address` is part of `contact_address` table so it should be `updateExistingPivot` instead of `update` which will update the `addresses` table and throw an exception