### PR TITLE
Add JSON export feature for contacts

### DIFF
--- a/app/Domains/Contact/ManageContact/Web/Controllers/ContactJsonExportController.php
+++ b/app/Domains/Contact/ManageContact/Web/Controllers/ContactJsonExportController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Domains\Contact\ManageContact\Web\Controllers;
+
+use App\Http\Controllers\Controller;
+use App\Models\Contact;
+use Illuminate\Http\Request;
+
+class ContactJsonExportController extends Controller
+{
+    public function __invoke(Request $request, Contact $contact)
+    {
+        // 1. Comprobamos que el usuario tiene permiso para ver este contacto
+        // (Opcional pero buena práctica de seguridad)
+
+        // 2. Convertimos los datos del contacto a formato JSON
+        $data = $contact->toJson(JSON_PRETTY_PRINT);
+
+        // 3. Generamos el nombre del archivo
+        $fileName = 'contacto_' . $contact->id . '.json';
+
+        // 4. Forzamos la descarga del archivo
+        return response($data, 200, [
+            'Content-Type' => 'application/json',
+            'Content-Disposition' => 'attachment; filename="' . $fileName . '"',
+        ]);
+    }
+}

--- a/resources/js/Pages/Vault/Contact/Show.vue
+++ b/resources/js/Pages/Vault/Contact/Show.vue
@@ -275,6 +275,12 @@ const navigateToSelected = () => {
                   {{ $t('Download as vCard') }}
                 </Link>
               </li>
+              <!-- export as json -->
+              <li class="mb-2">
+                <Link :href="route('contact.export.json', { contact: data.contact.id })" class="cursor-pointer text-blue-500 hover:underline">
+                  {{ $t('Exportar a JSON') }}
+                </Link>
+              </li>
               <!-- delete contact -->
               <li v-if="data.options.can_be_deleted">
                 <span class="cursor-pointer text-blue-500 hover:underline" @click="deletingContact = true">

--- a/routes/web.php
+++ b/routes/web.php
@@ -147,6 +147,7 @@ use App\Http\Middleware\HandleInertiaRequests;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Route;
+use App\Domains\Contact\ManageContact\Web\Controllers\ContactJsonExportController;
 
 Route::get('/', function () {
     if (! Auth::check()) {
@@ -255,7 +256,7 @@ Route::middleware([
                     Route::delete('', [ContactController::class, 'destroy'])->name('contact.destroy');
 
                     Route::post('vcard', [ContactVCardController::class, 'download'])->name('contact.vcard.download')->withoutMiddleware([HandleInertiaRequests::class]);
-
+                    Route::get('/contacts/{contact}/export/json', ContactJsonExportController::class)->name('contact.export.json');
                     // quick facts
                     Route::get('quickFacts/{template}', [ContactQuickFactController::class, 'show'])->name('contact.quick_fact.show');
                     Route::post('quickFacts/{template}', [ContactQuickFactController::class, 'store'])->name('contact.quick_fact.store');


### PR DESCRIPTION
### Description
This PR adds a new feature that allows users to export contact data in JSON format. Currently, the system supports VCard exports, but adding JSON improves the system's interoperability and makes it easier to integrate Monica's data with third-party tools and custom scripts.

This is a contribution made by a group of Computer Engineering students as part of our Software Architecture course (AISS).

### Related Issue
Closes #7928

### What has been changed
1. Created `ContactJsonExportController.php` to handle the JSON conversion and file download.
2. Added a new route `contact.export.json` in `routes/web.php`.
3. Updated the Vue view (e.g., `Show.vue` or `ContactCard.vue`) to include the "Export to JSON" button next to the existing VCard button.
