### PR TITLE
fix: fix synctoken id

### DIFF
--- a/app/Models/AddressBookSubscription.php
+++ b/app/Models/AddressBookSubscription.php
@@ -48,13 +48,6 @@ class AddressBookSubscription extends Model implements Loggable
     ];
 
     /**
-     * The attributes that aren't mass assignable.
-     *
-     * @var array<string>|bool
-     */
-    protected $guarded = ['id'];
-
-    /**
      * The attributes that should be cast to native types.
      *
      * @var array<string,string>

--- a/app/Models/SyncToken.php
+++ b/app/Models/SyncToken.php
@@ -12,13 +12,6 @@ class SyncToken extends Model
     protected $table = 'sync_tokens';
 
     /**
-     * The attributes that aren't mass assignable.
-     *
-     * @var array<string>|bool
-     */
-    protected $guarded = ['id'];
-
-    /**
      * The attributes that are mass assignable.
      *
      * @var list<string>

--- a/database/migrations/2025_07_06_100000_fix_synctokens.php
+++ b/database/migrations/2025_07_06_100000_fix_synctokens.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('sync_tokens', function (Blueprint $table) {
+            $table->unsignedBigInteger('id', true)->change();
+        });
+    }
+};


### PR DESCRIPTION
Update the sync token model to ensure the ID is correctly defined as an unsigned big integer and remove unnecessary guarded attributes.