### PR TITLE
feat: add daily schedule for pruning failed jobs in the queue

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -19,6 +19,7 @@ use App\Logging\CleanLogs;
 
 Schedule::command('model:prune', 'daily');
 Schedule::command('queue:prune-batches', 'daily');
+Schedule::command('queue:prune-failed', 'daily');
 if (config('telescope.enabled')) {
     Schedule::command('telescope:prune', 'daily');
 }


### PR DESCRIPTION
Introduce a scheduled command to prune failed jobs from the queue on a daily basis.