### PR TITLE
fix: Fix sync token foreign key relationship in addressbook subscriptions (again)

### DIFF
--- a/database/migrations/2025_07_06_200000_fix_synctokens.php
+++ b/database/migrations/2025_07_06_200000_fix_synctokens.php
@@ -11,8 +11,16 @@ return new class extends Migration
      */
     public function up(): void
     {
+        Schema::table('addressbook_subscriptions', function (Blueprint $table) {
+            $table->dropForeign('addressbook_subscriptions_sync_token_id_foreign');
+        });
+
         Schema::table('sync_tokens', function (Blueprint $table) {
             $table->unsignedBigInteger('id', true)->change();
+        });
+
+        Schema::table('addressbook_subscriptions', function (Blueprint $table) {
+            $table->foreign('sync_token_id')->references('id')->on('sync_tokens')->nullOnDelete();
         });
     }
 };

--- a/database/migrations/2025_07_06_200000_fix_synctokens.php
+++ b/database/migrations/2025_07_06_200000_fix_synctokens.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -11,16 +12,20 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::table('addressbook_subscriptions', function (Blueprint $table) {
-            $table->dropForeign('addressbook_subscriptions_sync_token_id_foreign');
-        });
+        if (DB::connection()->getDriverName() != 'sqlite') {
+            Schema::table('addressbook_subscriptions', function (Blueprint $table) {
+                $table->dropForeign('addressbook_subscriptions_sync_token_id_foreign');
+            });
+        }
 
         Schema::table('sync_tokens', function (Blueprint $table) {
             $table->unsignedBigInteger('id', true)->change();
         });
 
-        Schema::table('addressbook_subscriptions', function (Blueprint $table) {
-            $table->foreign('sync_token_id')->references('id')->on('sync_tokens')->nullOnDelete();
-        });
+        if (DB::connection()->getDriverName() !== 'sqlite') {
+            Schema::table('addressbook_subscriptions', function (Blueprint $table) {
+                $table->foreign('sync_token_id')->references('id')->on('sync_tokens')->nullOnDelete();
+            });
+        }
     }
 };


### PR DESCRIPTION
Update the foreign key constraint for `sync_token_id` in the `addressbook_subscriptions` table to reference the `sync_tokens` table, ensuring proper handling of deletions.