### PR TITLE
fix: add first_name and last_name to sortableAttributes

### DIFF
--- a/config/scout.php
+++ b/config/scout.php
@@ -140,7 +140,7 @@ return [
         'index-settings' => [
             Contact::class => [
                 'filterableAttributes' => ['id', 'vault_id'],
-                'sortableAttributes' => ['updated_at'],
+                'sortableAttributes' => ['updated_at', 'first_name', 'last_name'],
             ],
             Group::class => [
                 'filterableAttributes' => ['id', 'vault_id'],


### PR DESCRIPTION
Add the properties `first_name` and `last_name` to the `sortableAttributes` for meilisearch.

Should fix: https://github.com/monicahq/monica/issues/7764

