### PR TITLE
fix: Wrap life event participants to new line if necessary (fixes mobile overflow)

### DIFF
--- a/resources/js/Shared/Modules/LifeEvent.vue
+++ b/resources/js/Shared/Modules/LifeEvent.vue
@@ -246,7 +246,7 @@ const toggleLifeEventVisibility = (lifeEvent) => {
                 </div>
 
                 <!-- participants -->
-                <div v-if="!lifeEvent.collapsed" class="flex p-3 pb-1">
+                <div v-if="!lifeEvent.collapsed" class="flex flex-wrap p-3 pb-1">
                   <div v-for="contact in lifeEvent.participants" :key="contact.id" class="me-4">
                     <contact-card
                       :contact="contact"


### PR DESCRIPTION
Prevent page overflow, too small avatars and wraps participants to new lines.

Before:
<img width="478" height="365" alt="image" src="https://github.com/user-attachments/assets/94d720a0-11d0-4bec-8bce-c40bf94e63d0" />

After:
<img width="436" height="570" alt="image" src="https://github.com/user-attachments/assets/9a52c0ff-70ca-4bc9-bc5c-3e367940f0ba" />
