### PR TITLE
Fix date format in British English locale

### DIFF
--- a/app/Helpers/CountriesHelper.php
+++ b/app/Helpers/CountriesHelper.php
@@ -73,7 +73,12 @@ class CountriesHelper
         $locale = App::getLocale();
         $lang = LocaleHelper::getLocaleAlpha($locale);
 
-        return $country->getTranslation($lang)['common'];
+        $translations = $country->getTranslations();
+        if (! isset($translations[$lang])) {
+            return $country->getName();
+        }
+
+        return $translations[$lang]['common'];
     }
 
     /**

--- a/app/Helpers/DateHelper.php
+++ b/app/Helpers/DateHelper.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use function Safe\date;
 use function Safe\strtotime;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Auth;
 
 class DateHelper
@@ -217,7 +218,7 @@ class DateHelper
      */
     private static function formatDate(Carbon $date, string $format, bool $withTimezone = false): string
     {
-        $format = trans($format, [], Carbon::getLocale());
+        $format = trans($format, [], App::getLocale());
         if ($withTimezone) {
             $date = $date->setTimezone(static::getTimezone());
         }
@@ -260,7 +261,7 @@ class DateHelper
     public static function getMonthAndYear(int $month): string
     {
         $date = Carbon::now(static::getTimezone())->addMonthsNoOverflow($month);
-        $format = trans('format.short_month_year', [], Carbon::getLocale());
+        $format = trans('format.short_month_year', [], App::getLocale());
 
         return $date->translatedFormat($format) ?: '';
     }
@@ -314,7 +315,7 @@ class DateHelper
     {
         $months = collect([]);
         $currentDate = Carbon::parse('2000-01-01');
-        $format = trans('format.full_month', [], Carbon::getLocale());
+        $format = trans('format.full_month', [], App::getLocale());
 
         for ($month = 1; $month <= 12; $month++) {
             $currentDate->month = $month;
@@ -350,7 +351,7 @@ class DateHelper
     public static function getListOfHours(): Collection
     {
         $currentDate = Carbon::parse('2000-01-01 00:00:00');
-        $format = trans('format.full_hour', [], Carbon::getLocale());
+        $format = trans('format.full_hour', [], App::getLocale());
 
         $hours = collect([]);
         for ($hour = 1; $hour <= 24; $hour++) {

--- a/app/Helpers/LocaleHelper.php
+++ b/app/Helpers/LocaleHelper.php
@@ -167,18 +167,18 @@ class LocaleHelper
         if (Arr::has(static::$locales, $locale)) {
             return Arr::get(static::$locales, $locale);
         }
-        $locale = mb_strtolower($locale);
+        $lang = self::getLang($locale);
         $languages = (new ISO639)->allLanguages();
-        $lang = '';
+        $alpha3 = '';
         foreach ($languages as $l) {
-            if ($l[0] == $locale) {
-                $lang = $l[1];
+            if ($l[0] == $lang) {
+                $alpha3 = $l[1];
                 break;
             }
         }
-        static::$locales[$locale] = $lang;
+        static::$locales[$locale] = $alpha3;
 
-        return $lang;
+        return $alpha3;
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "license": "AGPL",
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-bcmath": "*",
         "ext-gd": "*",
         "ext-gmp": "*",

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -6,7 +6,7 @@
 ### This file is based off of the `apache` variant in the above mentioned repo
 ###
 
-FROM php:8.1-apache
+FROM php:8.2-apache
 
 # opencontainers annotations https://github.com/opencontainers/image-spec/blob/master/annotations.md
 LABEL org.opencontainers.image.authors="Alexis Saettler <alexis@saettler.org>" \
@@ -36,13 +36,15 @@ RUN set -ex; \
         zlib1g-dev \
         libzip-dev \
         libpng-dev \
+        libpq-dev \
         libxml2-dev \
         libfreetype6-dev \
         libjpeg62-turbo-dev \
         libgmp-dev \
         libmemcached-dev \
-        libmagickwand-dev \
+        libssl-dev \
         libwebp-dev \
+        libcurl4-openssl-dev \
     ; \
     \
     debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
@@ -58,13 +60,14 @@ RUN set -ex; \
         gmp \
         pdo_mysql \
         mysqli \
+        pdo_pgsql \
         soap \
     ; \
     \
 # pecl will claim success even if one install fails, so we need to perform each install separately
-    pecl install APCu; \
-    pecl install memcached; \
-    pecl install redis; \
+    pecl install APCu-5.1.26; \
+    pecl install memcached-3.3.0; \
+    pecl install redis-6.2.0; \
     \
     docker-php-ext-enable \
         apcu \
@@ -75,14 +78,14 @@ RUN set -ex; \
 # reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
     apt-mark auto '.*' > /dev/null; \
     apt-mark manual $savedAptMark; \
-        ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
-        | awk '/=>/ { print $3 }' \
+    ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+        | awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
         | sort -u \
         | xargs -r dpkg-query -S \
         | cut -d: -f1 \
         | sort -u \
         | xargs -rt apt-mark manual; \
-        \
+    \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
     rm -rf /var/lib/apt/lists/*
 
@@ -91,13 +94,16 @@ RUN set -ex; \
     \
     mkdir -p /var/spool/cron/crontabs; \
     rm -f /var/spool/cron/crontabs/root; \
-    echo '*/5 * * * * php /var/www/html/artisan schedule:run -v' > /var/spool/cron/crontabs/www-data
+    echo '* * * * * php /var/www/html/artisan schedule:run -v' > /var/spool/cron/crontabs/www-data
 
 # Opcache
 ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS="0" \
     PHP_OPCACHE_MAX_ACCELERATED_FILES="20000" \
     PHP_OPCACHE_MEMORY_CONSUMPTION="192" \
     PHP_OPCACHE_MAX_WASTED_PERCENTAGE="10"
+# Limits
+ENV PHP_MEMORY_LIMIT="512M" \
+    PHP_UPLOAD_LIMIT="512M"
 RUN set -ex; \
     \
     docker-php-ext-enable opcache; \
@@ -115,7 +121,11 @@ RUN set -ex; \
     \
     echo 'apc.enable_cli=1' >> $PHP_INI_DIR/conf.d/docker-php-ext-apcu.ini; \
     \
-    echo 'memory_limit=512M' > $PHP_INI_DIR/conf.d/memory-limit.ini
+    { \
+        echo 'memory_limit=${PHP_MEMORY_LIMIT}'; \
+        echo 'upload_max_filesize=${PHP_UPLOAD_LIMIT}'; \
+        echo 'post_max_size=${PHP_UPLOAD_LIMIT}'; \
+    } > $PHP_INI_DIR/conf.d/limits.ini;
 
 RUN set -ex; \
     \
@@ -127,6 +137,15 @@ RUN set -ex; \
         echo RemoteIPTrustedProxy 192.168.0.0/16; \
     } > $APACHE_CONFDIR/conf-available/remoteip.conf; \
     a2enconf remoteip
+
+# set apache config LimitRequestBody
+ENV APACHE_BODY_LIMIT 1073741824
+RUN set -ex; \
+    \
+    { \
+        echo 'LimitRequestBody ${APACHE_BODY_LIMIT}'; \
+    } > $APACHE_CONFDIR/conf-available/apache-limits.conf; \
+    a2enconf apache-limits
 
 RUN set -ex; \
     APACHE_DOCUMENT_ROOT=/var/www/html/public; \
@@ -164,7 +183,7 @@ RUN set -ex; \
 # Install node dependencies
 RUN set -ex; \
     \
-    curl -fsSL https://deb.nodesource.com/setup_18.x | bash -; \
+    curl -fsSL https://deb.nodesource.com/setup_20.x | bash -; \
     apt-get install -y nodejs; \
     npm install -g yarn; \
     yarn run inst; \

--- a/tests/Unit/Helpers/CountryHelperTest.php
+++ b/tests/Unit/Helpers/CountryHelperTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit\Helpers;
 
 use Tests\FeatureTestCase;
 use App\Helpers\CountriesHelper;
+use Illuminate\Support\Facades\App;
 
 class CountryHelperTest extends FeatureTestCase
 {
@@ -120,6 +121,38 @@ class CountryHelperTest extends FeatureTestCase
             ['ru', 'Europe/Moscow'],
             ['tr', 'Europe/Istanbul'],
             ['ja', 'Asia/Tokyo'],
+        ];
+    }
+
+    /**
+     * @dataProvider countryLocalesNotInCountryTranslationsProvider
+     */
+    public function test_country_get_does_not_fallback_to_wrong_language($locale, $iso)
+    {
+        App::setLocale($locale);
+
+        $country = CountriesHelper::getCountry($iso);
+        $expectedName = $country->getName();
+
+        $name = CountriesHelper::get($iso);
+
+        $this->assertEquals(
+            $expectedName,
+            $name
+        );
+    }
+
+    public function countryLocalesNotInCountryTranslationsProvider()
+    {
+        return [
+            ['ar', 'US'],
+            ['da', 'US'],
+            ['el', 'US'],
+            ['fa', 'US'],
+            ['he', 'US'],
+            ['id', 'US'],
+            ['no', 'US'],
+            ['ar', 'AD'],
         ];
     }
 }

--- a/tests/Unit/Helpers/DateHelperTest.php
+++ b/tests/Unit/Helpers/DateHelperTest.php
@@ -46,6 +46,17 @@ class DateHelperTest extends FeatureTestCase
         );
     }
 
+    public function testGetShortDateWithEnGBLocale()
+    {
+        $date = Carbon::parse('2017-01-22 17:56:03');
+        App::setLocale('en-GB');
+
+        $this->assertEquals(
+            '22 Jan 2017',
+            DateHelper::getShortDate($date)
+        );
+    }
+
     public function testGetFullDateWithEnglishLocale()
     {
         $date = Carbon::parse('2017-01-22 17:56:03');

--- a/tests/Unit/Helpers/LocaleHelperTest.php
+++ b/tests/Unit/Helpers/LocaleHelperTest.php
@@ -103,6 +103,34 @@ class LocaleHelperTest extends FeatureTestCase
     }
 
     /**
+     * @dataProvider localeHelperGetLocaleAlphaProvider
+     */
+    public function test_locale_get_locale_alpha($locale, $expect)
+    {
+        $alpha = LocaleHelper::getLocaleAlpha($locale);
+
+        $this->assertEquals(
+            $expect,
+            $alpha
+        );
+    }
+
+    public function localeHelperGetLocaleAlphaProvider()
+    {
+        return [
+            ['en', 'eng'],
+            ['de', 'deu'],
+            ['fr', 'fra'],
+            ['en-GB', 'eng'],
+            ['en-gb', 'eng'],
+            ['en_GB', 'eng'],
+            ['pt-BR', 'por'],
+            ['zh-TW', 'zho'],
+            ['xx-YY', ''],
+        ];
+    }
+
+    /**
      * @dataProvider localeHelperGetCountryProvider
      */
     public function test_locale_get_country($locale, $expect)


### PR DESCRIPTION
Hello friendly devs,

I noticed a bug in how dates are displayed: when setting locale to English (United Kingdom), a lot of places that show dates don't actually change format. The root cause seems to be that you are using the Locale setting from "Carbon", but when Locale is set in Carbon it "normalises" it. So eg 'en-GB' becomes 'en_GB'. But Laravel's internationalisation expects the locale name to exactly match, so it can't find 'en_GB' and falls back to 'en'.

The fix is to use `App::Locale` instead of `Carbon::Locale`. The unit tests all pass (and I added a new one to check the en-GB case). I also updated the dockerfile in this project to match monicahq/docker, so that any future devs would easily be able to create a test image. I have made an image from the code in this repo, which can be pulled from `ghcr.io/qxzkjp/monica:date-fix`. I have used it myself (it is running on my personal server) and I have tested that the UI is fixed and that there are no obvious introduced errors.

I appreciate that you are focusing all of your efforts on v5 at the moment, but I was hoping that if someone did all the coding work for you you'd have time available to merge and tag it. It's a simple fix but it'll be useful to a lot of people, and it seems that Chandler is not expected to be out of beta for a year or more.

PS for disclosure, I did use Claude Code to help make this change. I have read the code myself, and I made sure to test it. The fix was simple enough that Claude was able to do the whole task, but I promise I am a professional who is used to using AI assistance and getting good-quality output from it, not a random slop coder. I have had PRs accepted before without use of AI (admittedly years ago, I'm an infrequent contributor).