### PR TITLE
fix: Align icons in contact cards

### DIFF
--- a/resources/js/Shared/Icons/CalendarIcon.vue
+++ b/resources/js/Shared/Icons/CalendarIcon.vue
@@ -7,7 +7,7 @@ defineProps({
 <template>
   <svg
     v-if="type == 'filled'"
-    class="ms-2 h-4 w-4"
+    class="me-1 h-4 w-4"
     xmlns="http://www.w3.org/2000/svg"
     fill="none"
     viewBox="0 0 24 24"

--- a/resources/js/Shared/Icons/PeopleIcon.vue
+++ b/resources/js/Shared/Icons/PeopleIcon.vue
@@ -1,7 +1,7 @@
 <template>
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    class="icon-sidebar relative inline h-4 w-4"
+    class="icon-sidebar relative inline me-1 h-4 w-4"
     fill="none"
     viewBox="0 0 24 24"
     stroke="currentColor"


### PR DESCRIPTION
Align calendar and groups icon at contact card popover while using same margin logic for icons in other places.

Before
<img width="339" height="172" alt="image" src="https://github.com/user-attachments/assets/d19b4db7-f584-4847-a75c-0279f51a4665" />

After
<img width="336" height="150" alt="image" src="https://github.com/user-attachments/assets/6adb4809-60b9-4ead-a9c5-7a38de2d2fb1" />

Applies also to mood events in activity log (before)
<img width="474" height="242" alt="image" src="https://github.com/user-attachments/assets/be01c06e-d553-461c-9097-225b7452d08e" />

